### PR TITLE
Move event:OnArrived() to before the event.Sound nil check

### DIFF
--- a/lua/acf/client/cl_soundbase.lua
+++ b/lua/acf/client/cl_soundbase.lua
@@ -697,8 +697,8 @@ do
 			local event = SpeedOfSoundEvents[i]
 
 			if event.Time < RealTime() then
+				event:OnArrived()
 				if event.Sound then
-					event:OnArrived()
 					event:Play()
 				end
 


### PR DESCRIPTION
Some sound `event:OnArrived` functions can set `event.Sound` to nil such as one that calls `getBulletCrackSound` when none of the sounds are loaded which causes Lua errors when EmitSound is called.