### PR TITLE
Added gunner exception system

### DIFF
--- a/lua/acf/shared/guns/atrifle.lua
+++ b/lua/acf/shared/guns/atrifle.lua
@@ -28,7 +28,8 @@ ACF_defineGun("7.92mmATR", { --id
 		maxlength = 14,
 		propweight = 2.2
 	},
-	acepoints = 25
+	acepoints = 25,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("14.5mmATR", { --id
@@ -47,7 +48,8 @@ ACF_defineGun("14.5mmATR", { --id
 		maxlength = 21,
 		propweight = 3.8
 	},
-	acepoints = 50
+	acepoints = 50,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmATR", { --id
@@ -66,5 +68,6 @@ ACF_defineGun("20mmATR", { --id
 		maxlength = 24,
 		propweight = 5.5
 	},
-	acepoints = 100
+	acepoints = 100,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/flarelauncher.lua
+++ b/lua/acf/shared/guns/flarelauncher.lua
@@ -28,7 +28,8 @@ ACF_defineGun("40mmFGL", { --id
 		maxlength = 9,
 		propweight = 0.007
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 --add a gun to the class
@@ -47,5 +48,6 @@ ACF_defineGun("60mmFGL", { --id
 		maxlength = 3,
 		propweight = 0.014
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/grenadelauncher.lua
+++ b/lua/acf/shared/guns/grenadelauncher.lua
@@ -30,7 +30,8 @@ ACF_defineGun("40mmGL", { --id
 		maxlength = 7.5,
 		propweight = 0.01
 	},
-	acepoints = 250
+	acepoints = 250,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmGL", { --id
@@ -49,5 +50,6 @@ ACF_defineGun("20mmGL", { --id
 		maxlength = 7,
 		propweight = 0.005
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/machinegun.lua
+++ b/lua/acf/shared/guns/machinegun.lua
@@ -27,7 +27,8 @@ ACF_defineGun("7.62mmMG", { --id
 		maxlength = 13,
 		propweight = 0.04
 	},
-	acepoints = 50
+	acepoints = 50,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("12.7mmMG", {
@@ -44,7 +45,8 @@ ACF_defineGun("12.7mmMG", {
 		maxlength = 24,
 		propweight = 0.1
 	},
-	acepoints = 60
+	acepoints = 60,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("14.5mmMG", {
@@ -61,7 +63,8 @@ ACF_defineGun("14.5mmMG", {
 		maxlength = 27,
 		propweight = 0.04
 	},
-	acepoints = 80
+	acepoints = 80,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 
@@ -79,7 +82,8 @@ ACF_defineGun("20mmMG", {
 		maxlength = 32,
 		propweight = 0.09
 	},
-	acepoints = 100
+	acepoints = 100,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 do

--- a/lua/acf/shared/guns/mortar.lua
+++ b/lua/acf/shared/guns/mortar.lua
@@ -27,7 +27,8 @@ ACF_defineGun("50mmM", { --id
 		maxlength = 50,
 		propweight = 0.06
 	},
-	acepoints = 550
+	acepoints = 550,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("60mmM", { --id
@@ -45,7 +46,8 @@ ACF_defineGun("60mmM", { --id
 		maxlength = 65,
 		propweight = 0.1
 	},
-	acepoints = 650
+	acepoints = 650,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("80mmM", {
@@ -63,7 +65,8 @@ ACF_defineGun("80mmM", {
 		maxlength = 85,
 		propweight = 0.25
 	},
-	acepoints = 750
+	acepoints = 750,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("120mmM", {

--- a/lua/acf/shared/guns/smokelauncher.lua
+++ b/lua/acf/shared/guns/smokelauncher.lua
@@ -26,7 +26,8 @@ ACF_defineGun("40mmSL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.007
 	},
-	acepoints = 10
+	acepoints = 10,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmSL", { --id
@@ -43,7 +44,8 @@ ACF_defineGun("20mmSL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.0055
 	},
-	acepoints = 5
+	acepoints = 5,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("40mmCL", { --id
@@ -62,5 +64,6 @@ ACF_defineGun("40mmCL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.007
 	},
-	acepoints = 30
+	acepoints = 30,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -174,12 +174,13 @@ do
 		Gun.LinkRangeMul    = math.max(Gun.Caliber / 10,1) ^ 1.2
 		Gun.ACEPoints		= (Lookup.acepoints or 0.404) * ACE.CannonPointMul
 		Gun.RequiresGunner	= false
+		local GunnerExcluded	= Lookup.gunnerexception or false
 
 		Gun.noloaders	= ClassData.noloader or nil
 
 		Gun.Inaccuracy = ClassData.spread
 
-		if (Gun.Caliber * 10) > ACF.LargeGunsThreshold and ACF.LargeGunsRequireGunners ~= 0 then --If the caliber is large enough it requires a gunner.
+		if not GunnerExcluded and (Gun.Caliber * 10) > ACF.LargeGunsThreshold and ACF.LargeGunsRequireGunners ~= 0 then --If the caliber is large enough it requires a gunner.
 			Gun.RequiresGunner = true
 		end
 


### PR DESCRIPTION
ATRifles
Flare Launchers
Grenade Launchers
Machineguns
Mortars
And smoke launchers are now excluded from gunner caliber checks.
