### PR TITLE
Allow loaders to replace dead drivers and gunners

### DIFF
--- a/lua/acf/server/sv_contraption.lua
+++ b/lua/acf/server/sv_contraption.lua
@@ -22,6 +22,7 @@ ACE.ECMPods           = {} --ECM usage
 ACE.Opticals          = {} --GLATGM optical computers
 ACE.Explosives        = {} --Explosive entities like ammocrates & fueltanks go here
 ACE.Debris            = {} --Debris count
+ACE.Crewseats         = {}
 ACE.Mines             = ACE.Mines or {}
 ACE.MineOwners  	  = ACE.MineOwners or {} -- We want to develop without losing any data inside of this.
 ACE.ScalableEnts      = ACE.ScalableEnts or {}
@@ -98,6 +99,8 @@ hook.Add("OnEntityCreated", "ACE_EntRegister", function(Ent)
 			elseif ACE.ExplosiveEnts[Eclass] then
 				--Insert Ammocrates and other explosive stuff here
 				table.insert(ACE.Explosives, Ent) --print('[ACE | INFO]- Explosive registered count: ' .. table.Count( ACE.Explosives ))
+			elseif Eclass == "ace_crewseat_gunner" or Eclass == "ace_crewseat_loader" or Eclass == "ace_crewseat_driver" then
+				table.insert(ACE.Crewseats, Ent) --print('[ACE | INFO]- Tracking radar registered count: ' .. table.Count( ACE.radarEntities ))
 			end
 
 			if Ent.IsScalable then
@@ -170,6 +173,15 @@ hook.Add("EntityRemoved", "ACE_EntRemoval", function(Ent)
 					if IsValid(explosive) and explosive == Ent then
 						table.remove(ACE.Explosives, i)
 						--print("Explosive registered count: " .. #ACE.Explosives)
+						break
+					end
+				end
+			elseif Eclass == "ace_crewseat_gunner" or Eclass == "ace_crewseat_loader" or Eclass == "ace_crewseat_driver" then
+				for i, crewseat in ipairs(ACE.radarEntities) do
+					if IsValid(crewseat) and crewseat == Ent then
+
+						table.remove(ACE.Crewseats, i)
+						--print("Tracking radar registered count: " .. #ACE.radarEntities)
 						break
 					end
 				end

--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -40,11 +40,20 @@ function ENT:Initialize()
 	self.Weight = 60
 	self.AnglePenalty = 0
 	self.LinkedEngine = nil
+	self.Sound = "npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav"
+	self.SoundPitch = 100
+
+	if not IsValid(self:CPPIGetOwner()) then
+		self:CPPISetOwner(game.GetWorld())
+	end
 
 	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true
 	self.LegalIssues = ""
 	self.ACEPoints = 1
+
+	self.SpecialHealth	= false  --If true needs a special ACF_Activate function
+	self.SpecialDamage	= true  --If true needs a special ACF_OnDamage function
 
 	local rareNames = {"Mr.Marty", "RDC", "Cheezus", "KemGus", "Golem Man", "Arend", "Mac", "Firstgamerable", "kerbal cadet", "Psycho Dog", "Ferv", "Rice", "spEAM"}
 
@@ -70,11 +79,6 @@ local maxPenalty = 90
 function ENT:Think()
 	local curSeatAngle = deg(acos(self:GetUp():Dot(Vector(0, 0, 1))))
 	self.AnglePenalty = clamp(remap(curSeatAngle, startPenalty, maxPenalty, 0, 1), 0, 1)
-
-	if self.ACF.Health <= self.ACF.MaxHealth * 0.97 then
-		ACF_HEKill( self, VectorRand() , 0)
-		self:EmitSound("npc/combine_soldier/die" .. tostring(math.random(1, 3)) .. ".wav", 50)
-	end
 
 	if ACF.CurTime > self.NextLegalCheck then
 
@@ -112,4 +116,112 @@ function ENT:UpdateOverlayText()
 	end
 
 	self:SetOverlayText(str)
+end
+
+
+function ENT:ACF_OnDamage( Entity, Energy, FrArea, _, Inflictor, _, _ )	--This function needs to return HitRes
+	self.ACF.Armour = 3
+	local HitRes	= ACF_PropDamage( Entity, Energy , FrArea, 0, Inflictor ) --Calling the standard damage prop function. Angle of incidence set to 0 for more consistent damage.
+
+	--print(math.Round(HitRes.Damage * 100))
+	--print(HitRes.Loss * 100)
+
+	--print(HitRes.Overkill)
+
+	if HitRes.Kill or HitRes.Overkill > 1 then
+
+		self:ConsumeCrewseats()
+
+		return { Damage = 0, Overkill = 0, Loss = 0, Kill = false }
+
+	end
+
+	return HitRes --This function needs to return HitRes
+
+end
+
+function ENT:ConsumeCrewseats() --So we died I guess. Find another poor schmuck to takeover
+
+	EmitSound(self.Sound, self:GetPos(), 50, CHAN_AUTO, 1, 75, 0, self.SoundPitch)
+
+	self.Legal = false
+	self.LegalIssues = "Apparently He Died"
+
+	self:SetNoDraw( true )
+	self:SetNotSolid( true )
+
+	for _, Link in pairs( self.Master ) do	--Unlink itself
+		if IsValid( Link ) then
+			Link.HasDriver = false
+		end
+	end
+
+	local ReplaceSeat = false
+
+	local ClosestDist = math.huge
+
+	if next(ACE.Crewseats) then
+		local ReplaceEnt = nil
+		for _, SeatEnt in pairs(ACE.Crewseats) do
+
+			if not IsValid(SeatEnt) then
+				continue
+			end
+
+			if SeatEnt:CPPIGetOwner() ~= self:CPPIGetOwner() then
+				continue
+			end
+
+			local Eclass = SeatEnt:GetClass()
+			if Eclass ~= "ace_crewseat_loader" then
+				continue
+			end
+			--Range: 20m or 790. 624100 is squared.
+			local sqDist = SeatEnt:GetPos():DistToSqr(self:GetPos())
+			if sqDist < 624100 and (sqDist < ClosestDist) then
+					ClosestDist = sqDist
+					ReplaceEnt = SeatEnt
+			end
+		end
+
+		if IsValid(ReplaceEnt) then
+			ReplaceSeat = true --You just got promoted bud.
+			self.Name = ReplaceEnt.Name
+			ACF_HEKill( ReplaceEnt, VectorRand() , 0)
+			--print("Found one...")
+			--debugoverlay.Cross(SeatEnt:GetPos(), 10, 10, Color(255,100,0), true)
+		end
+	end
+
+	if ReplaceSeat then
+		local ReplaceTime = 5 + math.sqrt( ClosestDist ) / 39.37 * 1 --5 seconds plus 1 second per meter
+
+		timer.Create( "CrewDie" .. self:GetCreationID(), ReplaceTime, 1, function() if IsValid(self) then self:ResetLinks() end end )
+
+	else
+		ACF_HEKill( self, VectorRand() , 0)
+	end
+
+
+	return ReplaceSeat
+
+end
+
+function ENT:ResetLinks()
+
+	self.ACF.Health = self.ACF.MaxHealth or 1
+	self.ACF.Armour = self.ACF.MaxArmour or 1
+	self.NextLegalCheck = 0
+	self:SetNoDraw( false )
+	self:SetNotSolid( false )
+
+	for _, Link in pairs( self.Master ) do				--First clean the table of any invalid entities
+		if IsValid( Link ) then
+			table.insert( Link.CrewLink, self )
+			Link.HasDriver = true
+
+			--Need to think of a better workaround. Shooting someone's driver activates their engine?
+			Link:TriggerInput("Active",1) -- disable if not legal and active
+		end
+	end
 end

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -40,11 +40,20 @@ function ENT:Initialize()
 	self.Weight = 60
 	self.AnglePenalty = 0
 	self.LinkedGun = nil
+	self.Sound = "npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav"
+	self.SoundPitch = 100
+
+	if not IsValid(self:CPPIGetOwner()) then
+		self:CPPISetOwner(game.GetWorld())
+	end
 
 	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true
 	self.LegalIssues = ""
 	self.ACEPoints = 1
+
+	self.SpecialHealth	= false  --If true needs a special ACF_Activate function
+	self.SpecialDamage	= true  --If true needs a special ACF_OnDamage function
 
 	local rareNames = {"Mr.Marty", "RDC", "Cheezus", "KemGus", "Golem Man", "Arend", "Mac", "Firstgamerable", "kerbal cadet", "Psycho Dog", "Ferv", "Rice", "spEAM"}
 
@@ -70,11 +79,6 @@ local maxPenalty = 90
 function ENT:Think()
 	local curSeatAngle = deg(acos(self:GetUp():Dot(Vector(0, 0, 1))))
 	self.AnglePenalty = clamp(remap(curSeatAngle, startPenalty, maxPenalty, 0, 1), 0, 1)
-
-	if self.ACF.Health <= self.ACF.MaxHealth * 0.97 then
-		ACF_HEKill( self, VectorRand() , 0)
-		self:EmitSound("npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav", 50)
-	end
 
 	if ACF.CurTime > self.NextLegalCheck then
 
@@ -115,8 +119,107 @@ function ENT:UpdateOverlayText()
 end
 
 
+function ENT:ACF_OnDamage( Entity, Energy, FrArea, _, Inflictor, _, _ )	--This function needs to return HitRes
+	self.ACF.Armour = 3
+	local HitRes	= ACF_PropDamage( Entity, Energy , FrArea, 0, Inflictor ) --Calling the standard damage prop function. Angle of incidence set to 0 for more consistent damage.
+
+	--print(math.Round(HitRes.Damage * 100))
+	--print(HitRes.Loss * 100)
+
+	--print(HitRes.Overkill)
+
+	if HitRes.Kill or HitRes.Overkill > 1 then
+
+		self:ConsumeCrewseats()
+
+		return { Damage = 0, Overkill = 0, Loss = 0, Kill = false }
+
+	end
+
+	return HitRes --This function needs to return HitRes
+
+end
+
+function ENT:ConsumeCrewseats() --So we died I guess. Find another poor schmuck to takeover
+
+	EmitSound(self.Sound, self:GetPos(), 50, CHAN_AUTO, 1, 75, 0, self.SoundPitch)
+
+	self.Legal = false
+	self.LegalIssues = "Apparently He Died"
+
+	self:SetNoDraw( true )
+	self:SetNotSolid( true )
+
+	for _, Link in pairs( self.Master ) do	--Unlink itself
+		if IsValid( Link ) then
+			Link.HasGunner = false
+		end
+	end
+
+	local ReplaceSeat = false
+
+	local ClosestDist = math.huge
+
+	if next(ACE.Crewseats) then
+		local ReplaceEnt = nil
+		for _, SeatEnt in pairs(ACE.Crewseats) do
+
+			if not IsValid(SeatEnt) then
+				continue
+			end
+
+			if SeatEnt:CPPIGetOwner() ~= self:CPPIGetOwner() then
+				continue
+			end
+
+			local Eclass = SeatEnt:GetClass()
+			if Eclass ~= "ace_crewseat_loader" then
+				continue
+			end
+			--Range: 20m or 790. 624100 is squared.
+			local sqDist = SeatEnt:GetPos():DistToSqr(self:GetPos())
+			if sqDist < 624100 and (sqDist < ClosestDist) then
+					ClosestDist = sqDist
+					ReplaceEnt = SeatEnt
+			end
+		end
+
+		if IsValid(ReplaceEnt) then
+			ReplaceSeat = true --You just got promoted bud.
+			self.Name = ReplaceEnt.Name
+			ACF_HEKill( ReplaceEnt, VectorRand() , 0)
+			--print("Found one...")
+			--debugoverlay.Cross(SeatEnt:GetPos(), 10, 10, Color(255,100,0), true)
+		end
+	end
+
+	if ReplaceSeat then
+		--Could add dynamic time by finding closest entity to replace it with
+		local ReplaceTime = 5 + math.sqrt( ClosestDist ) / 39.37 * 1 --5 seconds plus 1 second per meter
+
+		timer.Create( "CrewDie" .. self:GetCreationID(), ReplaceTime, 1, function() if IsValid(self) then self:ResetLinks() end end )
+
+	else
+		ACF_HEKill( self, VectorRand() , 0)
+	end
 
 
+	return ReplaceSeat
 
+end
 
+function ENT:ResetLinks()
 
+	self.ACF.Health = self.ACF.MaxHealth or 1
+	self.ACF.Armour = self.ACF.MaxArmour or 1
+	self.NextLegalCheck = 0
+	self:SetNoDraw( false )
+	self:SetNotSolid( false )
+
+	for _, Link in pairs( self.Master ) do				--First clean the table of any invalid entities
+		if IsValid( Link ) then
+			table.insert( Link.CrewLink, self )
+			Link.HasGunner = true
+		end
+	end
+end

--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -126,6 +126,63 @@ ACF.SoundToolSupport = {
 		end
 	},
 
+	ace_crewseat_gunner = {
+
+		GetSound = function(ent) return { Sound = ent.Sound or "npc/combine_soldier/die1.wav", Pitch = ent.SoundPitch or 100 } end,
+
+		SetSound = function(ent, soundData)
+			ent.Sound = soundData.Sound
+			ent.SoundPitch = soundData.Pitch
+			ent:SetNWString( "Sound", soundData.Sound )
+			ent:SetNWInt( "SoundPitch",  soundData.Pitch )
+		end,
+
+		ResetSound = function(ent)
+			local soundData = {Sound = "npc/combine_soldier/die1.wav", Pitch = 100}
+
+			local setSound = ACF.SoundToolSupport["ace_crewseat_gunner"].SetSound
+			setSound( ent, soundData )
+		end
+	},
+
+	ace_crewseat_driver = {
+
+		GetSound = function(ent) return { Sound = ent.Sound or "npc/combine_soldier/die1.wav", Pitch = ent.SoundPitch or 100 } end,
+
+		SetSound = function(ent, soundData)
+			ent.Sound = soundData.Sound
+			ent.SoundPitch = soundData.Pitch
+			ent:SetNWString( "Sound", soundData.Sound )
+			ent:SetNWInt( "SoundPitch",  soundData.Pitch )
+		end,
+
+		ResetSound = function(ent)
+			local soundData = {Sound = "npc/combine_soldier/die1.wav", Pitch = 100}
+
+			local setSound = ACF.SoundToolSupport["ace_crewseat_driver"].SetSound
+			setSound( ent, soundData )
+		end
+	},
+
+	ace_crewseat_loader = {
+
+		GetSound = function(ent) return { Sound = ent.Sound or "npc/combine_soldier/die1.wav", Pitch = ent.SoundPitch or 100 } end,
+
+		SetSound = function(ent, soundData)
+			ent.Sound = soundData.Sound
+			ent.SoundPitch = soundData.Pitch
+			ent:SetNWString( "Sound", soundData.Sound )
+			ent:SetNWInt( "SoundPitch",  soundData.Pitch )
+		end,
+
+		ResetSound = function(ent)
+			local soundData = {Sound = "npc/combine_soldier/die1.wav", Pitch = 100}
+
+			local setSound = ACF.SoundToolSupport["ace_crewseat_loader"].SetSound
+			setSound( ent, soundData )
+		end
+	},
+
 	NewFormat = function()
 	end
 


### PR DESCRIPTION
When a gunner or driver dies, they will be replaced by a nearby loader if able with a slight delay.
Currently the delay is: 5 seconds + 1 second per meter

Crewseats were also added to the soundreplacer tool. Go wild