### PR TITLE
fix(rounds): Rounds effects were dependent of ammo cratse and not guns

### DIFF
--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -554,7 +554,7 @@ function ACF_BulletClient( Index, Bullet, Type, Hit, HitPos )
 			Effect:SetMaterialIndex( Index )	--Bullet Index
 			Effect:SetStart( Bullet.Flight / 10 )	--Bullet Direction
 			Effect:SetOrigin( Bullet.Pos )
-			Effect:SetEntity( Entity(Bullet["Crate"]) )
+			Effect:SetEntity( Bullet.Gun )
 			Effect:SetScale( 0 )
 			Effect:SetAttachment( IsMissile or 0 )
 		util.Effect( "ACF_BulletEffect", Effect, true, true )

--- a/lua/acf/shared/rounds/roundap.lua
+++ b/lua/acf/shared/rounds/roundap.lua
@@ -151,7 +151,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -164,7 +164,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -177,7 +177,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundapbc.lua
+++ b/lua/acf/shared/rounds/roundapbc.lua
@@ -144,7 +144,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -157,7 +157,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -170,7 +170,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundapc.lua
+++ b/lua/acf/shared/rounds/roundapc.lua
@@ -172,7 +172,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -185,7 +185,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -198,7 +198,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundapcbc.lua
+++ b/lua/acf/shared/rounds/roundapcbc.lua
@@ -175,7 +175,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -188,7 +188,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -201,7 +201,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundapds.lua
+++ b/lua/acf/shared/rounds/roundapds.lua
@@ -212,7 +212,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -225,7 +225,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -238,7 +238,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundapfsds.lua
+++ b/lua/acf/shared/rounds/roundapfsds.lua
@@ -164,7 +164,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -177,7 +177,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -190,7 +190,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundaphe.lua
+++ b/lua/acf/shared/rounds/roundaphe.lua
@@ -193,7 +193,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -205,7 +205,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundaphecbc.lua
+++ b/lua/acf/shared/rounds/roundaphecbc.lua
@@ -222,7 +222,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -234,7 +234,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundchaff.lua
+++ b/lua/acf/shared/rounds/roundchaff.lua
@@ -165,7 +165,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -177,7 +177,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundclusterap.lua
+++ b/lua/acf/shared/rounds/roundclusterap.lua
@@ -305,7 +305,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( Bullet.SimFlight:GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundclusterhe.lua
+++ b/lua/acf/shared/rounds/roundclusterhe.lua
@@ -353,7 +353,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( Bullet.SimFlight:GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundfl.lua
+++ b/lua/acf/shared/rounds/roundfl.lua
@@ -245,7 +245,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -258,7 +258,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -271,7 +271,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundflare.lua
+++ b/lua/acf/shared/rounds/roundflare.lua
@@ -164,7 +164,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -176,7 +176,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundglgm.lua
+++ b/lua/acf/shared/rounds/roundglgm.lua
@@ -277,7 +277,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Impact = EffectData()
-		Impact:SetEntity( Bullet.Crate )
+		Impact:SetEntity( Bullet.Gun )
 		Impact:SetOrigin( Bullet.SimPos )
 		Impact:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Impact:SetScale( Bullet.SimFlight:Length() )
@@ -291,7 +291,7 @@ function Round.pierceeffect( Effect, Bullet )
 	if Bullet.Detonated then
 
 		local Spall = EffectData()
-			Spall:SetEntity( Bullet.Crate )
+			Spall:SetEntity( Bullet.Gun )
 			Spall:SetOrigin( Bullet.SimPos )
 			Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 			Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundhe.lua
+++ b/lua/acf/shared/rounds/roundhe.lua
@@ -178,7 +178,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( Bullet.SimFlight:GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundheat.lua
+++ b/lua/acf/shared/rounds/roundheat.lua
@@ -295,7 +295,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Impact = EffectData()
-		Impact:SetEntity( Bullet.Crate )
+		Impact:SetEntity( Bullet.Gun )
 		Impact:SetOrigin( Bullet.SimPos )
 		Impact:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Impact:SetScale( Bullet.SimFlight:Length() )
@@ -309,7 +309,7 @@ function Round.pierceeffect( Effect, Bullet )
 	if Bullet.Detonated then
 
 		local Spall = EffectData()
-			Spall:SetEntity( Bullet.Crate )
+			Spall:SetEntity( Bullet.Gun )
 			Spall:SetOrigin( Bullet.SimPos )
 			Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 			Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundheatfs.lua
+++ b/lua/acf/shared/rounds/roundheatfs.lua
@@ -295,7 +295,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Impact = EffectData()
-		Impact:SetEntity( Bullet.Crate )
+		Impact:SetEntity( Bullet.Gun )
 		Impact:SetOrigin( Bullet.SimPos )
 		Impact:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Impact:SetScale( Bullet.SimFlight:Length() )
@@ -309,7 +309,7 @@ function Round.pierceeffect( Effect, Bullet )
 	if Bullet.Detonated then
 
 		local Spall = EffectData()
-			Spall:SetEntity( Bullet.Crate )
+			Spall:SetEntity( Bullet.Gun )
 			Spall:SetOrigin( Bullet.SimPos )
 			Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 			Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundhefs.lua
+++ b/lua/acf/shared/rounds/roundhefs.lua
@@ -182,7 +182,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( Bullet.SimFlight:GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundhesh.lua
+++ b/lua/acf/shared/rounds/roundhesh.lua
@@ -195,7 +195,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( Bullet.SimFlight:GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundhvap.lua
+++ b/lua/acf/shared/rounds/roundhvap.lua
@@ -180,7 +180,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -193,7 +193,7 @@ end
 function Round.pierceeffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )
@@ -206,7 +206,7 @@ end
 function Round.ricocheteffect( _, Bullet )
 
 	local Spall = EffectData()
-		Spall:SetEntity( Bullet.Crate )
+		Spall:SetEntity( Bullet.Gun )
 		Spall:SetOrigin( Bullet.SimPos )
 		Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundtheat.lua
+++ b/lua/acf/shared/rounds/roundtheat.lua
@@ -387,7 +387,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Impact = EffectData()
-		Impact:SetEntity( Bullet.Crate )
+		Impact:SetEntity( Bullet.Gun )
 		Impact:SetOrigin( Bullet.SimPos )
 		Impact:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Impact:SetScale( Bullet.SimFlight:Length() )
@@ -401,7 +401,7 @@ function Round.pierceeffect( Effect, Bullet )
 	if DetCount > 0 then
 
 		local Spall = EffectData()
-			Spall:SetEntity( Bullet.Crate )
+			Spall:SetEntity( Bullet.Gun )
 			Spall:SetOrigin( Bullet.SimPos )
 			Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 			Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/acf/shared/rounds/roundtheatfs.lua
+++ b/lua/acf/shared/rounds/roundtheatfs.lua
@@ -342,7 +342,7 @@ end
 function Round.endeffect( _, Bullet )
 
 	local Impact = EffectData()
-		Impact:SetEntity( Bullet.Crate )
+		Impact:SetEntity( Bullet.Gun )
 		Impact:SetOrigin( Bullet.SimPos )
 		Impact:SetNormal( (Bullet.SimFlight):GetNormalized() )
 		Impact:SetScale( Bullet.SimFlight:Length() )
@@ -356,7 +356,7 @@ function Round.pierceeffect( Effect, Bullet )
 	if DetCount > 0 then
 
 		local Spall = EffectData()
-			Spall:SetEntity( Bullet.Crate )
+			Spall:SetEntity( Bullet.Gun )
 			Spall:SetOrigin( Bullet.SimPos )
 			Spall:SetNormal( (Bullet.SimFlight):GetNormalized() )
 			Spall:SetScale( Bullet.SimFlight:Length() )

--- a/lua/effects/acf_bulleteffect/init.lua
+++ b/lua/effects/acf_bulleteffect/init.lua
@@ -78,10 +78,10 @@ do
 		else
 			--print("Creating Bullet Effect")
 			local BulletData = {}
-			BulletData.Crate = data:GetEntity()
+			BulletData.Gun = data:GetEntity()
 
-			--TODO: Check if it is actually a crate
-			if not IsValid(BulletData.Crate) then
+			--TODO: Check if it is actually a gun
+			if not IsValid(BulletData.Gun) then
 				RemoveBulletEntry( self )
 				return
 			end
@@ -91,14 +91,14 @@ do
 			BulletData.SimFlight    = data:GetStart() * 10
 			BulletData.SimPos       = data:GetOrigin()
 			BulletData.SimPosLast   = BulletData.SimPos
-			BulletData.Caliber      = BulletData.Crate:GetNWFloat( "Caliber", 10 )
-			BulletData.RoundMass    = BulletData.Crate:GetNWFloat( "ProjMass", 10 )
-			BulletData.FillerMass   = BulletData.Crate:GetNWFloat( "FillerMass" )
-			BulletData.WPMass       = BulletData.Crate:GetNWFloat( "WPMass" )
-			BulletData.DragCoef     = BulletData.Crate:GetNWFloat( "DragCoef", 1 )
-			BulletData.AmmoType     = BulletData.Crate:GetNWString( "AmmoType", "AP" )
+			BulletData.Caliber      = BulletData.Gun:GetNWFloat( "Caliber", 10 )
+			BulletData.RoundMass    = BulletData.Gun:GetNWFloat( "ProjMass", 10 )
+			BulletData.FillerMass   = BulletData.Gun:GetNWFloat( "FillerMass" )
+			BulletData.WPMass       = BulletData.Gun:GetNWFloat( "WPMass" )
+			BulletData.DragCoef     = BulletData.Gun:GetNWFloat( "DragCoef", 1 )
+			BulletData.AmmoType     = BulletData.Gun:GetNWString( "AmmoType", "AP" )
 
-			BulletData.Accel        = BulletData.Crate:GetNWVector( "Accel", Vector(0,0,-600))
+			BulletData.Accel        = BulletData.Gun:GetNWVector( "Accel", Vector(0,0,-600))
 
 			BulletData.LastThink    = CurTime() --ACF.CurTime
 			BulletData.Effect       = self.Entity
@@ -107,15 +107,15 @@ do
 			BulletData.HasSplashed = false
 			BulletData.InitialPos   = BulletData.SimPos --Store the first pos, se we can limit the crack sound at certain distance
 
-			BulletData.BulletModel  = BulletData.Crate:GetNWString( "BulletModel", "models/munitions/round_100mm_shot.mdl" )
+			BulletData.BulletModel  = BulletData.Gun:GetNWString( "BulletModel", "models/munitions/round_100mm_shot.mdl" )
 
 			BulletData.Tracer         = ParticleEmitter( BulletData.SimPos )
 
-			self.hasTracer = (BulletData.Crate:GetNWFloat( "Tracer" ) > 0)
+			self.hasTracer = (BulletData.Gun:GetNWFloat( "Tracer" ) > 0)
 
 			if self.hasTracer then
 				BulletData.Counter        = 0
-				BulletData.TracerColour   = BulletData.Crate:GetNWVector( "TracerColour", BulletData.Crate:GetColor() ) or Vector(255,255,255)
+				BulletData.TracerColour   = BulletData.Gun:GetNWVector( "TracerColour", BulletData.Gun:GetColor() ) or Vector(255,255,255)
 			end
 
 

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -594,9 +594,6 @@ do
 		self:SetNWString( "Ammo", self.Ammo )
 		self:SetNWString( "WireName", WireName )
 
-		self.NetworkData = ACF.RoundTypes[self.BulletData.Type].network
-		self:NetworkData( self.BulletData )
-
 		self:UpdateOverlayText()
 
 	end

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -933,6 +933,7 @@ function ENT:LoadAmmo( AddTime, Reload )
 
 	local AmmoEnt = self:FindNextCrate()
 	local curTime = CurTime()
+	local oldBulletData = self.BulletData
 
 	if AmmoEnt and AmmoEnt.Legal then
 		AmmoEnt.Ammo = AmmoEnt.Ammo - 1
@@ -1013,6 +1014,12 @@ function ENT:LoadAmmo( AddTime, Reload )
 
 		self.NextFire = curTime + reloadTime
 		self.LastLoadDuration = reloadTime
+
+		-- Check if the round type has changed, and if so, update the network data
+		if not oldBulletData or oldBulletData.Type ~= self.BulletData.Type then
+			self.NetworkData = ACF.RoundTypes[self.BulletData.Type].network
+			self:NetworkData( self.BulletData )
+		end
 
 		self:Think()
 		return true


### PR DESCRIPTION
This pull request fixes the following issue:
>https://drive.google.com/file/d/123tVd6U3s94JIipKbnLDjra5Hq1Z7qfV/view?usp=sharing
As you can see, if you replace the Flechettes ammunition by something else (HE, Smoke, Cluster, anything), it will keep the  "Flechettes" and "Flechettes Spread" properties for the next shot.

The effects were based on the network values of the crate. However, if I have an ammo crate of A round, and I fire a B round from my gun, then the B round will have the effects of A, which does not make any sense.

Now, instead of setting these network values to the crate entity, they are set on the gun entity, while paying attention to not update these values for each round fired, but only if the ammo type changes.