### PR TITLE
Fixed and balanced the spall system

### DIFF
--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -328,7 +328,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 	if SpallMul > 0 then 
 	
 		local WeightFactor = MatData.massMod or 1
-		local Max_Spall_Mass = 10
+		-- local Max_Spall_Mass = 10
 
 		local Velocityfactor = 2
 		local Max_Spall_Vel = 3000
@@ -388,7 +388,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 end
 
 --Handles HESH spalling
-function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Inflictor, Material )
+function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, _, Inflictor, Material )
 
 	--Don't use it if it's not allowed to
 	if not ACF.Spalling then return end
@@ -405,7 +405,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 	if SpallMul > 0 then
 
 		local WeightFactor = MatData.massMod or 1
-		local Max_Spall_Mass = 20
+		-- local Max_Spall_Mass = 20
 
 		local Velocityfactor = 1
 		local Max_Spall_Vel = 7000

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -324,32 +324,116 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 
 	-- Spall armor factor bias
 	local ArmorMul	= MatData.ArmorMul or 1
-	--local UsedArmor	= Armour * ArmorMul
 
-	if SpallMul > 0 and Caliber > 3 then --Caliber * 10 > UsedArmor
+	if SpallMul > 0 then 
+	
+		local WeightFactor = MatData.massMod or 1
+		local Max_Spall_Mass = 10
 
-		-- Normal spalling core
-		--For better consistency against light armor, spall no longer cares about the thickness of the armor but moreso the hole the cannon punches through and the energy it uses doing so.
+		local Velocityfactor = 2
+		local Max_Spall_Vel = 3000
+		
+		local Max_Spalls = 128
 
-		--Weight factor variable. Affects both the weight of the spall and indirectly affects the caliber of the spall
-		--0.75 results in 11mm spall with a 120mm SBC
-		--15 results in 20mm spall
-		local WeightFactor = 15
+		-- print("KE: " .. KE)
 
-		--Direct multiplier for spall velocity, used to fine-tune the spall penetration
+		local Cal_In_MM = (Caliber * 10)
+
+		-- print("Cal: ".. Caliber)
+		-- print("Cal: ".. Cal_In_MM)
+
+		local Spall = math.min(math.floor(Caliber * ACF.KEtoSpall * SpallMul * 5) * ACF.SpallMult, Max_Spalls)
+		local TotalWeight = (Spall / (Cal_In_MM * (PI / 180)))
+		local SpallWeight = ((TotalWeight / (Spall / 10)) + (ArmorMul + WeightFactor))
+		local SpallVel = ((KE ^ Velocityfactor) / SpallWeight)
+		local SpallArea = (TotalWeight / SpallWeight)
+		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
+		
+		-- print("AR: " .. SpallArea)
+		
+		-- print("TW: " .. TotalWeight)
+
+		-- print("SW: " .. SpallWeight)
+
+		-- print("SPALL: " .. Spall)
+		-- print("VEL: " .. SpallVel)
+
+
+		for i = 1,Spall do
+
+			ACE.CurSpallIndex = ACE.CurSpallIndex + 1
+			if ACE.CurSpallIndex > ACE.SpallMax then
+				ACE.CurSpallIndex = 1
+			end
+
+			-- Normal Trace creation
+			local Index = ACE.CurSpallIndex
+
+			ACE.Spall[Index] = {}
+			ACE.Spall[Index].start  = HitPos
+			ACE.Spall[Index].endpos = HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel / 8, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
+			ACE.Spall[Index].filter = table.Copy(Filter)
+			ACE.Spall[Index].mins	= Vector(0,0,0)
+			ACE.Spall[Index].maxs	= Vector(0,0,0)
+
+			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor)
+
+			-- little sound optimization
+			if i < math.max(math.Round(Spall / 2), 1) then
+			 	sound.Play(ACE.Sounds["Penetrations"]["large"]["close"][math.random(1,#ACE.Sounds["Penetrations"]["large"]["close"])], HitPos, 75, 100, 0.5)
+			 end
+
+		end
+	end
+end
+
+--Handles HESH spalling
+function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Inflictor, Material )
+
+	--Don't use it if it's not allowed to
+	if not ACF.Spalling then return end
+
+	local Mat		= Material or "RHA"
+	local MatData	= ACE_GetMaterialData( Mat )
+
+	-- Spall damage
+	local SpallMul	= MatData.spallmult or 1
+
+	-- Spall armor factor bias
+	local ArmorMul	= MatData.ArmorMul or 1
+
+	if SpallMul > 0 then
+
+		local WeightFactor = MatData.massMod or 1
+		local Max_Spall_Mass = 20
+
 		local Velocityfactor = 1
+		local Max_Spall_Vel = 7000
+		
+		local Max_Spalls = 128
 
-		--print("Cal: "..Caliber)
+		-- print("HE: " .. HEFiller)
 
-		local TotalWeight = PI * (Caliber / 8) ^ 2 * ArmorMul * WeightFactor
-		local Spall = math.min(math.floor((Caliber - 3) * ACF.KEtoSpall * SpallMul * 5) * ACF.SpallMult, 128)
-		local SpallWeight = TotalWeight / Spall * SpallMul * 30
-		local SpallVel = (KE * 2048 / SpallWeight) ^ 0.5 / Spall * SpallMul * 79.787
-		local SpallArea = (SpallWeight * 50 ) ^ 0.33
-		local SpallEnergy = ACF_Kinetic(SpallVel * Velocityfactor, SpallWeight * 11 , 800)
+		local Cal_In_MM = (Caliber * 10)
 
-		--local caliber = 20 * (SpallArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5
-		--print("SpallCal: "..caliber)
+		-- print("Cal: ".. Caliber)
+		-- print("Cal: ".. Cal_In_MM)
+
+		local Spall = math.min(math.floor(Caliber * HEFiller * SpallMul * 5) * ACF.SpallMult, Max_Spalls)
+		local TotalWeight = (Spall / (Cal_In_MM * (PI / 180)))
+		local SpallWeight = ((TotalWeight / (Spall / 10)) + (ArmorMul + WeightFactor))
+		local SpallVel = ((HEFiller ^ Velocityfactor) / SpallWeight)
+		local SpallArea = (TotalWeight / SpallWeight)
+		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
+		
+		-- print("AR: " .. SpallArea)
+		
+		-- print("TW: " .. TotalWeight)
+
+		-- print("SW: " .. SpallWeight)
+
+		-- print("HESH: " .. Spall)
+		-- print("VEL: " .. SpallVel)
 
 		for i = 1,Spall do
 
@@ -375,223 +459,6 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 				sound.Play(ACE.Sounds["Penetrations"]["large"]["close"][math.random(1,#ACE.Sounds["Penetrations"]["large"]["close"])], HitPos, 75, 100, 0.5)
 			end
 
-		end
-	end
-end
-
-
---Dedicated function for HESH spalling
-function ACF_PropShockwave( HitPos, HitVec, Filter, Caliber )
-
-	--Don't even bother at calculating something that doesn't exist
-	if table.IsEmpty(Filter) then return end
-
-	--General
-	local FindEnd	= true			--marked for initial loop
-	local iteration	= 0				--since while has not index
-
-	local EntsToHit	= Filter	--Used for the second tracer, where it tells what ents must hit
-
-	--HitPos
-	local HitFronts	= {}				--Any tracefronts hitpos will be stored here
-	local HitBacks	= {}				--Any traceback hitpos will be stored here
-
-	--Distances. Store any distance
-	local FrontDists	= {}
-	local BackDists	= {}
-
-	local Normals	= {}
-
-	--Results
-	local fNormal	= Vector(0,0,0)
-	local finalpos
-	local TotalArmor	= {}
-
-	--Tracefront general data--
-	local TrFront	= {}
-	TrFront.start	= HitPos
-	TrFront.endpos	= HitPos + HitVec:GetNormalized() * Caliber * 1.5
-	TrFront.ignoreworld = true
-	TrFront.filter	= {}
-
-	--Traceback general data--
-	local TrBack		= {}
-	TrBack.start		= HitPos + HitVec:GetNormalized() * Caliber * 1.5
-	TrBack.endpos	= HitPos
-	TrBack.ignoreworld  = true
-	TrBack.filter	= function( ent ) if ( ent:EntIndex() == EntsToHit[#EntsToHit]:EntIndex()) then return true end end
-
-	while FindEnd do
-
-		iteration = iteration + 1
-		--print('iteration #' .. iteration)
-
-		--In case of total failure, this loop is limited to 1000 iterations, don't make me increase it even more.
-		if iteration >= 1000 then FindEnd = false end
-
-		--================-TRACEFRONT-==================-
-		local tracefront = util.TraceHull( TrFront )
-
-		--insert the hitpos here
-		local HitFront = tracefront.HitPos
-		table.insert( HitFronts, HitFront )
-
-		--distance between the initial hit and hitpos of front plate
-		local distToFront = math.abs( (HitPos - HitFront):Length() )
-		table.insert( FrontDists, distToFront)
-
-		--TraceFront's armor entity
-		local Armour = tracefront.Entity.ACF and tracefront.Entity.ACF.Armour or 0
-
-		--Code executed once its scanning the 2nd prop
-		if iteration > 1 then
-
-			--check if they are totally overlapped
-			if math.Round(FrontDists[iteration-1]) ~= math.Round(FrontDists[iteration] ) then
-
-				--distance between the start of ent1 and end of ent2
-				local space = math.abs( (HitFronts[iteration] - HitBacks[iteration - 1]):Length() )
-
-				--prop's material
-				local mat = tracefront.Entity.ACF and tracefront.Entity.ACF.Material or "RHA"
-				local MatData = ACE_GetMaterialData( mat )
-
-
-				local Hasvoid = false
-				local NotOverlap = false
-
-				--print("DATA TABLE - DONT FUCKING DELETE")
-				--print('distToFront: ' .. distToFront)
-				--print('BackDists[iteration - 1]: ' .. BackDists[iteration - 1])
-				--print('DISTS DIFF: ' .. distToFront - BackDists[iteration - 1])
-
-				--check if we have void
-				if space > 1 then
-					Hasvoid = true
-				end
-
-				--check if we dont have props semi-overlapped
-				if distToFront > BackDists[iteration - 1] then
-					NotOverlap = true
-				end
-
-				--check if we have spaced armor, spall liners ahead, if so, end here
-				if (Hasvoid and NotOverlap) or (tracefront.Entity:IsValid() and ACE.CritEnts[ tracefront.Entity:GetClass() ]) or MatData.Stopshock then
-					--print("stopping")
-					FindEnd	= false
-					finalpos	= HitBacks[iteration - 1] + HitVec:GetNormalized() * 0.1
-					fNormal	= Normals[iteration - 1]
-					--print("iteration #' .. iteration .. ' / FINISHED!")
-
-					break
-				end
-			end
-
-			--start inserting new ents to the table when iteration pass 1, so we don't insert the already inserted prop (first one)
-			table.insert( EntsToHit, tracefront.Entity)
-
-		end
-
-		--Filter this ent from being processed again in the next checks
-		table.insert( TrFront.filter, tracefront.Entity )
-
-		--Add the armor value to table
-		table.insert( TotalArmor, Armour )
-
-		--================-TRACEBACK-==================
-		local traceback = util.TraceHull( TrBack )
-
-		--insert the hitpos here
-		local HitBack = traceback.HitPos
-		table.insert( HitBacks, HitBack )
-
-		--store the dist between the backhit and the hitvec
-		local distToBack = math.abs( (HitPos - HitBack):Length() )
-		table.insert( BackDists, distToBack)
-
-		table.insert( Normals, traceback.HitNormal )
-
-		--flag this iteration as lost
-		if not tracefront.Hit then
-
-			--print("[ACE|WARN]- TRACE HAS BROKEN!")
-
-			FindEnd	= false
-			finalpos	= HitBack + HitVec:GetNormalized() * 0.1
-			fNormal	= Normals[iteration]
-			--print("iteration #' .. iteration .. ' / FINISHED")
-
-			break
-		end
-
-		--for red traceback
-		--debugoverlay.Line( traceback.StartPos + Vector(0,0,#EntsToHit * 0.1), traceback.HitPos + Vector(0,0,#EntsToHit * 0.1), 20 , Color(math.random(100,255),0,0) )
-		--for green tracefront
-		--debugoverlay.Line( tracefront.StartPos + Vector(0,0,#EntsToHit * 0.1), tracefront.HitPos + Vector(0,0,#EntsToHit * 0.1), 20 , Color(0,math.random(100,255),0) )
-	end
-
-	local ArmorSum = 0
-	for i = 1, #TotalArmor do
-		--print("Armor prop count: ' .. i..", Armor value: ' .. TotalArmor[i])
-		ArmorSum = ArmorSum + TotalArmor[i]
-	end
-
-	--print(ArmorSum)
-	return finalpos, ArmorSum, TrFront.filter, fNormal
-end
-
-
---Handles HESH spalling
-function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Inflictor, Material )
-
-	local spallPos, Armour, PEnts, fNormal = ACF_PropShockwave( HitPos, -HitVec, Filter, Caliber )
-
-	local Mat		= Material or "RHA"
-	local MatData	= ACE_GetMaterialData( Mat )
-
-	-- Spall damage
-	local SpallMul	= MatData.spallmult or 1
-
-	-- Spall armor factor bias
-	local ArmorMul	= MatData.ArmorMul or 1
-	local UsedArmor	= Armour * ArmorMul
-
-	if SpallMul > 0 and ( HEFiller / 300 ) > UsedArmor then
-
-		--era stops the spalling at the cost of being detonated
-		if MatData.IsExplosive then Filter[1].ACF.ERAexploding = true return end
-
-		-- HESH spalling core
-		local TotalWeight = PI * (Caliber / 2) ^ 2 * math.max(UsedArmor, 30) * 2500
-		local Spall = math.min(math.floor((Caliber - 3) * 5 * ACF.KEtoSpall * SpallMul), 128) --24
-		local SpallWeight = TotalWeight / Spall * SpallMul * 5
-		local SpallVel = (HEFiller * 16 / SpallWeight) ^ 0.5 / Spall * SpallMul * 5
-		local SpallArea = (SpallWeight * 1) ^ 0.33
-		local SpallEnergy = ACF_Kinetic(SpallVel * 1, SpallWeight * 5, 800)
-
-		--print("Spall: "..Spall)
-
-		for i = 1,Spall do
-
-			ACE.CurSpallIndex = ACE.CurSpallIndex + 1
-			if ACE.CurSpallIndex > ACE.SpallMax then
-				ACE.CurSpallIndex = 1
-			end
-
-			-- HESH trace creation
-			local Index = ACE.CurSpallIndex
-
-			ACE.Spall[Index]			= {}
-			ACE.Spall[Index].start	= spallPos
-			ACE.Spall[Index].endpos	= spallPos + ((fNormal * 2500 + -HitVec):GetNormalized() + VectorRand() / 3):GetNormalized() * math.max(SpallVel * 10,math.random(450,600)) --I got bored of spall not going across the tank
-			ACE.Spall[Index].filter	= table.Copy(PEnts)
-
-			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor )
-
-			--little sound optimization
-			if i < math.max(math.Round(Spall / 4), 1) then
-				sound.Play(ACE.Sounds["Penetrations"]["large"]["close"][math.random(1,#ACE.Sounds["Penetrations"]["large"]["close"])], spallPos, 75, 100, 0.5)
-			end
 		end
 	end
 end
@@ -625,14 +492,30 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor )
 		local Mat		= SpallRes.Entity.ACF.Material or "RHA"
 		local MatData	= ACE_GetMaterialData( Mat )
 
-		local spallarmor	= MatData.spallarmor
+		local If_Has_Spall_Resil = 0
+		
+		if Mat == "Rub" then 
+			If_Has_Spall_Resil = MatData.spallresiliance
+		else
+			If_Has_Spall_Resil = MatData.spallresist
+		end
 
-		SpallEnergy.Penetration = SpallEnergy.Penetration / spallarmor
+		local spallarmor	= MatData.spallarmor
+		
+		local Spall_Armor_Resist = (spallarmor + If_Has_Spall_Resil / 2)
+
+		SpallEnergy.Penetration = (SpallEnergy.Penetration / math.Clamp(Spall_Armor_Resist, 1, 2))
 
 		--extra damage for ents like ammo, engines, etc
 		if ACE.CritEnts[ SpallRes.Entity:GetClass() ] then
-			SpallEnergy.Penetration = SpallEnergy.Penetration * 10
+			SpallEnergy.Penetration = (SpallEnergy.Penetration / math.Clamp(Spall_Armor_Resist, 1, 2))
 		end
+		
+		SpallEnergy.Penetration = math.floor(SpallEnergy.Penetration)
+		
+		-- print(SpallEnergy.Penetration)
+		
+		If_Has_Spall_Resil = 0
 
 		-- Applies the damage to the impacted entity
 		local HitRes = ACF_Damage( SpallRes.Entity , SpallEnergy , SpallArea , 0 , Inflictor, 0, nil, "Spall") --Angle replaced with 0 for inconsistent spall
@@ -1241,4 +1124,3 @@ function ACE_CalculateHERadius( HEWeight )
 	return Radius
 end
 --
-

--- a/lua/acf/shared/armor/aluminum.lua
+++ b/lua/acf/shared/armor/aluminum.lua
@@ -14,8 +14,8 @@ Material.effectiveness  = 0.34
 Material.resiliance	= 1.05
 Material.HEATMul		= 5 --Originally 80. Someone REALLY hated aluminum against HEAT.
 
-Material.spallarmor	= 1
-Material.spallresist	= 1
+Material.spallarmor	= 0.8
+Material.spallresist	= 1.24
 
 Material.spallmult	= 2
 Material.ArmorMul	= 0.334

--- a/lua/acf/shared/armor/aluminum.lua
+++ b/lua/acf/shared/armor/aluminum.lua
@@ -14,8 +14,7 @@ Material.effectiveness  = 0.34
 Material.resiliance	= 1.05
 Material.HEATMul		= 5 --Originally 80. Someone REALLY hated aluminum against HEAT.
 
-Material.spallarmor	= 0.8
-Material.spallresist	= 1.24
+Material.spallresist	= 1.02
 
 Material.spallmult	= 2
 Material.ArmorMul	= 0.334

--- a/lua/acf/shared/armor/cast.lua
+++ b/lua/acf/shared/armor/cast.lua
@@ -16,8 +16,8 @@ Material.curve		= 1
 Material.effectiveness  = 0.98
 Material.resiliance	= 0.4
 
-Material.spallarmor	= 1
-Material.spallresist	= 0.5
+Material.spallarmor	= 0.95
+Material.spallresist	= 1.1
 
 Material.spallmult	= 2
 Material.ArmorMul	= 1

--- a/lua/acf/shared/armor/cast.lua
+++ b/lua/acf/shared/armor/cast.lua
@@ -16,8 +16,7 @@ Material.curve		= 1
 Material.effectiveness  = 0.98
 Material.resiliance	= 0.4
 
-Material.spallarmor	= 0.95
-Material.spallresist	= 1.1
+Material.spallresist	= 1.025
 
 Material.spallmult	= 2
 Material.ArmorMul	= 1

--- a/lua/acf/shared/armor/ceramic.lua
+++ b/lua/acf/shared/armor/ceramic.lua
@@ -16,8 +16,7 @@ Material.curve		= 0.98
 Material.effectiveness  = 2.05
 Material.resiliance	= 100
 
-Material.spallarmor	= 1
-Material.spallresist	= 0.0
+Material.spallresist	= 1
 
 Material.spallmult	= 2.5
 Material.ArmorMul	= 1.8

--- a/lua/acf/shared/armor/ceramic.lua
+++ b/lua/acf/shared/armor/ceramic.lua
@@ -17,7 +17,7 @@ Material.effectiveness  = 2.05
 Material.resiliance	= 100
 
 Material.spallarmor	= 1
-Material.spallresist	= 1
+Material.spallresist	= 0.0
 
 Material.spallmult	= 2.5
 Material.ArmorMul	= 1.8

--- a/lua/acf/shared/armor/era.lua
+++ b/lua/acf/shared/armor/era.lua
@@ -27,7 +27,6 @@ Material.Nresiliance = 1
 Material.APSensorFactor	= 4	-- quotient used to determinate minimal pen for detonation for Kinetic shells
 Material.HEATSensorFactor	= 16	-- quotient used to determinate minimal pen for detonation for chemical shells
 
-Material.spallarmor	= 1
 Material.spallresist = 1
 
 Material.spallmult = 0

--- a/lua/acf/shared/armor/rha.lua
+++ b/lua/acf/shared/armor/rha.lua
@@ -16,8 +16,7 @@ Material.curve		= 1 --Slight and almost unnoticable penalty to high thickness ar
 Material.effectiveness  = 1
 Material.resiliance	= 1
 
-Material.spallarmor	= 1.24
-Material.spallresist	= 1
+Material.spallresist	= 1.12
 
 Material.spallmult	= 1
 Material.ArmorMul	= 1

--- a/lua/acf/shared/armor/rha.lua
+++ b/lua/acf/shared/armor/rha.lua
@@ -16,7 +16,7 @@ Material.curve		= 1 --Slight and almost unnoticable penalty to high thickness ar
 Material.effectiveness  = 1
 Material.resiliance	= 1
 
-Material.spallarmor	= 1
+Material.spallarmor	= 1.24
 Material.spallresist	= 1
 
 Material.spallmult	= 1

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -25,9 +25,7 @@ Material.HEATresiliance = 3
 
 Material.HEresiliance	= 6
 
-
-Material.spallarmor	= 1
-Material.spallresiliance = 1.6
+Material.spallresist = 1.3
 
 Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
 Material.ArmorMul	= 0.05

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -27,7 +27,7 @@ Material.HEresiliance	= 6
 
 
 Material.spallarmor	= 1
-Material.spallresiliance = 15
+Material.spallresiliance = 1.6
 
 Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
 Material.ArmorMul	= 0.05

--- a/lua/acf/shared/armor/textolite.lua
+++ b/lua/acf/shared/armor/textolite.lua
@@ -21,7 +21,7 @@ Material.HEATresiliance       = 0.5
 Material.HEresiliance         = 0.75
 
 Material.spallarmor           = 1
-Material.spallresist          = 0.65
+Material.spallresist          = 0.0
 
 Material.spallmult            = 1.3
 Material.ArmorMul             = 0.23

--- a/lua/acf/shared/armor/textolite.lua
+++ b/lua/acf/shared/armor/textolite.lua
@@ -20,8 +20,7 @@ Material.resiliance           = 50
 Material.HEATresiliance       = 0.5
 Material.HEresiliance         = 0.75
 
-Material.spallarmor           = 1
-Material.spallresist          = 0.0
+Material.spallresist          = 1
 
 Material.spallmult            = 1.3
 Material.ArmorMul             = 0.23


### PR DESCRIPTION
Me and Cheezus have been testing spall changes on my server I've done to the ACE code for the past 3 days. I'd like you to review the code and or to push the modifications to the master branch or atleast the dev for future testing. I have currently only modified the spall functions and only tweaked two material data values in each armor type. The thing is the current spall system had lots of problems in how it was being calculated.

**By this I mean some of the problems were:**
1. Spall did not lose penetration over distance nor impacting armor of any type
2. Hesh spall was inconistent and heavily underpowered when compared to kinetic spall
3. In the spall calculations there was alot of proprietary and non-dynamic bullshit along with some values returning abnormally high values and or inf values when debugging
4. Regarding 3. there were also properitary constants which definitely were not any sort of unit conversion constants. Example being a constant Weight factor of 15 which comments said the weight factor meant that each spall flake was fucking 20mm spall

> (Spall was essentially 0/inf mass giant metal flakes that went mach 10 and did not lose energy, and infact penetration was being multiplied each impact)

**Some of the changes I've made include:**
1. Revamping the calculations
2. Noticed there were spall resist and armor material data variables that were not being used so I implemented them
3. Regarding 2. besides changing `sv_acfdamage.lua`, the only other scripts I've changed as I've said was the material scripts but only to slightly raise/lower `Material.spallarmor` and `Material.spallresist` (this is so that material types had more influence in spall along with affecting spall weight.)

So now the main difference between before and now is not just that the calculations were fixed and improved, but that the system is more dynamic and balanced. (Look back upon the problems listed and think about how tanks were being instantly vaporized by 75mm apfsds)