### PR TITLE
[Balancing] Tweaked missile handling

### DIFF
--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -34,7 +34,7 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/aim9m.mdl",
 		rackmdl				= "models/missiles/aim9m.mdl",
-		firedelay			= 0.75,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 30.0,
 
@@ -90,7 +90,7 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 
 ACF_defineGun("AIM-7 AAM", {							-- id
 	name             = "AIM-7 Sparrow",
-	desc             = "While not as advanced as its modern counterparts, the Sparrow makes up for it in thrust and plentiful speed. Do not underestimate it.\n\nInertial Guidance: Yes\nECCM: No\nDatalink: Yes\nTop Speed: 310 m/s",
+	desc             = "While not as advanced as its modern counterparts, the Sparrow makes up for it in thrust and plentiful speed. Do not underestimate it.\n\nInertial Guidance: No\nECCM: No\nDatalink: Yes\nTop Speed: 310 m/s",
 	model            = "models/missiles/arend/aim7f.mdl",
 	effect           = "ACE_MissileMedium",
 	effectbooster    = "ACE_MissileMedium",
@@ -106,7 +106,7 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/aim7f.mdl",
 		rackmdl				= "models/missiles/arend/aim7f.mdl",
-		firedelay			= 1.0,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -116,10 +116,10 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 30,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.28,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 32.5,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.26,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 110,							-- Acceleration in m/s.
+		thrust				= 95,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
 		burntime			= 10,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
@@ -128,14 +128,14 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 300,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostacceleration	= 150,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
 		boostertime			= 0.2,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
-		dragcoef			= 0.001,						-- percent speed loss per second
-		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
+		dragcoef			= 0.00075,						-- percent speed loss per second
+		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 	},
@@ -178,7 +178,7 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/aim120c.mdl",
 		rackmdl				= "models/missiles/aim120c.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 60.0,
 
@@ -188,8 +188,8 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 25,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 26.5,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.22,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 100,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
@@ -200,7 +200,7 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 300,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostacceleration	= 350,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
 		boostertime			= 0.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
@@ -235,7 +235,7 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 --with its seek cone and is suggested to AIM before launching.
 ACF_defineGun("AIM-54 AAM", {							-- id
 	name             = "AIM-54 Phoenix",
-	desc             = "Supersonic long-range air to air missile with early radar homing.Though relatively easy to dodge, this 300 kg beast will atomize any aircraft it hits. Getting hit is a traumatic experience. \n\nInertial Guidance: Yes\nECCM: No\nDatalink: Yes\nTop Speed: 191 m/s",
+	desc             = "Supersonic long-range air to air missile with early radar homing.Though relatively easy to dodge, this 300 kg beast will atomize any aircraft it hits. Getting hit is a traumatic experience. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 191 m/s",
 	model            = "models/missiles/arend/aim54c.mdl",
 	effect           = "ACE_MissileLarge",
 	gunclass         = "AAM",
@@ -250,7 +250,7 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/aim54c.mdl",
 		rackmdl				= "models/missiles/arend/aim54c.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 60.0,
 
@@ -261,10 +261,10 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320
-		turnrate			= 12,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.65,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 19,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.35,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 70,							-- Acceleration in m/s.
+		thrust				= 65,							-- Acceleration in m/s.
 		burntime			= 15,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
@@ -278,10 +278,10 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
-		dragcoef			= 0.002,						-- percent speed loss per second
+		dragcoef			= 0.00055,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
-		predictiondelay		= 0.35							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
+		predictiondelay		= 0.15							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -294,7 +294,7 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 
-	agility            = 3,									-- multiplier for missile turn-rate.  --was 0.7
+	irccm				= true,
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.5,								-- Required time (in seconds) for missile to start guiding at target once launched
 	ghosttime          = 0.05									-- Time where this missile will be unable to hit surfaces, in seconds
@@ -302,7 +302,7 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 
 ACF_defineGun("SRAAM AAM", {								-- id
 	name             = "SRAAM",
-	desc             = "Thrust vectoring absurdity. Shoots hot straight off the rails like some bat out of hell. Short range in every sense of the word but have fun dodging this one. Antimissile capable.\n\nInertial Guidance: Yes\nECCM: No\nDatalink: No\nTop Speed: 302 m/s",
+	desc             = "Wonderfully schizophrenic thrust vectoring absurdity. Shoots hot straight off the rails like some bat out of hell. Short range in every sense of the word but have fun dodging this one. Antimissile capable.\n\nInertial Guidance: Yes\nECCM: No\nDatalink: No\nTop Speed: 302 m/s",
 	model            = "models/missiles/arend/sraam_unfolded.mdl",
 	effect           = "ACE_MissileSmall",
 	effectbooster    = "ACE_MissileSmall",
@@ -318,7 +318,7 @@ ACF_defineGun("SRAAM AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/sraam_unfolded.mdl",
 		rackmdl				= "models/missiles/arend/sraam_folded.mdl",
-		firedelay			= 0.75,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -328,8 +328,8 @@ ACF_defineGun("SRAAM AAM", {								-- id
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 								--320
 		turnrate			= 60,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
-		thrusterturnrate	= 90,							--Max turnrate from thrusters regardless of speed. Active only if the missile motor is active.
+		finefficiency		= 0.1,							--Fraction of speed redirected every second at max deflection
+		thrusterturnrate	= 300,							--Max turnrate from thrusters regardless of speed. Active only if the missile motor is active.
 
 		thrust				= 0,							-- Acceleration in m/s.
 		burntime			= 0.0,							-- time in seconds for rocket motor to burn at max proppelant.
@@ -339,13 +339,13 @@ ACF_defineGun("SRAAM AAM", {								-- id
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 300,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
-		boostertime			= 1.4,							-- Time in seconds for booster runtime
+		boostacceleration	= 220,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostertime			= 1.5,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 3,							--Time in seconds after launch/booster stop before missile scuttles
 
-		dragcoef			= 0.0025,						-- percent speed loss per second
+		dragcoef			= 0.001,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 	},
@@ -387,7 +387,7 @@ ACF_defineGun("Magic AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r550magic.mdl",
 		rackmdl				= "models/missiles/arend/r550magic.mdl",
-		firedelay			= 0.75,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -459,7 +459,7 @@ ACF_defineGun("MICA AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/mica_em.mdl",
 		rackmdl				= "models/missiles/arend/mica_em.mdl",
-		firedelay			= 0.75,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -467,12 +467,12 @@ ACF_defineGun("MICA AAM", {								-- id
 		propweight			= 4,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
-								--320
+
 		turnrate			= 50,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.55,							--Fraction of speed redirected every second at max deflection
+		finefficiency		= 0.5,							--Fraction of speed redirected every second at max deflection
 		thrusterturnrate	= 20,							--Max turnrate from thrusters regardless of speed. Active only if the missile motor is active.
 
-		thrust				= 55,							-- Acceleration in m/s.
+		thrust				= 50,							-- Acceleration in m/s.
 		burntime			= 3.0,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
@@ -480,7 +480,7 @@ ACF_defineGun("MICA AAM", {								-- id
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 300,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostacceleration	= 250,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
 		boostertime			= 0.25,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
@@ -532,7 +532,7 @@ ACF_defineGun("Meteor AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/meteor.mdl",
 		rackmdl				= "models/missiles/arend/meteor.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 60.0,
 
@@ -542,7 +542,7 @@ ACF_defineGun("Meteor AAM", {							-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 35,							--Turn rate of missile at max deflection per 100 m/s
+		turnrate			= 37,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 65,							-- Acceleration in m/s.
@@ -560,7 +560,7 @@ ACF_defineGun("Meteor AAM", {							-- id
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
-		dragcoef			= 0.001,						-- percent speed loss per second
+		dragcoef			= 0.0012,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
@@ -603,7 +603,7 @@ ACF_defineGun("R-60 AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r60m.mdl",
 		rackmdl				= "models/missiles/arend/r60m.mdl",
-		firedelay			= 0.75,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 30.0,
 
@@ -612,7 +612,7 @@ ACF_defineGun("R-60 AAM", {								-- id
 
 		armour				= 15,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 50,							--Turn rate of missile at max deflection per 100 m/s
+		turnrate			= 53,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.35,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 55,							-- Acceleration in m/s.
@@ -674,7 +674,7 @@ ACF_defineGun("R-73 AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r73.mdl",
 		rackmdl				= "models/missiles/arend/r73.mdl",
-		firedelay			= 0.75,
+		firedelay			= 1.5,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -746,7 +746,7 @@ ACF_defineGun("R-77 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r77.mdl",
 		rackmdl				= "models/missiles/arend/r77.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 60.0,
 
@@ -756,8 +756,8 @@ ACF_defineGun("R-77 AAM", {							-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 15,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 17,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.22,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 130,							-- Acceleration in m/s.
 		burntime			= 10,							-- time in seconds for rocket motor to burn at max proppelant.
@@ -817,7 +817,7 @@ ACF_defineGun("R-27 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r27t.mdl",
 		rackmdl				= "models/missiles/arend/r27t.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
@@ -827,8 +827,8 @@ ACF_defineGun("R-27 AAM", {							-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 50,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.3,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 58,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 70,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
@@ -886,7 +886,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 	round = {
 		rocketmdl			= "models/missiles/arend/r33.mdl",
 		rackmdl				= "models/missiles/arend/r33.mdl",
-		firedelay			= 1.0,
+		firedelay			= 2.0,
 		reloadspeed			= 1.5,
 		reloaddelay			= 60.0,
 
@@ -896,10 +896,10 @@ ACF_defineGun("R-33 AAM", {							-- id
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320
-		turnrate			= 9.5,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.65,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 18,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.4,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 90,							-- Acceleration in m/s.
+		thrust				= 80,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
 		burntime			= 15,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
@@ -914,7 +914,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
-		dragcoef			= 0.002,						-- percent speed loss per second
+		dragcoef			= 0.0005,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
@@ -930,7 +930,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 
-	agility            = 3,									-- multiplier for missile turn-rate.  --was 0.7
+	irccm				= true,
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.5,								-- Required time (in seconds) for missile to start guiding at target once launched
 	ghosttime          = 0.05									-- Time where this missile will be unable to hit surfaces, in seconds

--- a/lua/acf/shared/missiles/missile_asm.lua
+++ b/lua/acf/shared/missiles/missile_asm.lua
@@ -38,7 +38,7 @@ ACF_defineGun("AGM-122 ASM", {						-- id
 		rocketmdl			= "models/missiles/aim9m.mdl",
 		rackmdl				= "models/missiles/aim9m.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 1.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 25.0,
 
 		maxlength			= 140,							-- Length of missile. Used for ammo properties.
@@ -110,7 +110,7 @@ ACF_defineGun("AGM-45 ASM", {						-- id
 		rocketmdl			= "models/missiles/arend/aim7f.mdl",
 		rackmdl				= "models/missiles/arend/aim7f.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 1.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 30.0,
 
 		maxlength			= 150,							-- Length of missile. Used for ammo properties.
@@ -181,7 +181,7 @@ ACF_defineGun("AGM-88 ASM", {						-- id
 		rocketmdl			= "models/missiles/arend/agm-88.mdl",
 		rackmdl				= "models/missiles/arend/agm-88.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 1.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 45.0,
 
 		maxlength			= 150,							-- Length of missile. Used for ammo properties.
@@ -251,7 +251,7 @@ ACF_defineGun("KH-31 ASM", {						-- id
 		rocketmdl			= "models/missiles/arend/kh31.mdl",
 		rackmdl				= "models/missiles/arend/kh31.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 2.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 60.0,
 
 
@@ -323,7 +323,7 @@ ACF_defineGun("AGM-65 ASM", {						-- id
 		rocketmdl			= "models/missiles/arend/agm65d.mdl",
 		rackmdl				= "models/missiles/arend/agm65d.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 2.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 80.0,
 
 
@@ -392,7 +392,7 @@ ACF_defineGun("Storm Shadow ASM", {						-- id
 		rocketmdl			= "models/macc/storm_shadow_open.mdl",
 		rackmdl				= "models/macc/storm_shadow_closed.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 2.0,
+		reloadspeed			= 6.0,
 		reloaddelay			= 80.0,
 
 

--- a/lua/acf/shared/missiles/missile_atgm.lua
+++ b/lua/acf/shared/missiles/missile_atgm.lua
@@ -33,8 +33,8 @@ ACF_defineGun("BGM-71E ASM", {								-- id
 		rocketmdl			= "models/missiles/bgm_71e.mdl",
 		rackmdl				= "models/missiles/bgm_71e.mdl",
 		firedelay			= 2,
-		reloadspeed			= 1.5,
-		reloaddelay			= 30.0,
+		reloadspeed			= 6,
+		reloaddelay			= 13.0,
 
 		maxlength			= 105,							-- Length of missile. Used for ammo properties.
 		propweight			= 1.2,							-- Motor mass - motor casing. Used for ammo properties.
@@ -102,8 +102,8 @@ ACF_defineGun("9M113 ATGM", {									-- id
 		rocketmdl				= "models/missiles/arend/9m113.mdl",
 		rackmdl				= "models/missiles/arend/9m113_folded.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 2.0,
-		reloaddelay			= 40.0,
+		reloadspeed			= 6.0,
+		reloaddelay			= 12.0,
 
 		maxlength			= 105,							-- Length of missile. Used for ammo properties.
 		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
@@ -168,8 +168,8 @@ ACF_defineGun("9M133 ASM", {									-- id
 		rocketmdl				= "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
 		rackmdl				= "models/kali/weapons/kornet/parts/9m133 kornet missile.mdl",
 		firedelay			= 4,
-		reloadspeed			= 2.0,
-		reloaddelay			= 40.0,
+		reloadspeed			= 6.0,
+		reloaddelay			= 16.0,
 
 		maxlength			= 105,							-- Length of missile. Used for ammo properties.
 		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
@@ -238,8 +238,8 @@ ACF_defineGun("AT-3 ASM", { --id
 		rocketmdl				= "models/missiles/at3.mdl",
 		rackmdl				= "models/missiles/at3.mdl",
 		firedelay			= 2,
-		reloadspeed			= 1.5,
-		reloaddelay			= 15.0,
+		reloadspeed			= 5,
+		reloaddelay			= 10.0,
 
 		maxlength			= 55,							-- Length of missile. Used for ammo properties.
 		propweight			= 1.2,							-- Motor mass - motor casing. Used for ammo properties.
@@ -309,8 +309,8 @@ ACF_defineGun("AT-2 ASM", { --id
 		rocketmdl				= "models/missiles/at2.mdl",
 		rackmdl				= "models/missiles/at2.mdl",
 		firedelay			= 2,
-		reloadspeed			= 1.5,
-		reloaddelay			= 40.0,
+		reloadspeed			= 16,
+		reloaddelay			= 12.0,
 
 		maxlength			= 55,							-- Length of missile. Used for ammo properties.
 		propweight			= 1.2,							-- Motor mass - motor casing. Used for ammo properties.
@@ -377,9 +377,9 @@ ACF_defineGun("FGM-148 ASM", {
 	round = {
 		rocketmdl				= "models/mcace/Jevelinemissile.mdl",
 		rackmdl				= "models/mcace/Jevelinemissile.mdl",
-		firedelay			= 0.5,
-		reloadspeed			= 1.0,
-		reloaddelay			= 60.0,
+		firedelay			= 1.5,
+		reloadspeed			= 10.0,
+		reloaddelay			= 25.0,
 
 		maxlength			= 110,							-- Length of missile. Used for ammo properties.
 		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
@@ -446,8 +446,8 @@ ACF_defineGun("Spike-LR ASM", {
 		rocketmdl				= "models/missiles/arend/spikelr.mdl",
 		rackmdl				= "models/missiles/arend/spikelr_closed.mdl",
 		firedelay			= 4,
-		reloadspeed			= 1.0,
-		reloaddelay			= 60.0,
+		reloadspeed			= 10,
+		reloaddelay			= 25.0,
 
 		maxlength			= 60,							-- Length of missile. Used for ammo properties.
 		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
@@ -521,8 +521,8 @@ ACF_defineGun("Ataka ASM", { --id
 		rocketmdl				= "models/missiles/9m120.mdl",
 		rackmdl				= "models/missiles/9m120.mdl",
 		firedelay			= 4,
-		reloadspeed			= 1.0,
-		reloaddelay			= 40.0,
+		reloadspeed			= 6.0,
+		reloaddelay			= 30.0,
 
 		maxlength			= 105,							-- Length of missile. Used for ammo properties.
 		propweight			= 1.7,							-- Motor mass - motor casing. Used for ammo properties.
@@ -592,8 +592,8 @@ ACF_defineGun("AGM-114 ASM", {						--id
 		rocketmdl				= "models/missiles/agm_114.mdl",
 		rackmdl				= "models/missiles/agm_114.mdl",
 		firedelay			= 4,
-		reloadspeed			= 1.0,
-		reloaddelay			= 60.0,
+		reloadspeed			= 6.0,
+		reloaddelay			= 40.0,
 
 		maxlength			= 150,							-- Length of missile. Used for ammo properties.
 		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
@@ -661,8 +661,8 @@ ACF_defineGun("Vikhr ASM", { --id
 		rocketmdl				= "models/missiles/arend/9k121.mdl",
 		rackmdl				= "models/missiles/arend/9k121_folded.mdl",
 		firedelay			= 3,
-		reloadspeed			= 1.0,
-		reloaddelay			= 40.0,
+		reloadspeed			= 6.0,
+		reloaddelay			= 30.0,
 
 		maxlength			= 105,							-- Length of missile. Used for ammo properties.
 		propweight			= 1.7,							-- Motor mass - motor casing. Used for ammo properties.

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -17,7 +17,7 @@ ACF_defineGunClass("SAM", {
 -- The FIM-92, a lightweight, medium-speed short-range anti-air missile.
 ACF_defineGun("FIM-92 SAM", {								-- id
 	name             = "FIM-92 Missile",
-	desc             = "The FIM-92 Stinger is a lightweight and versatile close-range air defense missile.\nWith a seek cone of 15 degrees and a sharply limited range that makes it useless versus high-flying targets, it is best to aim before firing and choose shots carefully.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: No\nTop Speed: 194 m/s",
+	desc             = "The FIM-92 Stinger is a lightweight and versatile close-range air defense missile.\nWith a seek cone of 15 degrees and a sharply limited range that makes it useless versus high-flying targets, it is best to aim before firing and choose shots carefully.\n\nInertial Guidance: No\nECCM: No\nDatalink: No\nTop Speed: 194 m/s",
 	model            = "models/missiles/fim_92.mdl",
 	effect           = "ACE_MissileTiny",					--Tiny motor for tiny rocket
 	gunclass         = "SAM",
@@ -31,9 +31,9 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 	round = {
 		rocketmdl				= "models/missiles/fim_92.mdl",
 		rackmdl				= "models/missiles/fim_92_folded.mdl",
-		firedelay			= 0.5,
-		reloadspeed			= 1.0,
-		reloaddelay			= 25,
+		firedelay			= 2.5,
+		reloadspeed			= 8.0,
+		reloaddelay			= 20,
 
 		--Former 125 and 1.5. Reduced blast from 107Mj to 60Mj. For reference a 100kg bomb has 117Kj.
 		maxlength			= 85,							-- Length of missile. Used for ammo properties.
@@ -59,7 +59,7 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.003,						-- percent speed loss per second
-		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
+		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.4							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 	},
 
@@ -76,7 +76,7 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 	seekcone           = 15,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.	--was 55
 	SeekSensitivity    = 1,
-	irccm				= true,
+	irccm				= false,
 
 	armdelay	= 0.15,									-- minimum fuse arming delay		-was 0.3
 	guidelay           = 0,									-- Required time (in seconds) for missile to start guiding at target once launched
@@ -86,7 +86,7 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 -- The Mistral missile is a faster short range missile with greater range than fim92 but less agility
 ACF_defineGun("Mistral SAM", {								-- id
 	name             = "Mistral Missile",
-	desc             = "A very fast short range missile, faster and less agile than FIM-92. Mostly for Anti-Aircraft and Anti-Missile operations.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: No\nTop Speed: 204 m/s",
+	desc             = "A very fast short range missile, faster and less agile than FIM-92. Mostly for Anti-Aircraft and Anti-Missile operations.\n\nInertial Guidance: No\nECCM: No\nDatalink: No\nTop Speed: 204 m/s",
 	model            = "models/missiles/fim_92_folded.mdl",
 	effect           = "ACE_MissileTiny",					-- Tiny motor for tiny rocket
 	gunclass         = "SAM",
@@ -100,9 +100,9 @@ ACF_defineGun("Mistral SAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/fim_92.mdl",
 		rackmdl				= "models/missiles/fim_92_folded.mdl",
-		firedelay			= 0.75,
-		reloadspeed			= 1.0,
-		reloaddelay			= 30.0,
+		firedelay			= 2.5,
+		reloadspeed			= 8.0,
+		reloaddelay			= 25.0,
 
 		--Formerly 130 and 1.5. Reduced blast from 112Mj to 72Mj. For reference a 100kg bomb has 117Kj.
 		maxlength			= 110,							-- Length of missile. Used for ammo properties.
@@ -128,7 +128,7 @@ ACF_defineGun("Mistral SAM", {								-- id
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.005,						-- percent speed loss per second
-		inertialcapable		= true,						-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
+		inertialcapable		= false,						-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.1							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 	},
 
@@ -143,7 +143,7 @@ ACF_defineGun("Mistral SAM", {								-- id
 	seekcone			= 15,										-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone			= 70,										-- getting outside this cone will break the lock.  Divided by 2.	--was 55
 	SeekSensitivity		= 1,
-	irccm				= true,
+	irccm				= false,
 
 	guidelay   = 0,										-- Required time (in seconds) for missile to start guiding at target once launched
 	ghosttime  = 0.5,									-- Time where this missile will be unable to hit surfaces, in seconds
@@ -168,9 +168,9 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/9m31.mdl",
 		rackmdl				= "models/missiles/9m31f.mdl",
-		firedelay			= 0.75,
-		reloadspeed			= 2.0,
-		reloaddelay			= 40.0,
+		firedelay			= 1.25,
+		reloadspeed			= 5.0,
+		reloaddelay			= 30.0,
 
 		--Formerly 190 and 1. Reduced blast from 213j to 120Mj. For reference a 100kg bomb has 117Kj.
 		maxlength			= 145,							-- Length of missile. Used for ammo properties.
@@ -181,7 +181,7 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 		turnrate			= 60,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 60,							-- Acceleration in m/s.
+		thrust				= 62,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
 		burntime			= 10,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
@@ -238,8 +238,8 @@ ACF_defineGun("VT-1 SAM", {										-- id
 		rocketmdl			= "models/missiles/arend/vt1.mdl",
 		rackmdl				= "models/missiles/arend/vt1_folded.mdl",
 		firedelay			= 0.75,
-		reloadspeed			= 2.0,
-		reloaddelay			= 40.0,
+		reloadspeed			= 5.0,
+		reloaddelay			= 30.0,
 
 		--Formerly 190 and 1. Reduced blast from 213j to 120Mj. For reference a 100kg bomb has 117Kj.
 		maxlength			= 145,							-- Length of missile. Used for ammo properties.
@@ -247,7 +247,7 @@ ACF_defineGun("VT-1 SAM", {										-- id
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 65,							--Turn rate of missile at max deflection per 100 m/s
+		turnrate			= 70,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.3,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 60,							-- Acceleration in m/s.
@@ -306,7 +306,7 @@ ACF_defineGun("9M311 SAM", {										-- id
 		rocketmdl			= "models/missiles/arend/9m311_unfolded.mdl",
 		rackmdl				= "models/missiles/arend/9m311_folded.mdl",
 		firedelay			= 0.75,
-		reloadspeed			= 2.0,
+		reloadspeed			= 5.0,
 		reloaddelay			= 40.0,
 
 		--Formerly 190 and 1. Reduced blast from 283j to 116Mj. For reference a 100kg bomb has 117Kj.
@@ -377,8 +377,8 @@ ACF_defineGun("9M331 SAM", {								-- id
 		rocketmdl			= "models/missiles/arend/9m331_unfolded.mdl",
 		rackmdl				= "models/missiles/arend/9m331_folded.mdl",
 		firedelay			= 0.5,
-		reloadspeed			= 2.0,
-		reloaddelay			= 45,
+		reloadspeed			= 5.0,
+		reloaddelay			= 40,
 
 		maxlength			= 55,							-- Length of missile. Used for ammo properties.
 		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
@@ -447,8 +447,8 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 		rocketmdl			= "models/macc/9m38m1.mdl",
 		rackmdl				= "models/macc/9m38m1.mdl",
 		firedelay			= 1.0,
-		reloadspeed			= 1.5,
-		reloaddelay			= 60.0,
+		reloadspeed			= 10,
+		reloaddelay			= 45.0,
 
 
 		maxlength			= 110,							-- Length of missile. Used for ammo properties.


### PR DESCRIPTION
New philosophy for multi missile reloads. Lower reload delay but increase inter-reload time. Promotes conserving shots.

All 2+ Racks:
-Increased fire delay

Stinger & Mistral:
-Increased fire delay
-Removed IOG and ECCM

Strela:
-Slight boost to missile speed

VT-1:
-Slightly increased agility

Aim-7:
-Nerfed acceleration of missile
-Reduced overall top speed
-Increased turnrate, Reduced turning energy retention
-Removed IOG making the missile easier to defeat
Note: It's slower but one of the more agile medium range A2A missiles.

Aim-120:
-Increased booster motor thrust
-Slightly increased turnrate, Reduced turning energy retention

Aim-54:
-Increased top speed
-Reduced acceleration
-Increased turnrate, Reduced turning energy retention
-Added ECCM to phoenix. It's a C model after all.
Note: Easy to G-pull. It WILL chase you down.

SRAAM:
-Trippled already schizophrenic turnrate
-Reduced turning energy retention. More wackiness!
-Reduced thrust and increased burntime slightly
-Reduced drag coefficient

MICA:
-Slightly nerfed thrust
-Reduced turning energy retention

Meteor:
-Slightly increased turnrate
-Slightly increased drag coefficient

R-60:
-Slightly increased turnrate

R-77:
-Increased turnrate, Reduced turning energy retention

R-27:
-Increased turnrate, Reduced turning energy retention

R-33:
-Appreciably increased top speed
-Increased turnrate, Reduced turning energy retention
-Added ECCM