### PR TITLE
Changed decoys to block overshoot fusing

### DIFF
--- a/lua/acf/shared/fuses/f_overshoot.lua
+++ b/lua/acf/shared/fuses/f_overshoot.lua
@@ -49,6 +49,8 @@ do
 
 		if not self:IsArmed() then return false end
 
+		if (missile.IsDecoyed or false) then return false end
+
 		local missilePos = missile:GetPos()
 		local missileTarget = missile.TargetPos
 

--- a/lua/acf/shared/guidances/d_infrared.lua
+++ b/lua/acf/shared/guidances/d_infrared.lua
@@ -17,7 +17,7 @@ this.Name = ClassName
 this.Target = nil
 
 -- Cone to acquire targets within.
-this.SeekCone = 12
+this.SeekCone = 6
 
 -- Cone to retain targets within.
 this.ViewCone = 70
@@ -78,10 +78,14 @@ function this:GetGuidance(missile)
 		return {}
 	end
 
-	if (self.Target:GetClass( ) == "ace_flare" and self.HasIRCCM) then
-		--print("IRCCM reject")
-		self.Target = nil
-		return {}
+	missile.IsDecoyed = false
+	if self.Target:GetClass( ) == "ace_flare" then
+		missile.IsDecoyed = true
+		if self.HasIRCCM then
+			--print("IRCCM reject")
+			self.Target = nil
+			return {}
+		end
 	end
 
 	local missilePos = missile:GetPos()

--- a/lua/acf/shared/guidances/f_radar.lua
+++ b/lua/acf/shared/guidances/f_radar.lua
@@ -50,6 +50,7 @@ function this:Configure(missile)
 	self.ViewCone = ACF_GetGunValue(missile.BulletData, "viewcone") or this.ViewCone
 	self.ViewConeCos = math.cos(math.rad(self.ViewCone))
 	self.SeekCone = ACF_GetGunValue(missile.BulletData, "seekcone") or this.SeekCone
+	self.SeekCone = self.SeekCone * 3
 	self.GCMultiplier	= ACF_GetGunValue(missile.BulletData, "groundclutterfactor") or this.GCMultiplier
 	self.HasIRCCM	= ACF_GetGunValue(missile.BulletData, "irccm") or this.HasIRCCM
 end
@@ -68,9 +69,14 @@ function this:GetGuidance(missile)
 		return {}
 	end
 
-	if (self.Target:GetClass( ) == "ace_flare" and self.HasIRCCM) then
-		self.Target = nil
-		return {}
+	missile.IsDecoyed = false
+	if self.Target:GetClass( ) == "ace_flare" then
+		missile.IsDecoyed = true
+		if self.HasIRCCM then
+			--print("IRCCM reject")
+			self.Target = nil
+			return {}
+		end
 	end
 
 	local missilePos = missile:GetPos()
@@ -262,16 +268,19 @@ function this:AcquireLock(missile)
 
 			if classifyent:GetClass() == "ace_flare" then
 				Multiplier = classifyent.RadarSig
+				--print(Multiplier)
 				--print("FlareSeen")
 			end
 
 			--Could do pythagorean stuff but meh, works 98% of time
-			local testang = (absang.p + absang.y) * Multiplier
+			local testang = (absang.p + absang.y + 2.5) / Multiplier
 
 			--Sorts targets as closest to being directly in front of radar
 			if testang < bestAng then
-
-				bestAng = testang
+				if Multiplier > 1 then
+					print("Flarewon")
+				end
+					bestAng = testang
 				bestent = classifyent
 
 			end

--- a/lua/acf/shared/guidances/i_radarsemi.lua
+++ b/lua/acf/shared/guidances/i_radarsemi.lua
@@ -71,6 +71,16 @@ function this:GetGuidance(missile)
 		return {}
 	end
 
+	missile.IsDecoyed = false
+	if self.Target:GetClass( ) == "ace_flare" then
+		missile.IsDecoyed = true
+		if self.HasIRCCM then
+			--print("IRCCM reject")
+			self.Target = nil
+			return {}
+		end
+	end
+
 	local missilePos = missile:GetPos()
 	--local missileForward = missile:GetForward()
 	--local targetPhysObj = self.Target:GetPhysicsObject()
@@ -204,8 +214,15 @@ function this:AcquireLock(missile)
 
 			debugoverlay.Sphere(entpos, 100, 5, Color(255,100,0,255))
 
+			local Multiplier = 1
+
+			if classifyent:GetClass() == "ace_flare" then
+				Multiplier = classifyent.RadarSig
+				--print("FlareSeen")
+			end
+
 			--Could do pythagorean stuff but meh, works 98% of time
-			local testang = absang.p + absang.y
+			local testang = (absang.p + absang.y) * Multiplier
 
 			--Sorts targets as closest to being directly in front of radar
 			if testang < bestAng then

--- a/lua/acf/shared/guidances/j_topattackir.lua
+++ b/lua/acf/shared/guidances/j_topattackir.lua
@@ -17,7 +17,7 @@ this.Name = ClassName
 this.Target = nil
 
 -- Cone to acquire targets within.
-this.SeekCone = 5
+this.SeekCone = 2
 
 -- Cone to retain targets within.
 this.ViewCone = 180
@@ -83,10 +83,14 @@ function this:GetGuidance(missile)
 		return {}
 	end
 
-	if (self.Target:GetClass( ) == "ace_flare" and self.HasIRCCM) then
-		--print("IRCCM reject")
-		self.Target = nil
-		return {}
+	missile.IsDecoyed = false
+	if self.Target:GetClass( ) == "ace_flare" then
+		missile.IsDecoyed = true
+		if self.HasIRCCM then
+			--print("IRCCM reject")
+			self.Target = nil
+			return {}
+		end
 	end
 	--print("Target")
 

--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -79,7 +79,7 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 				["1xRK_small"] = true
 			},
 
-	seekcone           = 30,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 15,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
@@ -151,7 +151,7 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 						["2xRK"] = true
 					},
 
-	seekcone           = 24,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
+	seekcone           = 12,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= false,
@@ -224,7 +224,7 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 						["2xRK"] = true
 					},
 
-	seekcone           = 24,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
+	seekcone           = 12,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= true,
@@ -294,7 +294,7 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 
 	racks              = {["1xRK"] = true},					-- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
-	seekcone           = 24,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
+	seekcone           = 12,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 
@@ -364,7 +364,7 @@ ACF_defineGun("SRAAM AAM", {								-- id
 			},
 
 
-	seekcone           = 30,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 15,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 
@@ -436,7 +436,7 @@ ACF_defineGun("Magic AAM", {								-- id
 				["1xRK_small"] = true
 			},
 
-	seekcone           = 30,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 15,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
@@ -511,7 +511,7 @@ ACF_defineGun("MICA AAM", {								-- id
 			},
 
 
-	seekcone           = 30,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 15,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
@@ -583,7 +583,7 @@ ACF_defineGun("Meteor AAM", {							-- id
 						["2xRK"] = true
 					},
 
-	seekcone           = 24,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
+	seekcone           = 12,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= true,
@@ -655,7 +655,7 @@ ACF_defineGun("R-60 AAM", {								-- id
 				["1xRK_small"] = true
 			},
 
-	seekcone           = 30,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 15,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 
@@ -729,7 +729,7 @@ ACF_defineGun("R-73 AAM", {								-- id
 
 
 	--Doesn't use the IRCCM system. Instead has a narrower seek cone that makes it better able to filter flares.
-	seekcone           = 18,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 9,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 
@@ -801,7 +801,7 @@ ACF_defineGun("R-77 AAM", {							-- id
 
 	--Doesn't use the IRCCM system. Instead has a narrower seek cone that makes it better able to filter flares.
 
-	seekcone           = 12,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
+	seekcone           = 6,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 27.5,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 
@@ -872,7 +872,7 @@ ACF_defineGun("R-27 AAM", {							-- id
 						["2xRK"] = true
 					},
 
-	seekcone           = 12,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
+	seekcone           = 6,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 
@@ -939,7 +939,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 
 	racks              = {["1xRK"] = true},					-- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
-	seekcone           = 16,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
+	seekcone           = 8,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -74,7 +74,7 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 				["4x FIM-92"] = true
 			},
 
-	seekcone           = 35,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
+	seekcone           = 15,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.	--was 55
 	SeekSensitivity    = 1,
 	irccm				= false,
@@ -142,7 +142,7 @@ ACF_defineGun("Mistral SAM", {								-- id
 					["2x FIM-92"] = true
 				},
 
-	seekcone			= 35,										-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
+	seekcone			= 15,										-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone			= 70,										-- getting outside this cone will break the lock.  Divided by 2.	--was 55
 	SeekSensitivity		= 1,
 	irccm				= false,
@@ -214,7 +214,7 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 						["4x Strela-1"] = true
 					},
 
-	seekcone           = 16,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
+	seekcone           = 8,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 0.8,
 
@@ -282,7 +282,7 @@ ACF_defineGun("VT-1 SAM", {										-- id
 				["1x VT-1"] = true
 			},
 
-	seekcone           = 12,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
+	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
@@ -352,7 +352,7 @@ ACF_defineGun("9M311 SAM", {										-- id
 				["1x 9m311"] = true
 			},
 
-	seekcone           = 12,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
+	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
@@ -423,7 +423,7 @@ ACF_defineGun("9M331 SAM", {								-- id
 						["1x9M331 Pod"] = true
 				},
 
-	seekcone           = 12,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
+	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 60,									-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 
@@ -493,7 +493,7 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 
 	racks              = {["1xRK"] = true},					-- a whitelist for racks that this missile can load into.  can also be a 'function(bulletData, rackEntity) return boolean end'
 
-	seekcone           = 12,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
+	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 	irccm				= true,

--- a/lua/acf/shared/rounds/roundchaff.lua
+++ b/lua/acf/shared/rounds/roundchaff.lua
@@ -29,14 +29,14 @@ function Round.create( Gun, BulletData )
 		local phys = ent:GetPhysicsObject()
 		phys:SetVelocity( BulletData.Flight * 0.125 )
 		--phys:EnableGravity(false)
-		local avgFac = 1 - (math.Rand(0.1,0.5) ^ 2)
+		local avgFac = 1 - (math.Rand(0.2,0.85) ^ 2)
 		ent.Heat = 0 --No thermal signiture for chaff.
 		ent.FirstHeat = ent.Heat
 
-		ent.RadarSig = (BulletData.FillerMass or 1) * 2.565 * avgFac --1.71 is 1x. 2.1375 is 1.25x radar signiture avg at full filler.
+		ent.RadarSig = (BulletData.FillerMass or 1) * 5 * avgFac --1.71 is 1x. 2.1375 is 1.25x radar signiture avg at full filler.
 		ent.FirstRadarSig = ent.RadarSig
 		--print(avgFac)
-		--print(ent.Heat)
+		--print(ent.RadarSig)
 
 	end
 

--- a/lua/acf/shared/rounds/roundflare.lua
+++ b/lua/acf/shared/rounds/roundflare.lua
@@ -29,8 +29,8 @@ function Round.create( Gun, BulletData )
 
 		local phys = ent:GetPhysicsObject()
 		phys:SetVelocity( BulletData.Flight * 0.35 )
-		local avgFac = 1 - (math.Rand(0.1,0.5) ^2)
-		ent.Heat = (BulletData.FillerMass or 1) * 1368 * avgFac -- 1028.8 is 600 temperature for a standard 40mm flare. This is twice an aircraft moving at 300 mph. I've added some extra measure. 1.71 * temp needed.
+		local avgFac = 1 - (math.Rand(0.2,0.85) ^ 2)
+		ent.Heat = (BulletData.FillerMass or 1) * 641 * avgFac -- 513 is 300 temperature for a standard 40mm flare. This is 1x an aircraft moving at 300 mph. I've added some extra measure. 1.71 * temp needed.
 		ent.FirstHeat = ent.Heat
 		ent.RadarSig = 0.25 --Flares have a quarter of the radar signiture of a normal target
 		--print(avgFac)


### PR DESCRIPTION
Despite being decoyed missiles would often still destroy the target plane because they would fuse on the flares. This is no longer the case.

Changes:
Decoyed missiles to no longer detonate on flares
Reduced seek cones of missiles.
Changed reliability of chaff and flares.
Flares will need more flares to reliably decoy missiles in a high speed plane.
Chaff will be more effective if maneuvering but not entirely reliable.