### PR TITLE
Fix nil value error due to EntityMods table not existing on all entities

### DIFF
--- a/lua/entities/acf_ammo.lua
+++ b/lua/entities/acf_ammo.lua
@@ -441,7 +441,7 @@ end
 
 function ENT:Think()
 	if not self:IsSolid() then self.Ammo = 0 end
---	if self.EntityMods.MakeSphericalCollisions then self.Ammo = 0 end
+	if self.EntityMods and self.EntityMods.MakeSphericalCollisions then self.Ammo = 0 end
 
 	self:UpdateMass()
 	

--- a/lua/entities/acf_engine.lua
+++ b/lua/entities/acf_engine.lua
@@ -448,7 +448,7 @@ function ENT:CheckLegal()
 	if not self:IsSolid() then return false end
 	
 	-- make sure it's not spherical :)
-	if self.EntityMods.MakeSphericalCollisions then return false end
+	if self.EntityMods and self.EntityMods.MakeSphericalCollisions then return false end
 
 	-- make sure weight is not below stock
 	if self:GetPhysicsObject():GetMass() < self.Weight then return false end

--- a/lua/entities/acf_fueltank.lua
+++ b/lua/entities/acf_fueltank.lua
@@ -392,7 +392,10 @@ function ENT:Think()
 	
 	--make sure it's not invisible to traces
 	if not self:IsSolid() then self.Fuel = 0 end
-	
+
+	--make sure it's not made spherical
+	if self.EntityMods and self.EntityMods.MakeSphericalCollisions then self.Fuel = 0 end
+
 	if self.Leaking > 0 then
 		self:NextThink( CurTime() + 0.25 )
 		self.Fuel = math.max(self.Fuel - self.Leaking,0)

--- a/lua/entities/acf_gearbox.lua
+++ b/lua/entities/acf_gearbox.lua
@@ -679,7 +679,7 @@ function ENT:CheckLegal()
 	if self:GetPhysicsObject():GetMass() < self.Mass then return false end
 	
 	--make sure it's not spherical :)
-	if self.EntityMods.MakeSphericalCollisions then return false end
+	if self.EntityMods and self.EntityMods.MakeSphericalCollisions then return false end
 
 	self.RootParent = nil
 	-- if not parented then its legal


### PR DESCRIPTION
Now checks whether the EntityMods table exists before checking its contents for MakeSphericalCollisions to prevent a nil value error if EntityMods doesn't exist yet.