### PR TITLE
Added better seat selction, Fixed missile damage perms,  Oldammo check

### DIFF
--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -642,17 +642,21 @@ do
 		HEFS	= true
 	}
 
-	function ENT:ACF_OnDamage( Entity, Energy, FrArea, _, Inflictor, _, Type )	--This function needs to return HitRes
+	function ENT:ACF_OnDamage( Ent, Energy, FrArea, _, Inflictor, _, Type )	--This function needs to return HitRes
 
 		local Mul	= (( HEtbl[Type] and 0.1 ) or 1) --HE penetrators better penetrate the armor of missiles
-		local HitRes	= ACF_PropDamage( Entity, Energy , FrArea * Mul, 0, Inflictor ) --Calling the standard damage prop function. Angle of incidence set to 0 for more consistent damage.
+		local HitRes	= ACF_PropDamage( Ent, Energy , FrArea * Mul, 0, Inflictor ) --Calling the standard damage prop function. Angle of incidence set to 0 for more consistent damage.
+		--local Activated = ACF_Check( Ent )
+		--local CanDo = hook.Run("ACF_BulletDamage", Activated, Ent, Energy, FrArea, 0, Inflictor )
 
+		local CanDo = hook.Run("ACF_BulletDamage", _, Ent, _, _, _, Inflictor, _, _ )
+		----------------------(_, Entity, _, _, _, Inflictor, _, _)
 		--print(math.Round(HitRes.Damage * 100))
 		--print(HitRes.Loss * 100)
 
 		--print(HitRes.Overkill)
 
-		if HitRes.Kill or HitRes.Overkill > 1 then
+		if (HitRes.Kill or HitRes.Overkill > 1) and CanDo then
 
 			--self:Detonate()
 			self.MissileActive = true

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -191,6 +191,8 @@ do
 					--util.Effect not working during MP workaround. Waiting a while fixes the issue.
 
 					timer.Simple(DetDelay, function()
+						if not IsValid(self) then return end
+
 						local OldAmmo = self.Ammo
 						local Ratio = math.Rand(0.1,0.4)
 						self.Ammo = math.ceil(OldAmmo * Ratio * 2)

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -296,8 +296,10 @@ end
 function ENT:FindSeatForDriver()
 
 	local MaxDist = 348749.3 --Max distance to link driver seats. (15 meters * 39.37)^2 = 348749.3
-	local maxWeight = 0
+	local closestDist = math.huge
 	local SeatEnt = nil
+
+	local EngContraption = self:GetContraption()
 
 	for _, ent in pairs( ACE.critEnts ) do
 
@@ -312,13 +314,11 @@ function ENT:FindSeatForDriver()
 
 		if SqDist > MaxDist then continue end --Outside link range. Continue.
 
+		if EngContraption ~= ent:GetContraption() then continue end --Seatent isn't on the same contraption as the engine. Ignore it.
 
-		local phys = ent:GetPhysicsObject()
-		if not IsValid(phys) then continue end
-		local Mass = phys:GetMass()
-		if Mass > maxWeight then
+		if SqDist < closestDist then
 			SeatEnt = ent
-			maxWeight = Mass
+			closestDist = SqDist
 		end
 	end
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -518,7 +518,6 @@ function ENT:AddMissile(MissileSlot) --Where the majority of the missile paramat
 
 	local missile = ents.Create("ace_missile")
 	missile:CPPISetOwner(ply)
-	missile.DamageOwner = ply
 	missile.DoNotDuplicate  = true
 	missile.Launcher		= self
 


### PR DESCRIPTION
Added better seat selection. It will now check to make sure the drivers seats are on the contraption as well as prioritizing the closest seats to the engine.

Missiles will no longer detonate if shot without the proper permissions. No more unexpected chain reactions of death.

Added an isvalid check to the oldammo. Should fix the error from appearing.