### PR TITLE
Various bugfixes

### DIFF
--- a/lua/acf/client/cl_acfmenu_gui.lua
+++ b/lua/acf/client/cl_acfmenu_gui.lua
@@ -447,7 +447,7 @@ function ACFHomeGUICreate()
 
 	acfmenupanel["CData"]["VersionInit"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"]["VersionInit"]:SetText(versiontext)
-	acfmenupanel["CData"]["VersionInit"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionInit"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionInit"]:SizeToContents()
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"]["VersionInit"] )
 
@@ -456,7 +456,7 @@ function ACFHomeGUICreate()
 
 	acfmenupanel["CData"]["VersionText"]:SetFont("Trebuchet18")
 	acfmenupanel["CData"]["VersionText"]:SetText("ACE Is " .. versionstring .. "!\n\n")
-	acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionText"]:SizeToContents()
 
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"]["VersionText"] )
@@ -531,7 +531,7 @@ function ACFHomeGUIUpdate( Table )
 	end
 
 	acfmenupanel["CData"]["VersionText"]:SetText(txt)
-	acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionText"]:SetColor(color)
 	acfmenupanel["CData"]["VersionText"]:SizeToContents()
 
@@ -1093,7 +1093,7 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 	acfmenupanel["CData"][Name .. "_label"]:SetPos( 0, 0)
 	acfmenupanel["CData"][Name .. "_label"]:SetText( Title )
 	acfmenupanel["CData"][Name .. "_label"]:SizeToContents()
-	acfmenupanel["CData"][Name .. "_label"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_label"]:SetTextColor( Color( 0, 0, 0) )
 
 	if acfmenupanel.AmmoData[Name] then
 			acfmenupanel["CData"][Name]:SetValue(acfmenupanel.AmmoData[Name])
@@ -1121,7 +1121,7 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"][Name .. "_text"]:SetTall( 20 )
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"][Name .. "_text"] )
 
@@ -1142,7 +1142,7 @@ function PANEL:AmmoCheckbox(Name, Title, Desc, Tooltip )
 
 	acfmenupanel["CData"][Name] = vgui.Create( "DCheckBoxLabel" )
 	acfmenupanel["CData"][Name]:SetText( Title or "" )
-	acfmenupanel["CData"][Name]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"][Name]:SizeToContents()
 	acfmenupanel["CData"][Name]:SetChecked(acfmenupanel.AmmoData[Name] or false)
 
@@ -1171,7 +1171,7 @@ function PANEL:AmmoCheckbox(Name, Title, Desc, Tooltip )
 	acfmenupanel["CData"][Name .. "_text"] = acfmenupanel["CData"][Name .. "_text"]
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"][Name .. "_text"] )
 
 	end
@@ -1197,7 +1197,7 @@ function PANEL:CPanelText(Name, Desc, Font, Panel)
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 
 	if Font then acfmenupanel["CData"][Name .. "_text"]:SetFont( Font ) end
 
@@ -1220,6 +1220,5 @@ function PANEL:CPanelText(Name, Desc, Font, Panel)
 end
 
 net.Receive( "colorchatmessage", function( _, _ ) --Wooo colored chat
-	print("Recieved")
 	chat.AddText( net.ReadColor(), net.ReadString() )
 end )

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -95,7 +95,7 @@ function ACF_HE( Hitpos , _ , FillerMass, FragMass, Inflictor, NoOcc, Gun )
 
 		for _, ent in pairs( ACE.critEnts ) do
 			local epos = ent:GetPos()
-			local SqDist = Hitpos:DistToSqr( ent:GetPos() )
+			local SqDist = Hitpos:DistToSqr( epos )
 			if SqDist > RadSq then continue end --Perhaps a table storing positions would be faster?
 
 			local LosArmor = ACE_LOSMultiTrace(Hitpos,epos, HEPen)

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -36,7 +36,7 @@ function ACE_CheckLegalCont(Contraption)
 		local Ply = Contraption:GetACEBaseplate():CPPIGetOwner()
 		local AboveAmt = Contraption.totalMass - ACF.MaxWeight
 
-		local msg = "[ACE] " .. Ply:Nick() .. " has a vehicle [" .. math.ceil(AboveAmt) .. "kg] over the limit, weighing [" .. math.ceil(Contraption.totalMass) .. "kg / " .. math.ceil(ACF.PointsLimit) .. "kg]"
+		local msg = "[ACE] " .. Ply:Nick() .. " has a vehicle [" .. math.ceil(AboveAmt) .. "kg] over the limit, weighing [" .. math.ceil(Contraption.totalMass) .. "kg / " .. math.ceil(ACF.MaxWeight) .. "kg]"
 		chatMessageGlobal( msg, Color( 255, 234, 0))
 
 		Contraption.OTWarnings.WarnedOverWeight = true

--- a/lua/acf/shared/guidances/m_acoustic_straight.lua
+++ b/lua/acf/shared/guidances/m_acoustic_straight.lua
@@ -1,5 +1,5 @@
 
-local ClassName = "Acoustic_Straightsearch"
+local ClassName = "Acoustic_Straight"
 
 
 ACF = ACF or {}

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -323,7 +323,7 @@ function ENT:TriggerInput( iname, value )
 					local HasWarned = self.OTWarnings.WarnedFuel or false
 					--self.OTWarnings
 					if not HasWarned then
-						chatMessagePly( self:CPPIGetOwner() , "[ACE] Your engine requires fuel to work.", Color( 255, 0, 0 ))
+						chatMessagePly( self:CPPIGetOwner() , "[ACE] Your engine requires fuel to work and that it be activated BEFORE the engine.", Color( 255, 0, 0 ))
 						self.OTWarnings.WarnedFuel = true
 					end
 				end


### PR DESCRIPTION
Adjusted color of text to be the default color to work with skins
Removed received message when receiving an error.
Fixed points instead of kg typo in mass warning
Improved clarity of certain warning messages.
Made HEPenetration variable re-use the variable instead of recalculating a position again.
Fixed acoustic torpedo guidance.