### PR TITLE
Changed radar water groundclutter. Missile radars dont detect underwater

### DIFF
--- a/lua/entities/acf_missileradar/init.lua
+++ b/lua/entities/acf_missileradar/init.lua
@@ -257,6 +257,8 @@ function ENT:ScanForMissiles()
 
 	for _, missile in pairs(missiles) do
 
+		if missile.IsUnderWater or 0 > 3 then continue end
+
 		i = i + 1
 
 		entArray[i] = missile


### PR DESCRIPTION
Changed radar water groundclutter.  Water can now act as ground clutter for radar.
Targets above 20 tons on the water can now be detected by radar up to a depth of 5m.

Missile radars no longer detect underwater