### PR TITLE
Merged dev with master

### DIFF
--- a/lua/acf/client/cl_acfmenu_gui.lua
+++ b/lua/acf/client/cl_acfmenu_gui.lua
@@ -447,7 +447,7 @@ function ACFHomeGUICreate()
 
 	acfmenupanel["CData"]["VersionInit"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"]["VersionInit"]:SetText(versiontext)
-	acfmenupanel["CData"]["VersionInit"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionInit"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionInit"]:SizeToContents()
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"]["VersionInit"] )
 
@@ -456,7 +456,7 @@ function ACFHomeGUICreate()
 
 	acfmenupanel["CData"]["VersionText"]:SetFont("Trebuchet18")
 	acfmenupanel["CData"]["VersionText"]:SetText("ACE Is " .. versionstring .. "!\n\n")
-	acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionText"]:SizeToContents()
 
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"]["VersionText"] )
@@ -531,7 +531,7 @@ function ACFHomeGUIUpdate( Table )
 	end
 
 	acfmenupanel["CData"]["VersionText"]:SetText(txt)
-	acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"]["VersionText"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"]["VersionText"]:SetColor(color)
 	acfmenupanel["CData"]["VersionText"]:SizeToContents()
 
@@ -1093,7 +1093,7 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 	acfmenupanel["CData"][Name .. "_label"]:SetPos( 0, 0)
 	acfmenupanel["CData"][Name .. "_label"]:SetText( Title )
 	acfmenupanel["CData"][Name .. "_label"]:SizeToContents()
-	acfmenupanel["CData"][Name .. "_label"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_label"]:SetTextColor( Color( 0, 0, 0) )
 
 	if acfmenupanel.AmmoData[Name] then
 			acfmenupanel["CData"][Name]:SetValue(acfmenupanel.AmmoData[Name])
@@ -1121,7 +1121,7 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"][Name .. "_text"]:SetTall( 20 )
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"][Name .. "_text"] )
 
@@ -1142,7 +1142,7 @@ function PANEL:AmmoCheckbox(Name, Title, Desc, Tooltip )
 
 	acfmenupanel["CData"][Name] = vgui.Create( "DCheckBoxLabel" )
 	acfmenupanel["CData"][Name]:SetText( Title or "" )
-	acfmenupanel["CData"][Name]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel["CData"][Name]:SizeToContents()
 	acfmenupanel["CData"][Name]:SetChecked(acfmenupanel.AmmoData[Name] or false)
 
@@ -1171,7 +1171,7 @@ function PANEL:AmmoCheckbox(Name, Title, Desc, Tooltip )
 	acfmenupanel["CData"][Name .. "_text"] = acfmenupanel["CData"][Name .. "_text"]
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 	acfmenupanel.CustomDisplay:AddItem( acfmenupanel["CData"][Name .. "_text"] )
 
 	end
@@ -1197,7 +1197,7 @@ function PANEL:CPanelText(Name, Desc, Font, Panel)
 	acfmenupanel["CData"][Name .. "_text"] = vgui.Create( "DLabel" )
 
 	acfmenupanel["CData"][Name .. "_text"]:SetText( Desc or "" )
-	acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
+	--acfmenupanel["CData"][Name .. "_text"]:SetTextColor( Color( 0, 0, 0) )
 
 	if Font then acfmenupanel["CData"][Name .. "_text"]:SetFont( Font ) end
 
@@ -1220,6 +1220,5 @@ function PANEL:CPanelText(Name, Desc, Font, Panel)
 end
 
 net.Receive( "colorchatmessage", function( _, _ ) --Wooo colored chat
-	print("Recieved")
 	chat.AddText( net.ReadColor(), net.ReadString() )
 end )

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -494,6 +494,140 @@ function ACE_CreateLinkRope( Pos, Ent1, LPos1, Ent2, LPos2 )
 end
 
 --[[----------------------------------------------------------------------
+	A variation of the CreateKeyframeRope( ... ) for visualizing safezones
+	This one is more simple than the original function.
+	Creates a rope without any constraint
+------------------------------------------------------------------------]]
+function ACE_CreateSZRope( Pos, Ent, LPos1, LPos2 )
+
+	local rope = ents.Create( "keyframe_rope" )
+	rope:SetPos( Pos )
+	rope:SetKeyValue( "Width", 15 )
+	rope:SetKeyValue( "Type", 2 )
+
+	rope:SetKeyValue( "RopeMaterial", "cable/physbeam" )
+
+	-- Attachment point 1
+	rope:SetEntity( "StartEntity", Ent )
+	rope:SetKeyValue( "StartOffset", tostring( LPos1 ) )
+	rope:SetKeyValue( "StartBone", 0 )
+
+	-- Attachment point 2
+	rope:SetEntity( "EndEntity", Ent )
+	rope:SetKeyValue( "EndOffset", tostring( LPos2 ) )
+	rope:SetKeyValue( "EndBone", 0 )
+
+	rope:Spawn()
+	rope:Activate()
+
+	-- Delete the rope if the attachments get killed
+	Ent:DeleteOnRemove( rope )
+
+	return rope
+
+end
+
+function ACE_VisualizeSZ(Point1, Point2)
+
+	local SZEnt = ents.Create("prop_physics")
+	if SZEnt:IsValid() then
+		SZEnt:SetModel( "models/jaanus/wiretool/wiretool_pixel_med.mdl" )
+		SZEnt:Spawn()
+		SZEnt:SetColor( Color(255,0,0) )
+
+		local phys = SZEnt:GetPhysicsObject()
+		if (IsValid(phys)) then
+			phys:EnableMotion( false )
+		end
+		SZEnt:SetNotSolid( true )
+	end
+
+	--Upper Rectangle
+	local PT1 = Vector(Point1.x,Point1.y,Point2.z) + Vector(0,0,2)
+	local PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
+	local LPT1 = SZEnt:WorldToLocal(PT1)
+	local LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point1.x,Point1.y,Point2.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
+	PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	--Lower Rectangle
+	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	--4 corners
+	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point1.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+	PT1 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
+	PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+
+--[[
+	PT1 = Vector(Point1.x,Point1.y,Point1.z)
+	PT2 = Vector(Point2.x,Point1.y,Point1.z)
+	LPT1 = SZEnt:WorldToLocal(PT1)
+	LPT2 = SZEnt:WorldToLocal(PT2)
+	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+]]--
+
+	return SZEnt
+end
+
+--[[----------------------------------------------------------------------
 	This function will look for the driver/operator of a gun/rack based
 	from the used gun inputs when firing.
 	Meant for determining if the driver seat is legal.

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -241,7 +241,14 @@ end
 -- replaced with _ due to lack of use: Bone
 function ACF_VehicleDamage(Entity, Energy, FrArea, Angle, Inflictor, _, Gun, Type)
 
-	local HitRes = ACF_CalcDamage( Entity , Energy , FrArea , Angle  , Type)
+	--We create a dummy table to pass armour values to the calc function
+	local Target = {
+		ACF = {
+			Armour = 2 --8
+		}
+	}
+
+	local HitRes = ACF_CalcDamage( Target , Energy , FrArea , Angle  , Type)
 	local Driver = Entity:GetDriver()
 	local validd = Driver:IsValid()
 

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -95,7 +95,7 @@ function ACF_HE( Hitpos , _ , FillerMass, FragMass, Inflictor, NoOcc, Gun )
 
 		for _, ent in pairs( ACE.critEnts ) do
 			local epos = ent:GetPos()
-			local SqDist = Hitpos:DistToSqr( ent:GetPos() )
+			local SqDist = Hitpos:DistToSqr( epos )
 			if SqDist > RadSq then continue end --Perhaps a table storing positions would be faster?
 
 			local LosArmor = ACE_LOSMultiTrace(Hitpos,epos, HEPen)

--- a/lua/acf/server/sv_acfpermission.lua
+++ b/lua/acf/server/sv_acfpermission.lua
@@ -107,8 +107,16 @@ local function getMapSZs()
 	end
 
 	this.Safezones = safezones
+
+	timer.Simple( 5, function() this.visualizeSafeZones() end )
+
 	return true
 end
+
+hook.Add( "CleanUpMap", "RestoreSZsCleanup", function( _ )
+	--getMapSZs()
+	this.visualizeSafeZones()
+end )
 
 local function SaveMapDPM(mode)
 	local mapname = string.gsub(game.GetMap(), "[ ^ %a%d-_]", "_")
@@ -119,6 +127,21 @@ local function LoadMapDPM()
 	local mapname = string.gsub(game.GetMap(), "[ ^ %a%d-_]", "_")
 	return file.Read(mapDPMDir .. mapname .. ".txt", "DATA")
 end
+
+function this.visualizeSafeZones()
+
+	if not this.Safezones then return false end
+
+	--szname is _ because unused. I could potentially color the visual safezones???
+	for _, szpts in pairs(this.Safezones) do
+		szmin = szpts[1]
+		szmax = szpts[2]
+		ACE_VisualizeSZ(szmin, szmax)
+	end
+
+	return false
+end
+
 
 hook.Add( "Initialize", "ACF_LoadSafesForMap", function()
 	if not getMapSZs() then

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -36,7 +36,7 @@ function ACE_CheckLegalCont(Contraption)
 		local Ply = Contraption:GetACEBaseplate():CPPIGetOwner()
 		local AboveAmt = Contraption.totalMass - ACF.MaxWeight
 
-		local msg = "[ACE] " .. Ply:Nick() .. " has a vehicle [" .. math.ceil(AboveAmt) .. "kg] over the limit, weighing [" .. math.ceil(Contraption.totalMass) .. "kg / " .. math.ceil(ACF.PointsLimit) .. "kg]"
+		local msg = "[ACE] " .. Ply:Nick() .. " has a vehicle [" .. math.ceil(AboveAmt) .. "kg] over the limit, weighing [" .. math.ceil(Contraption.totalMass) .. "kg / " .. math.ceil(ACF.MaxWeight) .. "kg]"
 		chatMessageGlobal( msg, Color( 255, 234, 0))
 
 		Contraption.OTWarnings.WarnedOverWeight = true

--- a/lua/acf/shared/guidances/m_acoustic_straight.lua
+++ b/lua/acf/shared/guidances/m_acoustic_straight.lua
@@ -1,5 +1,5 @@
 
-local ClassName = "Acoustic_Straightsearch"
+local ClassName = "Acoustic_Straight"
 
 
 ACF = ACF or {}

--- a/lua/acf/shared/guns/atrifle.lua
+++ b/lua/acf/shared/guns/atrifle.lua
@@ -28,7 +28,8 @@ ACF_defineGun("7.92mmATR", { --id
 		maxlength = 14,
 		propweight = 2.2
 	},
-	acepoints = 25
+	acepoints = 25,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("14.5mmATR", { --id
@@ -47,7 +48,8 @@ ACF_defineGun("14.5mmATR", { --id
 		maxlength = 21,
 		propweight = 3.8
 	},
-	acepoints = 50
+	acepoints = 50,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmATR", { --id
@@ -66,5 +68,6 @@ ACF_defineGun("20mmATR", { --id
 		maxlength = 24,
 		propweight = 5.5
 	},
-	acepoints = 100
+	acepoints = 100,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/flarelauncher.lua
+++ b/lua/acf/shared/guns/flarelauncher.lua
@@ -28,7 +28,8 @@ ACF_defineGun("40mmFGL", { --id
 		maxlength = 9,
 		propweight = 0.007
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 --add a gun to the class
@@ -47,5 +48,6 @@ ACF_defineGun("60mmFGL", { --id
 		maxlength = 3,
 		propweight = 0.014
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/grenadelauncher.lua
+++ b/lua/acf/shared/guns/grenadelauncher.lua
@@ -30,7 +30,8 @@ ACF_defineGun("40mmGL", { --id
 		maxlength = 7.5,
 		propweight = 0.01
 	},
-	acepoints = 250
+	acepoints = 250,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmGL", { --id
@@ -49,5 +50,6 @@ ACF_defineGun("20mmGL", { --id
 		maxlength = 7,
 		propweight = 0.005
 	},
-	acepoints = 150
+	acepoints = 150,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/acf/shared/guns/machinegun.lua
+++ b/lua/acf/shared/guns/machinegun.lua
@@ -27,7 +27,8 @@ ACF_defineGun("7.62mmMG", { --id
 		maxlength = 13,
 		propweight = 0.04
 	},
-	acepoints = 50
+	acepoints = 50,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("12.7mmMG", {
@@ -44,7 +45,8 @@ ACF_defineGun("12.7mmMG", {
 		maxlength = 24,
 		propweight = 0.1
 	},
-	acepoints = 60
+	acepoints = 60,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("14.5mmMG", {
@@ -61,7 +63,8 @@ ACF_defineGun("14.5mmMG", {
 		maxlength = 27,
 		propweight = 0.04
 	},
-	acepoints = 80
+	acepoints = 80,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 
@@ -79,7 +82,8 @@ ACF_defineGun("20mmMG", {
 		maxlength = 32,
 		propweight = 0.09
 	},
-	acepoints = 100
+	acepoints = 100,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 do

--- a/lua/acf/shared/guns/mortar.lua
+++ b/lua/acf/shared/guns/mortar.lua
@@ -27,7 +27,8 @@ ACF_defineGun("50mmM", { --id
 		maxlength = 50,
 		propweight = 0.06
 	},
-	acepoints = 550
+	acepoints = 550,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("60mmM", { --id
@@ -45,7 +46,8 @@ ACF_defineGun("60mmM", { --id
 		maxlength = 65,
 		propweight = 0.1
 	},
-	acepoints = 650
+	acepoints = 650,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("80mmM", {
@@ -63,7 +65,8 @@ ACF_defineGun("80mmM", {
 		maxlength = 85,
 		propweight = 0.25
 	},
-	acepoints = 750
+	acepoints = 750,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("120mmM", {

--- a/lua/acf/shared/guns/smokelauncher.lua
+++ b/lua/acf/shared/guns/smokelauncher.lua
@@ -26,7 +26,8 @@ ACF_defineGun("40mmSL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.007
 	},
-	acepoints = 10
+	acepoints = 10,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("20mmSL", { --id
@@ -43,7 +44,8 @@ ACF_defineGun("20mmSL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.0055
 	},
-	acepoints = 5
+	acepoints = 5,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )
 
 ACF_defineGun("40mmCL", { --id
@@ -62,5 +64,6 @@ ACF_defineGun("40mmCL", { --id
 		maxlength	= 17.5,
 		propweight	= 0.007
 	},
-	acepoints = 30
+	acepoints = 30,
+	gunnerexception = true --Bypasses regular gunner rules.
 } )

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -323,7 +323,7 @@ function ENT:TriggerInput( iname, value )
 					local HasWarned = self.OTWarnings.WarnedFuel or false
 					--self.OTWarnings
 					if not HasWarned then
-						chatMessagePly( self:CPPIGetOwner() , "[ACE] Your engine requires fuel to work.", Color( 255, 0, 0 ))
+						chatMessagePly( self:CPPIGetOwner() , "[ACE] Your engine requires fuel to work and that it be activated BEFORE the engine.", Color( 255, 0, 0 ))
 						self.OTWarnings.WarnedFuel = true
 					end
 				end

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -128,7 +128,16 @@ do
 		Engine.FuelTank         = 0
 		Engine.Heat             = ACE.AmbientTemp
 
-		Engine.ACEPoints		= math.ceil((Lookup.acepoints or 0.404) * ACE.EnginePointMul)
+
+		local FuelCostMul = {
+			Petrol				= 1.0,
+			Diesel				= 1.2, --Due to generally higher torques
+			Multifuel			= 1.2, --Due to generally higher torques
+			Electric			= 0.8 --Due to odd power outputs
+		}
+		local PtsPerHP = 2.33
+		local FallBackCost = (Engine.peakkw / 0.7457) * PtsPerHP * (FuelCostMul[Engine.FuelType] or 1)
+		Engine.ACEPoints		= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointMul)
 
 		Engine.TorqueScale	= ACF.TorqueScale[Engine.EngineType]
 

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -174,12 +174,13 @@ do
 		Gun.LinkRangeMul    = math.max(Gun.Caliber / 10,1) ^ 1.2
 		Gun.ACEPoints		= (Lookup.acepoints or 0.404) * ACE.CannonPointMul
 		Gun.RequiresGunner	= false
+		local GunnerExcluded	= Lookup.gunnerexception or false
 
 		Gun.noloaders	= ClassData.noloader or nil
 
 		Gun.Inaccuracy = ClassData.spread
 
-		if (Gun.Caliber * 10) > ACF.LargeGunsThreshold and ACF.LargeGunsRequireGunners ~= 0 then --If the caliber is large enough it requires a gunner.
+		if not GunnerExcluded and (Gun.Caliber * 10) > ACF.LargeGunsThreshold and ACF.LargeGunsRequireGunners ~= 0 then --If the caliber is large enough it requires a gunner.
 			Gun.RequiresGunner = true
 		end
 

--- a/lua/weapons/weapon_szcreator/cl_init.lua
+++ b/lua/weapons/weapon_szcreator/cl_init.lua
@@ -1,0 +1,45 @@
+include("shared.lua")
+
+SWEP.DrawAmmo		= false
+SWEP.DrawCrosshair	= true
+SWEP.DrawWeaponInfoBox	= true
+SWEP.BounceWeaponIcon	= true
+
+
+concommand.Add( "ace_szcreationmenu", function(_, _, args)
+    local frame = vgui.Create( "DFrame" )
+    frame:SetSize( 300, 100 )
+    frame:SetSizable(false)
+
+    frame:SetDraggable(false)
+    frame:SetTitle("[ACE] Safezone Creation Tool")
+
+    frame:Center()
+    frame:SetVisible(true)
+    frame:MakePopup()
+    frame:ShowCloseButton(true)
+
+    frame:SetScreenLock(true)
+
+    local SZName = ""
+
+    local TextEntry = vgui.Create( "DTextEntry", frame ) -- create the form as a child of frame
+    TextEntry:Dock( TOP )
+    TextEntry:DockMargin( 0, 5, 0, 0 )
+    TextEntry:SetPlaceholderText( "<Enter a name for the safezone here>" )
+    TextEntry.OnChange = function( self )
+        SZName = self:GetValue()
+    end
+
+    local x,y = frame:GetSize()
+    local button = vgui.Create( "DButton", frame)
+    button:SetText( "Create Safezone" )
+    button:SetSize(100,30)
+    button:SetPos( x / 2 - 50, y / 2 + 10)
+    button.DoClick = function()
+        frame:Close()
+        --print("Min: " .. args[1] .. "x, " .. args[2] .. "y, " .. args[3] .. "z")
+        LocalPlayer():ConCommand("ACF_AddSafeZone " .. SZName .. " " .. args[1] .. " " .. args[2] .. " " .. args[3] .. " " .. args[4] .. " " .. args[5] .. " " .. args[6])
+        LocalPlayer():ConCommand("ACF_SaveSafeZones")
+    end
+end )

--- a/lua/weapons/weapon_szcreator/init.lua
+++ b/lua/weapons/weapon_szcreator/init.lua
@@ -1,0 +1,4 @@
+AddCSLuaFile ("cl_init.lua")
+AddCSLuaFile ("shared.lua")
+
+include ("shared.lua")

--- a/lua/weapons/weapon_szcreator/shared.lua
+++ b/lua/weapons/weapon_szcreator/shared.lua
@@ -1,0 +1,181 @@
+AddCSLuaFile("shared.lua")
+SWEP.Base = "weapon_ace_base"
+
+if CLIENT then
+	SWEP.PrintName		= "SZ-Creation Tool"
+	SWEP.Slot			= 4
+	SWEP.SlotPos		= 3
+end
+
+SWEP.Spawnable		= true
+SWEP.AdminOnly		= true
+
+SWEP.Category = "ACE Tools"
+SWEP.SubCategory = "Tools"
+
+--Visual
+SWEP.ViewModelFlip	= false
+SWEP.ViewModel		= "models/weapons/v_slam.mdl"
+SWEP.WorldModel		= "models/weapons/w_slam.mdl"
+SWEP.ReloadSound	= "Weapon_Pistol.Reload"
+SWEP.HoldType		= "rpg"
+SWEP.CSMuzzleFlashes	= true
+
+
+-- Other settings
+SWEP.Weight			= 10
+
+-- Weapon info
+SWEP.Purpose		= "Creates safezones"
+SWEP.Instructions	= "Left/Right click to set points. Holding shift sets it to your position else goes to aimpos. Reload to open the menu."
+
+SWEP.Corner1Ent = nil
+SWEP.SZCorner1  = Vector()
+SWEP.Corner2Ent = nil
+SWEP.SZCorner2  = Vector()
+SWEP.PreviewEntity = nil --Anchor entity for visual ropes to be attached to.
+
+SWEP.LastMenuOpen = 0
+
+function SWEP:PrimaryAttack()
+	self:SetNextPrimaryFire( CurTime() + 0.5 )
+
+	if CLIENT then
+		return
+	end
+
+	local owner = self:GetOwner()
+	local PointPos = Vector(0,0,0)
+	if owner:IsSprinting() then
+		PointPos = owner:GetShootPos()
+	else
+		local ET = owner:GetEyeTrace()
+		if ET.Hit then
+			PointPos = ET.HitPos
+		end
+	end
+
+	if not IsValid(self.Corner1Ent) then
+		local propEnt = ents.Create("prop_physics")
+		if propEnt:IsValid() then
+		propEnt:SetModel( "models/jaanus/wiretool/wiretool_pixel_med.mdl" )
+		propEnt:Spawn()
+		propEnt:SetNotSolid( true )
+		propEnt:SetColor( Color(0,255,0) )
+
+		local phys = propEnt:GetPhysicsObject()
+		if (IsValid(phys)) then
+			phys:EnableMotion( false )
+		end
+
+		self.Corner1Ent = propEnt
+		end
+	end
+
+	ACE_SendMsg(owner, Color(0,255,0), "[ACE SZ Tool] moved point(1)")
+	print("[ACE SZ Tool] moved point(1)")
+	self.Corner1Ent:SetPos(PointPos)
+	self.SZCorner1  = PointPos
+
+	local soundstr =  "npc/roller/code2.wav"
+	self:EmitSound(soundstr,500,100)
+
+	if IsValid(self.Corner1Ent) and IsValid(self.Corner2Ent) then
+		if IsValid(self.PreviewEntity) then
+			self.PreviewEntity:Remove()
+		end
+		self.PreviewEntity = ACE_VisualizeSZ(self.SZCorner1, self.SZCorner2)
+	end
+
+end
+
+function SWEP:SecondaryAttack()
+
+	self:SetNextSecondaryFire( CurTime() + 0.5 )
+
+	if CLIENT then
+		return
+	end
+
+
+	local owner = self:GetOwner()
+	local PointPos = Vector(0,0,0)
+	if owner:IsSprinting() then
+		PointPos = owner:GetShootPos()
+	else
+		local ET = owner:GetEyeTrace()
+		if ET.Hit then
+			PointPos = ET.HitPos
+		end
+	end
+
+	if not IsValid(self.Corner2Ent) then
+		local propEnt = ents.Create("prop_physics")
+		if propEnt:IsValid() then
+		propEnt:SetModel( "models/jaanus/wiretool/wiretool_pixel_med.mdl" )
+		propEnt:Spawn()
+		propEnt:SetNotSolid( true )
+		propEnt:SetColor( Color(255,0,0) )
+
+		local phys = propEnt:GetPhysicsObject()
+		if (IsValid(phys)) then
+			phys:EnableMotion( false )
+		end
+
+		self.Corner2Ent = propEnt
+		end
+	end
+
+	ACE_SendMsg(owner, Color(255,0,0), "[ACE SZ Tool] moved point(2)")
+	print("[ACE SZ Tool] moved point(2)")
+	self.Corner2Ent:SetPos(PointPos)
+	self.SZCorner2  = PointPos
+
+
+	local soundstr =  "npc/roller/code2.wav"
+	self:EmitSound(soundstr,500,100)
+
+	if IsValid(self.Corner1Ent) and IsValid(self.Corner2Ent) then
+		if IsValid(self.PreviewEntity) then
+			self.PreviewEntity:Remove()
+		end
+		self.PreviewEntity = ACE_VisualizeSZ(self.SZCorner1, self.SZCorner2)
+	end
+
+end
+
+function SWEP:Think()
+end
+
+function SWEP:Reload()
+
+	if CurTime() < self.LastMenuOpen then return false end
+	self.LastMenuOpen = CurTime() + 2
+
+	local owner = self:GetOwner()
+	CmdStr = ""
+	CmdStr = CmdStr .. "LocalPlayer():ConCommand('ace_szcreationmenu"
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner1.x,2 )
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner1.y,2 )
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner1.z,2 )
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner2.x,2 )
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner2.y,2 )
+	CmdStr = CmdStr .. " " --Arg Seperator
+	CmdStr = CmdStr .. math.Round( self.SZCorner2.z,2 )
+	CmdStr = CmdStr .. "')" --Arg Seperator and end
+
+	print(CmdStr)
+	owner:SendLua( CmdStr )
+	--owner:ConCommand(CmdStr)
+
+
+	self:DefaultReload(ACT_VM_RELOAD)
+
+	self:Think()
+	return true
+end


### PR DESCRIPTION
-Vehicles without a driver will default to using the seat as a driver. This removes the need for a driver on manned vehicles.
Sorry for the trouble everyone.
Driver crewmembers do still provide a horsepower boost and can be swapped out by other crewmembers on death.

-Added a tool to help server owners quickly create safezones. This tool can now be found in the weapons folder. Place points with Right/Left click. Hold Shift to place the point at your position instead. Press R to open a menu to create a safezone.

-Alongside the tool I also added visualization of safezones.

-Limited the armor of seat entities in checks to 1mm. This should make damaging players in seats more consistent.

-Improved clarity of certain fuel and legality related warning messages.

Bugfixes: 

-Fixed an error when firing guns not constrained to anything.

-Fixed a calculation error causing aluminum to cost less than RHA and weigh less.

-Adjusted color of text to be the default color to work with skins

-Removed received message when receiving an error.

-Fixed points instead of kg typo in mass warning

-Made HEPenetration variable re-use the variable instead of recalculating a position again.

-Fixed acoustic torpedo guidance.
