### PR TITLE
Merged Dev to Main

### DIFF
--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -55,6 +55,8 @@ function ACF_CreateBullet( BulletData )
 	ACF_BulletClient( ACF.CurBulletIndex, ACF.Bullet[ACF.CurBulletIndex], "Init" , 0 )
 	ACF_CalcBulletFlight( ACF.CurBulletIndex, ACF.Bullet[ACF.CurBulletIndex] )
 
+	hook.Run("ACFOnBulletCreation", ACF.CurBulletIndex, ACF.Bullet[ACF.CurBulletIndex] or BulletData)
+
 end
 
 --[[------------------------------------------------------------------------------------------------
@@ -84,6 +86,7 @@ function ACF_RemoveBullet( Index )
 	ACF.Bullet[Index] = nil
 	if Bullet and Bullet.OnRemoved then Bullet:OnRemoved() end
 
+	hook.Run("ACFOnBulletRemoved", Index, Bullet)
 end
 
 --[[------------------------------------------------------------------------------------------------
@@ -301,6 +304,8 @@ do
 
 			Penetrated = function(Index, Bullet, FlightRes, type)
 
+				hook.Run("ACFOnBulletPenetrated", Index, Bullet, FlightRes)
+
 				if Bullet.OnPenetrated then
 					Bullet.OnPenetrated(Index, Bullet, FlightRes)
 				end
@@ -334,6 +339,8 @@ do
 
 			Ricochet = function(Index, Bullet, FlightRes, type)
 
+				hook.Run("ACFOnBulletRicochet", Index, Bullet, FlightRes)
+
 				if Bullet.OnRicocheted then
 					Bullet.OnRicocheted(Index, Bullet, FlightRes)
 				end
@@ -360,6 +367,8 @@ do
 ------------ Called and performed when the bullet was told to stop there. Nothing else ------------
 
 			Hit = function(Index, Bullet, FlightRes, _)
+
+				hook.Run("ACFOnBulletHit", Index, Bullet, FlightRes)
 
 				if Bullet.OnEndFlight then
 					Bullet.OnEndFlight(Index, Bullet, FlightRes)

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -139,21 +139,29 @@ function ACF_Damage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Gun, T
 		return { Damage = 0, Overkill = 0, Loss = 0, Kill = false }
 	end
 
+	local oldACFTbl = table.Copy( Entity.ACF or {} )
+	local hitRes = nil
+
 	if Entity.SpecialDamage then
-		return Entity:ACF_OnDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Type )
+
+		hitRes = Entity:ACF_OnDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Type )
+
 	elseif Activated == "Prop" then
 
-		return ACF_PropDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone , Type)
+		hitRes = ACF_PropDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone , Type)
 
 	elseif Activated == "Vehicle" then
 
-		return ACF_VehicleDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Gun , Type)
+		hitRes = ACF_VehicleDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Gun , Type)
 
 	elseif Activated == "Squishy" then
 
-		return ACF_SquishyDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Gun , Type)
+		hitRes = ACF_SquishyDamage( Entity , Energy , FrArea , Angle , Inflictor , Bone, Gun , Type)
 
 	end
+
+	hook.Run("ACFOnDamage", Entity, Energy, FrArea, Angle, Inflictor, Bone, Gun, Type, hitRes, oldACFTbl)
+	return hitRes
 
 end
 

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -1077,7 +1077,7 @@ function ACF_HEKill( Entity , HitVector , Energy , BlastPos )
 					phys:SetVelocity(Parent:GetVelocity() )
 				end
 
-				phys:ApplyForceCenter( (HitVector:GetNormalized() + VectorRand() * 0.25) * Energy * 5  )
+				phys:ApplyForceCenter( (HitVector:GetNormalized() + VectorRand() * 0.5) * Energy * 50  )
 			end
 		end
 	end
@@ -1090,7 +1090,6 @@ end
 
 -- Creates a debris related to kinetic destruction.
 function ACF_APKill( Entity , HitVector , Power )
-
 	-- kill the children of this ent, instead of disappearing them from removing parent
 	ACF_KillChildProps( Entity, Entity:GetPos(), Power )
 
@@ -1123,13 +1122,13 @@ function ACF_APKill( Entity , HitVector , Power )
 			local Parent =  ACF_GetPhysicalParent( Entity )
 
 			if IsValid(phys) and IsValid(physent) then
-				phys:SetDragCoefficient( 15 )
+				phys:SetDragCoefficient( 5 )
 				phys:SetMass( math.max(physent:GetMass() * 3,300) )
 				phys:SetVelocity(Parent:GetVelocity() )
 				if IsValid(Parent) then
 					phys:SetVelocity( Parent:GetVelocity() )
 				end
-				phys:ApplyForceCenter( HitVector:GetNormalized() * Power * 50)
+				phys:ApplyForceCenter( HitVector:GetNormalized() * Power * 500)
 			end
 		end
 	end

--- a/lua/acf/shared/engines/turbine.lua
+++ b/lua/acf/shared/engines/turbine.lua
@@ -18,7 +18,7 @@ ACF_DefineEngine( "Turbine-Small-Trans", {
 	iselec = true,
 	istrans = true,
 	flywheeloverride = 4167,
-	acepoints = 734
+	acepoints = 612
 } )
 
 ACF_DefineEngine( "Turbine-Medium-Trans", {
@@ -38,7 +38,7 @@ ACF_DefineEngine( "Turbine-Medium-Trans", {
 	iselec = true,
 	istrans = true,
 	flywheeloverride = 5000,
-	acepoints = 1316
+	acepoints = 1096
 } )
 
 ACF_DefineEngine( "Turbine-Large-Trans", {
@@ -58,7 +58,7 @@ ACF_DefineEngine( "Turbine-Large-Trans", {
 	iselec = true,
 	istrans = true,
 	flywheeloverride = 5625,
-	acepoints = 3621
+	acepoints = 3017
 } )
 
 ACF_DefineEngine( "Turbine-Small", {
@@ -77,7 +77,7 @@ ACF_DefineEngine( "Turbine-Small", {
 	limitrpm = 10000,
 	iselec = true,
 	flywheeloverride = 4167,
-	acepoints = 918
+	acepoints = 765
 } )
 
 ACF_DefineEngine( "Turbine-Medium", {
@@ -96,7 +96,7 @@ ACF_DefineEngine( "Turbine-Medium", {
 	limitrpm = 12000,
 	iselec = true,
 	flywheeloverride = 5000,
-	acepoints = 1647
+	acepoints = 1372
 } )
 
 ACF_DefineEngine( "Turbine-Large", {
@@ -115,7 +115,7 @@ ACF_DefineEngine( "Turbine-Large", {
 	limitrpm = 13500,
 	iselec = true,
 	flywheeloverride = 5625,
-	acepoints = 4524
+	acepoints = 3770
 } )
 
 --Forward facing ground turbines
@@ -136,7 +136,7 @@ ACF_DefineEngine( "Turbine-Ground-Small", {
 	limitrpm = 3000,
 	iselec = true,
 	flywheeloverride = 1667,
-	acepoints = 528
+	acepoints = 440
 } )
 
 ACF_DefineEngine( "Turbine-Ground-Medium", {
@@ -156,7 +156,7 @@ ACF_DefineEngine( "Turbine-Ground-Medium", {
 	iselec = true,
 	flywheeloverride = 1450,
 	pitch = 115,
-	acepoints = 766
+	acepoints = 638
 } )
 
 ACF_DefineEngine( "Turbine-Ground-Large", {
@@ -176,7 +176,7 @@ ACF_DefineEngine( "Turbine-Ground-Large", {
 	iselec = true,
 	flywheeloverride = 1250,
 	pitch = 135,
-	acepoints = 2472
+	acepoints = 2060
 } )
 
 --Transaxial Ground Turbines
@@ -198,7 +198,7 @@ ACF_DefineEngine( "Turbine-Small-Ground-Trans", {
 	iselec = true,
 	istrans = true,
 	flywheeloverride = 1667,
-	acepoints = 881
+	acepoints = 734
 } )
 
 ACF_DefineEngine( "Turbine-Medium-Ground-Trans", {
@@ -219,7 +219,7 @@ ACF_DefineEngine( "Turbine-Medium-Ground-Trans", {
 	istrans = true,
 	flywheeloverride = 1450,
 	pitch = 115,
-	acepoints = 1580
+	acepoints = 1316
 } )
 
 ACF_DefineEngine( "Turbine-Large-Ground-Trans", {
@@ -240,7 +240,7 @@ ACF_DefineEngine( "Turbine-Large-Ground-Trans", {
 	istrans = true,
 	flywheeloverride = 1250,
 	pitch = 135,
-	acepoints = 4344
+	acepoints = 3620
 } )
 
 
@@ -263,7 +263,7 @@ ACF_DefineEngine( "(+)Turbine-Small-SuperAero", {
 	iselec = true,
 	pitch = 70,
 	flywheeloverride = 12000,
-	acepoints = 762
+	acepoints = 635
 } )
 
 
@@ -286,5 +286,5 @@ ACF_DefineEngine( "AGT 1500 Large Turbine", {
 	iselec = true,
 	pitch = 130,
 	flywheeloverride = 5300,
-	acepoints = 4222
+	acepoints = 3518
 } )

--- a/lua/acf/shared/guidances/k_beamrider.lua
+++ b/lua/acf/shared/guidances/k_beamrider.lua
@@ -77,7 +77,7 @@ function this:GetGuidance(missile)
 	local Dist = GEntPos:Distance(missile:GetPos())
 
 
-	self.TargetPos = GEntPos + GEntDir * (Dist + 39.37 * 15)
+	self.TargetPos = GEntPos + GEntDir * (Dist + 39.37 * 35)
 	return {TargetPos = self.TargetPos, ViewCone = self.ViewCone}
 
 end

--- a/lua/acf/shared/guns/atrifle.lua
+++ b/lua/acf/shared/guns/atrifle.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("ATR", {
 	type = "Gun",
-	spread = 0.02,
+	spread = 0.01,
 	name = "Anti-Tank Rifle",
 	desc = ACFTranslation.GunClasses[1],
 	muzzleflash = "MG",

--- a/lua/acf/shared/guns/autocannon.lua
+++ b/lua/acf/shared/guns/autocannon.lua
@@ -4,7 +4,7 @@ do
 	--define the class
 	ACF_defineGunClass("AC", {
 		type = "Gun",
-		spread = 0.2,
+		spread = 0.15,
 		name = "Autocannon",
 		desc = ACFTranslation.GunClasses[2],
 		muzzleflash = "AC",

--- a/lua/acf/shared/guns/autoloader.lua
+++ b/lua/acf/shared/guns/autoloader.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("AL", {
 	type = "Gun",
-	spread = 0.1,
+	spread = 0.12,
 	name = "Autoloader",
 	desc = ACFTranslation.GunClasses[3],
 	muzzleflash = "C",

--- a/lua/acf/shared/guns/autoloader.lua
+++ b/lua/acf/shared/guns/autoloader.lua
@@ -14,7 +14,7 @@ ACF_defineGunClass("AL", {
 
 --add a gun to the class
 ACF_defineGun("50mmAL", { --id
-	name = "50mm Autoloading Cannon",
+	name = "50mm Drum Autoloader",
 	desc = "A lightweight bullet spitting monster found on certain ground attack planes. Capable of rapidly filling targets with many high pen darts.",
 	model = "models/tankgun/tankgun_al_50mm.mdl",
 	sound = "ace_weapons/multi_sound/75mm_multi.mp3",
@@ -23,7 +23,7 @@ ACF_defineGun("50mmAL", { --id
 	caliber = 5,
 	weight = 850,
 	year = 1946,
-	rofmod = 1,
+	rofmod = 0.8,
 	magsize = 12,
 	magreload = 20,
 	round = {
@@ -35,7 +35,7 @@ ACF_defineGun("50mmAL", { --id
 
 --add a gun to the class
 ACF_defineGun("75mmAL", { --id
-	name = "75mm Autoloading Cannon",
+	name = "75mm Drum Autoloader",
 	desc = "A quick-firing 75mm gun, pops off a number of rounds in relatively short order.",
 	model = "models/tankgun/tankgun_al_75mm.mdl",
 	sound = "ace_weapons/multi_sound/75mm_multi.mp3",
@@ -44,9 +44,9 @@ ACF_defineGun("75mmAL", { --id
 	caliber = 7.5,
 	weight = 980,
 	year = 1946,
-	rofmod = 1,
+	rofmod = 0.7,
 	magsize = 12,
-	magreload = 20,
+	magreload = 30,
 	round = {
 		maxlength = 78,
 		propweight = 3.8
@@ -55,7 +55,7 @@ ACF_defineGun("75mmAL", { --id
 } )
 
 ACF_defineGun("100mmAL", {
-	name = "100mm Autoloading Cannon",
+	name = "100mm Drum Autoloader",
 	desc = "The 100mm is good for rapidly hitting medium armor, then running like your ass is on fire to reload.",
 	model = "models/tankgun/tankgun_al_100mm.mdl",
 	sound = "ace_weapons/multi_sound/100mm_multi.mp3",
@@ -64,9 +64,9 @@ ACF_defineGun("100mmAL", {
 	caliber = 10.0,
 	weight = 1800,
 	year = 1956,
-	rofmod = 0.8,
+	rofmod = 0.7,
 	magsize = 12,
-	magreload = 25,
+	magreload = 35,
 	round = {
 		maxlength = 93,
 		propweight = 20
@@ -75,7 +75,7 @@ ACF_defineGun("100mmAL", {
 } )
 
 ACF_defineGun("120mmAL", {
-	name = "120mm Autoloading Cannon",
+	name = "120mm Drum Autoloader",
 	desc = "The 120mm autoloader can do serious damage before reloading, but the reload time is killer.",
 	model = "models/tankgun/tankgun_al_120mm.mdl",
 	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
@@ -84,9 +84,9 @@ ACF_defineGun("120mmAL", {
 	caliber = 12.0,
 	weight = 2700,
 	year = 1956,
-	rofmod = 0.9,
+	rofmod = 0.7,
 	magsize = 12,
-	magreload = 30,
+	magreload = 35,
 	round = {
 		maxlength = 115,
 		propweight = 30
@@ -95,7 +95,7 @@ ACF_defineGun("120mmAL", {
 } )
 
 ACF_defineGun("140mmAL", {
-	name = "140mm Autoloading Cannon",
+	name = "140mm Drum Autoloader",
 	desc = "The 140mm can shred a medium tank's armor with one magazine, and even function as shoot & scoot artillery, with its useful HE payload.",
 	model = "models/tankgun/tankgun_al_140mm.mdl",
 	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
@@ -104,7 +104,7 @@ ACF_defineGun("140mmAL", {
 	caliber = 14.0,
 	weight = 4800,
 	year = 1970,
-	rofmod = 0.9,
+	rofmod = 0.7,
 	magsize = 12,
 	magreload = 40,
 	round = {
@@ -116,7 +116,7 @@ ACF_defineGun("140mmAL", {
 
 
 ACF_defineGun("170mmAL", {
-	name = "170mm Autoloading Cannon",
+	name = "170mm Drum Autoloader",
 	desc = "The 170mm can shred an average 40ton tank's armor with one magazine.",
 	model = "models/tankgun/tankgun_al_170mm.mdl",
 	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
@@ -125,7 +125,7 @@ ACF_defineGun("170mmAL", {
 	caliber = 17.0,
 	weight = 12460,
 	year = 1970,
-	rofmod = 1,
+	rofmod = 0.7,
 	magsize = 12,
 	magreload = 40,
 	round = {
@@ -135,3 +135,91 @@ ACF_defineGun("170mmAL", {
 	acepoints = 6000
 } )
 
+
+
+--PLACEHOLDERS until we get an actual autoloader system.
+
+ACF_defineGun("75mmBAL", {
+	name = "75mm Breech Autoloader",
+	desc = "PLACEHOLDER. 75mm Breech Autoloader. Autoloading giving it a consistent rate of fire in all conditions.",
+	model = "models/tankgun_new/tankgun_75mm.mdl",
+	sound = "ace_weapons/multi_sound/75mm_multi.mp3",
+	gunclass = "AL",
+	caliber = 7.5,
+	weight = 1400,
+	year = 1960,
+	rofmod = 1.2,
+	round = {
+		maxlength = 78,
+		propweight = 3.8
+	},
+	acepoints = 2400
+} )
+
+ACF_defineGun("100mmBAL", {
+	name = "100mm Breech Autoloader",
+	desc = "PLACEHOLDER. 100mm Breech Autoloader, with good penetration performance, can perform a deadly strike in one single pass. Seen on those modern tank destroyers.",
+	model = "models/tankgun_new/tankgun_100mm.mdl",
+	sound = "ace_weapons/multi_sound/100mm_multi.mp3",
+	gunclass = "AL",
+	caliber = 10.0,
+	weight = 2350,
+	year = 1960,
+	rofmod = 1.2,
+	round = {
+		maxlength = 93,
+		propweight = 20
+	},
+	acepoints = 3000
+} )
+
+ACF_defineGun("120mmBAL", {
+	name = "120mm Breech Autoloader",
+	desc = "PLACEHOLDER. 120mm Breech Autoloader. Gives up some of the burst rate of fire of manually loaded guns for consistency and not having the cost of training loaders.",
+	model = "models/tankgun_new/tankgun_120mm.mdl",
+	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
+	gunclass = "AL",
+	caliber = 12.0,
+	weight = 4700,
+	year = 1970,
+	rofmod = 1.2,
+	round = {
+		maxlength = 115,
+		propweight = 30
+	},
+	acepoints = 3700
+} )
+
+ACF_defineGun("140mmBAL", {
+	name = "140mm Breech Autoloader",
+	desc = "PLACEHOLDER. 140mm Breech Autoloader, Beefy 140mm autoloading cannon for dealing with heavily armored MBTs. With a consistent ROF due to the autoloader.",
+	model = "models/tankgun_new/tankgun_140mm.mdl",
+	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
+	gunclass = "AL",
+	caliber = 14.0,
+	weight = 6300,
+	year = 1995,
+	rofmod = 1.2,
+	round = {
+		maxlength = 140,
+		propweight = 60
+	},
+	acepoints = 4100
+} )
+
+ACF_defineGun("170mmBAL", {
+	name = "170mm Breech Autoloader",
+	desc = "PLACEHOLDER. 170mm Breech Autoloader. Absolutely massive breechloading cannon perfect for tank destroyers looking to rip apart armor without spaghettifying your loader's arms.",
+	model = "models/tankgun_new/tankgun_170mm.mdl",
+	sound = "ace_weapons/multi_sound/120mm_multi.mp3",
+	gunclass = "AL",
+	caliber = 17.0,
+	weight = 15350,
+	year = 1990,
+	rofmod = 1.2,
+	round = {
+		maxlength = 180,
+		propweight = 34
+	},
+	acepoints = 5200
+} )

--- a/lua/acf/shared/guns/cannon.lua
+++ b/lua/acf/shared/guns/cannon.lua
@@ -56,7 +56,7 @@ ACF_defineGun("75mmC", {
 	caliber = 7.5,
 	weight = 660,
 	year = 1942,
-	maxrof = 17, -- maximum rounds per minute
+	maxrof = 25, -- maximum rounds per minute
 	round = {
 		maxlength = 78,
 		propweight = 3.8
@@ -73,7 +73,7 @@ ACF_defineGun("85mmC", {
 	caliber = 8.5,
 	weight = 1030,
 	year = 1944,
-	maxrof = 15.5, -- maximum rounds per minute
+	maxrof = 23.5, -- maximum rounds per minute
 	round = {
 		maxlength = 85.5,
 		propweight = 6.65
@@ -90,7 +90,7 @@ ACF_defineGun("100mmC", {
 	caliber = 10.0,
 	weight = 1400,
 	year = 1944,
-	maxrof = 14, -- maximum rounds per minute
+	maxrof = 22, -- maximum rounds per minute
 	round = {
 		maxlength = 93,
 		propweight = 9.5
@@ -107,7 +107,7 @@ ACF_defineGun("120mmC", {
 	caliber = 12.0,
 	weight = 2100,
 	year = 1955,
-	maxrof = 10, -- maximum rounds per minute
+	maxrof = 20, -- maximum rounds per minute
 	round = {
 		maxlength = 110,
 		propweight = 18
@@ -124,7 +124,7 @@ ACF_defineGun("140mmC", {
 	caliber = 14.0,
 	weight = 3900,
 	year = 1990,
-	maxrof = 8, -- maximum rounds per minute
+	maxrof = 12, -- maximum rounds per minute
 	round = {
 		maxlength = 127,
 		propweight = 28
@@ -141,7 +141,7 @@ ACF_defineGun("170mmC", {
 	caliber = 17.0,
 	weight = 7800,
 	year = 1990,
-	maxrof = 4, -- maximum rounds per minute
+	maxrof = 6.5, -- maximum rounds per minute
 	round = {
 		maxlength = 154,
 		propweight = 34

--- a/lua/acf/shared/guns/howitzer.lua
+++ b/lua/acf/shared/guns/howitzer.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("HW", {
 	type = "Gun",
-	spread = 0.3,
+	spread = 0.15,
 	name = "Howitzer",
 	desc = ACFTranslation.GunClasses[8],
 	muzzleflash = "C",

--- a/lua/acf/shared/guns/machinegun.lua
+++ b/lua/acf/shared/guns/machinegun.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("MG", {
 	type = "Gun",
-	spread = 0.2,
+	spread = 0.13,
 	name = "Machinegun",
 	desc = ACFTranslation.GunClasses[9],
 	muzzleflash = "MG",

--- a/lua/acf/shared/guns/machinegun.lua
+++ b/lua/acf/shared/guns/machinegun.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("MG", {
 	type = "Gun",
-	spread = 0.16,
+	spread = 0.2,
 	name = "Machinegun",
 	desc = ACFTranslation.GunClasses[9],
 	muzzleflash = "MG",

--- a/lua/acf/shared/guns/mortar.lua
+++ b/lua/acf/shared/guns/mortar.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("MO", {
 	type = "Gun",
-	spread = 0.6,
+	spread = 0.5,
 	name = "Mortar",
 	desc = ACFTranslation.GunClasses[10],
 	muzzleflash = "MO",

--- a/lua/acf/shared/guns/rotaryautocannon.lua
+++ b/lua/acf/shared/guns/rotaryautocannon.lua
@@ -2,7 +2,7 @@ do
 	--define the class
 	ACF_defineGunClass("RAC", {
 		type = "Gun",
-		spread = 0.25,
+		spread = 0.2,
 		name = "Rotary Autocannon",
 		desc = ACFTranslation.GunClasses[11],
 		muzzleflash = "RAC",

--- a/lua/acf/shared/guns/semiauto.lua
+++ b/lua/acf/shared/guns/semiauto.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("SA", {
 	type = "Gun",
-	spread = 0.11,
+	spread = 0.15,
 	name = "Semiautomatic Cannon",
 	desc = ACFTranslation.GunClasses[12],
 	muzzleflash = "AC",

--- a/lua/acf/shared/guns/shortcannon.lua
+++ b/lua/acf/shared/guns/shortcannon.lua
@@ -105,7 +105,7 @@ ACF_defineGun("120mmSC", {
 	gunclass = "SC",
 	caliber = 12.0,
 	weight = 1400,
-	maxrof = 17, -- maximum rounds per minute
+	maxrof = 23, -- maximum rounds per minute
 	year = 1944,
 	round = {
 		maxlength = 110,

--- a/lua/acf/shared/guns/smokelauncher.lua
+++ b/lua/acf/shared/guns/smokelauncher.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("SL", {
 	type		= "Gun",
-	spread		= 0.15,
+	spread		= 0.2,
 	name		= "Smoke Launcher",
 	desc		= ACFTranslation.GunClasses[14],
 	muzzleflash = "MO",

--- a/lua/acf/shared/guns/smoothcannon.lua
+++ b/lua/acf/shared/guns/smoothcannon.lua
@@ -1,7 +1,7 @@
 --define the class
 ACF_defineGunClass("SBC", {
 	type = "Gun",
-	spread = 0.095,
+	spread = 0.12,
 	name = "Smooth-Bore Cannon",
 	desc = ACFTranslation.GunClasses[15],
 	muzzleflash = "C",

--- a/lua/acf/shared/guns/smoothcannon.lua
+++ b/lua/acf/shared/guns/smoothcannon.lua
@@ -39,7 +39,7 @@ ACF_defineGun("75mmSBC", {
 	gunclass = "SBC",
 	caliber = 7.5,
 	weight = 900,
-	maxrof = 17, -- maximum rounds per minute
+	maxrof = 25, -- maximum rounds per minute
 	year = 1960,
 	round = {
 		maxlength = 78,
@@ -56,7 +56,7 @@ ACF_defineGun("100mmSBC", {
 	gunclass = "SBC",
 	caliber = 10.0,
 	weight = 1700,
-	maxrof = 14, -- maximum rounds per minute
+	maxrof = 22, -- maximum rounds per minute
 	year = 1960,
 	round = {
 		maxlength = 93,
@@ -73,7 +73,7 @@ ACF_defineGun("120mmSBC", {
 	gunclass = "SBC",
 	caliber = 12.0,
 	weight = 3200,
-	maxrof = 10, -- maximum rounds per minute
+	maxrof = 20, -- maximum rounds per minute
 	year = 1970,
 	round = {
 		maxlength = 115,
@@ -90,7 +90,7 @@ ACF_defineGun("140mmSBC", {
 	gunclass = "SBC",
 	caliber = 14.0,
 	weight = 4300,
-	maxrof = 8, -- maximum rounds per minute
+	maxrof = 12, -- maximum rounds per minute
 	year = 1995,
 	round = {
 		maxlength = 140,
@@ -108,7 +108,7 @@ ACF_defineGun("170mmSBC", {
 	gunclass = "SBC",
 	caliber = 17.0,
 	weight = 12350,
-	maxrof = 4, -- maximum rounds per minute
+	maxrof = 6.5, -- maximum rounds per minute
 	year = 1990,
 	round = {
 		maxlength = 180,

--- a/lua/acf/shared/missiles/missile_arty.lua
+++ b/lua/acf/shared/missiles/missile_arty.lua
@@ -64,7 +64,7 @@ ACF_defineGun("Type 63 RA", {							-- id
 		boostertime			= 0.5,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -142,7 +142,7 @@ ACF_defineGun("SAKR-10 RA", {							-- id
 		boostertime			= 1.5,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -218,7 +218,7 @@ ACF_defineGun("RW61 RA", {								-- id
 		boostertime			= 1.5,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.004,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -291,7 +291,7 @@ ACF_defineGun("M26 RA", {							-- id
 		boostertime			= 0.5,							-- Time in seconds for booster runtime
 		boostdelay			= 0.2,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
@@ -359,7 +359,7 @@ ACF_defineGun("SS-40 RA", {								-- id
 		boostertime			= 5,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -433,7 +433,7 @@ ACF_defineGun("M31 RA", {							-- id
 		boostertime			= 3,							-- Time in seconds for booster runtime
 		boostdelay			= 0.25,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.

--- a/lua/acf/shared/missiles/missile_atgm.lua
+++ b/lua/acf/shared/missiles/missile_atgm.lua
@@ -494,14 +494,14 @@ ACF_defineGun("Spike-LR ASM", {
 		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.003,						-- percent speed loss per second
-		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
+		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= false,
 		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul			= math.sqrt(2.5),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.5,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 7,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 333
+		pointcost			= 400
 	},
 
 	ent				= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_pod.lua
+++ b/lua/acf/shared/missiles/missile_pod.lua
@@ -62,7 +62,7 @@ ACF_defineGun("40mmFFAR", { --id
 		boostertime			= 1.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.003,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -132,7 +132,7 @@ ACF_defineGun("70mmFFAR", { --id
 		boostertime			= 1.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -205,7 +205,7 @@ ACF_defineGun("S8KO", { --id
 		boostertime			= 0.35,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.001,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -276,7 +276,7 @@ ACF_defineGun("Zuni ASR", { --id
 		boostertime			= 1.8,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.0025,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.

--- a/lua/acf/shared/missiles/missile_uar.lua
+++ b/lua/acf/shared/missiles/missile_uar.lua
@@ -62,7 +62,7 @@ ACF_defineGun("SPG-9 ASR", { --id
 		boostertime			= 1.8,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.0015,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -131,7 +131,7 @@ ACF_defineGun("RS82 ASR", { --id
 		boostertime			= 1.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -200,7 +200,7 @@ ACF_defineGun("HVAR ASR", { --id
 		boostertime			= 1.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -268,7 +268,7 @@ ACF_defineGun("S-24 ASR", { --id
 		boostertime			= 1.1,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
-		fusetime			= 20,							--Time in seconds after launch/booster stop before missile scuttles
+		fusetime			= 60,							--Time in seconds after launch/booster stop before missile scuttles
 
 		dragcoef			= 0.004,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.

--- a/lua/acf/shared/rounds/roundclusterhe.lua
+++ b/lua/acf/shared/rounds/roundclusterhe.lua
@@ -81,8 +81,8 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	GUIData.FuseDistance = Data.FuseDistance
-	GUIData.BombletCount = math.Round(math.Clamp(math.Round(Data.FillerMass * 1.5),5,80) * Data.ClusterMult / 100)
-	GUIData.AdjFillerMass = Data.FillerMass / GUIData.BombletCount / 1.5
+	GUIData.BombletCount = math.Round(math.Clamp(math.Round(Data.FillerMass * 2),10,160) * Data.ClusterMult / 100)
+	GUIData.AdjFillerMass = Data.FillerMass / GUIData.BombletCount
 	local AdjProjMass = Data.ProjMass / 2
 	GUIData.BlastRadius = GUIData.AdjFillerMass ^ 0.33 * 8
 	local FragMass = AdjProjMass - GUIData.AdjFillerMass
@@ -159,11 +159,7 @@ do
 		--Make cluster to fail. Allow with rounds on whitelist only.
 		--if not WhiteList[RoundType] then return end
 
-		local Bomblets  = math.Round(math.Clamp(math.Round(bdata.FillerMass * 1.5),5,80) * (bdata.ClusterMult or 100) / 100)	--30 bomblets original
-
-		if bdata.Type == "HEAT" then
-			Bomblets = math.Clamp(Bomblets,3,25)
-		end
+		local Bomblets  = math.Round(math.Clamp(math.Round(bdata.FillerMass * 2),10,160) * (bdata.ClusterMult or 100) / 100)	--30 bomblets original
 
 		local GEnt = bdata.Gun
 
@@ -177,7 +173,7 @@ do
 		GEnt.BulletDataC["Caliber"] 		= math.Clamp(bdata.Caliber / Bomblets * 30, 0.05, bdata.Caliber ) --Controls visual size, does nothing else
 		GEnt.BulletDataC["Crate"]			= bdata.Crate
 		GEnt.BulletDataC["DragCoef"]		= bdata.DragCoef / Bomblets / 2
-		GEnt.BulletDataC["FillerMass"]	= bdata.FillerMass / Bomblets / 1.5 	--nan armor ocurrs when this value is > 1
+		GEnt.BulletDataC["FillerMass"]	= bdata.FillerMass / Bomblets 	--nan armor ocurrs when this value is > 1
 
 		--print(GEnt.BulletDataC["FillerMass"])
 		--print(Bomblets)
@@ -192,7 +188,7 @@ do
 		GEnt.BulletDataC["Id"]			= bdata.Id
 		GEnt.BulletDataC["KETransfert"]	= bdata.KETransfert
 		GEnt.BulletDataC["LimitVel"]		= 700
-		GEnt.BulletDataC["MuzzleVel"]		= 150
+		GEnt.BulletDataC["MuzzleVel"]		= 75
 		--GEnt.BulletDataC["MuzzleVel"]		= bdata.MuzzleVel * 20
 		GEnt.BulletDataC["Owner"]			= bdata.Owner
 		GEnt.BulletDataC["PenArea"]		= bdata.PenArea
@@ -203,34 +199,11 @@ do
 		GEnt.BulletDataC["PropMass"]		= bdata.PropMass
 		GEnt.BulletDataC["Ricochet"]		= 90--bdata.Ricochet
 
-		GEnt.BulletDataC.FuseLength = 1.0 --Cluster munitions shouldn't travel that far
-		--print(bdata.Ricochet)
-
 		GEnt.BulletDataC["RoundVolume"]	= bdata.RoundVolume
 		GEnt.BulletDataC["ShovePower"]	= bdata.ShovePower
 		GEnt.BulletDataC["Tracer"]		= 0
 
-
-		--GEnt.BulletDataC["Type"]		= bdata.Type
 		GEnt.BulletDataC["Type"]		= "HE"
-
-		if GEnt.BulletDataC.Type == "HEAT" then
-
-			GEnt.BulletDataC["SlugMass"] 		= bdata.SlugMass / (Bomblets / 6)
-			GEnt.BulletDataC["SlugCaliber"] 	= bdata.SlugCaliber / (Bomblets / 6)
-			GEnt.BulletDataC["SlugDragCoef"] 	= bdata.SlugDragCoef / (Bomblets / 6)
-			GEnt.BulletDataC["SlugMV"] 		= bdata.SlugMV / (Bomblets / 6)
-			GEnt.BulletDataC["SlugPenArea"] 	= bdata.SlugPenArea / (Bomblets / 6)
-			GEnt.BulletDataC["SlugRicochet"] 	= bdata.SlugRicochet
-			GEnt.BulletDataC["ConeVol"] 		= bdata.SlugMass * 1000 / 7.9 / (Bomblets / 6)
-			GEnt.BulletDataC["CasingMass"] 	= GEnt.BulletDataC.ProjMass + GEnt.BulletDataC.FillerMass + (GEnt.BulletDataC.ConeVol * 1000 / 7.9)
-			GEnt.BulletDataC["BoomFillerMass"] = GEnt.BulletDataC.FillerMass / 1.5
-
-			--local SlugEnergy = ACF_Kinetic( missile.BulletDataC.MuzzleVel * 39.37 + missile.BulletDataC.SlugMV * 39.37 , missile.BulletDataC.SlugMass, 999999 )
-			--local  MaxPen = (SlugEnergy.Penetration/missile.BulletDataC.SlugPenArea) * ACF.KEtoRHA
-			--print(MaxPen)
-
-		end
 
 		GEnt.FakeCrate = GEnt.FakeCrate or ents.Create("acf_fakecrate2")
 
@@ -256,9 +229,9 @@ do
 					--Spread = ((GEnt:GetUp() * (2 * math.random() - 1)) + (GEnt:GetRight() * (2 * math.random() - 1))) * (I - 1) / 45
 					local Spread = VectorRand()
 					--Spread = Spread
-					Spread = Vector(Spread.x * math.abs(Spread.x), Spread.y * math.abs(Spread.y), Spread.z * math.abs(Spread.z))
+					--Spread = Vector(Spread.x * math.abs(Spread.x), Spread.y * math.abs(Spread.y), Spread.z * math.abs(Spread.z))
 					--GEnt.BulletDataC["Flight"] = (MuzzleVec + ( Spread * math.min((GEnt.BulletDataC.Bomblets/10) * 0.1 , 0.65))):GetNormalized() * GEnt.BulletDataC["MuzzleVel"] * 39.37 * math.Rand(0.5,1.0)
-					GEnt.BulletDataC["Flight"] = (MuzzleVec + ( Spread * 0.4)):GetNormalized() * GEnt.BulletDataC["MuzzleVel"] * 39.37 * math.Rand(0.5,1.0) --Fixed scatter pattern since we're using the detonate offset to control spread.
+					GEnt.BulletDataC["Flight"] = (MuzzleVec + ( Spread * 0.6)):GetNormalized() * GEnt.BulletDataC["MuzzleVel"] * 39.37 * math.Rand(0.5,1.0) --Fixed scatter pattern since we're using the detonate offset to control spread.
 
 					local MuzzlePos = bullet.Pos
 					GEnt.BulletDataC.Pos = MuzzlePos - MuzzleVec

--- a/lua/acf/shared/rounds/roundclusterheat.lua
+++ b/lua/acf/shared/rounds/roundclusterheat.lua
@@ -131,8 +131,8 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	GUIData.FuseDistance = Data.FuseDistance
-	GUIData.BombletCount = math.Round(math.Clamp(math.Round(Data.FillerMass * 1.5),5,80) * Data.ClusterMult / 100)
-	GUIData.AdjFillerMass = Data.FillerMass / GUIData.BombletCount / 1.5
+	GUIData.BombletCount = math.Round(math.Clamp(math.Round(Data.FillerMass * 3),10,160) * Data.ClusterMult / 100)
+	GUIData.AdjFillerMass = Data.FillerMass / GUIData.BombletCount / 2
 	local AdjProjMass = Data.ProjMass / 2
 	GUIData.BlastRadius = GUIData.AdjFillerMass ^ 0.33 * 8
 	local FragMass = AdjProjMass - GUIData.AdjFillerMass
@@ -212,7 +212,7 @@ do
 		--Make cluster to fail. Allow with rounds on whitelist only.
 		--if not WhiteList[RoundType] then return end
 
-		local Bomblets  = math.Round(math.Clamp(math.Round(bdata.FillerMass * 1.5),5,80) * (bdata.ClusterMult or 100) / 100)	--30 bomblets original
+		local Bomblets  = math.Round(math.Clamp(math.Round(bdata.FillerMass * 3),10,160) * (bdata.ClusterMult or 100) / 100)	--30 bomblets original
 
 		local GEnt = bdata.Gun
 
@@ -223,16 +223,16 @@ do
 		GEnt.BulletDataC["Accel"]			= Vector(0,0,-600)
 		GEnt.BulletDataC["BoomPower"]		= bdata.BoomPower
 
-		GEnt.BulletDataC["Caliber"] 		= math.Clamp(bdata.Caliber / Bomblets * 10 , 0.05, bdata.Caliber ) --Controls visual size, does nothing else
+		GEnt.BulletDataC["Caliber"] 		= math.Clamp(bdata.Caliber / Bomblets * 5 , 0.05, bdata.Caliber ) --Controls visual size, does nothing else
 		GEnt.BulletDataC["Crate"]			= bdata.Crate
 		GEnt.BulletDataC["DragCoef"]		= bdata.DragCoef / Bomblets / 4
-		GEnt.BulletDataC["FillerMass"]	= bdata.FillerMass / Bomblets 	--nan armor ocurrs when this value is > 1
+		GEnt.BulletDataC["FillerMass"]	= bdata.FillerMass / Bomblets / 2 	--nan armor ocurrs when this value is > 1
 
 		--print(GEnt.BulletDataC["FillerMass"])
 		--print(Bomblets)
 		--print(missile.BulletDataC["FillerMass"])
 
-		GEnt.BulletDataC["Filter"]		= GEnt
+		GEnt.BulletDataC["Filter"]		= {}
 		GEnt.BulletDataC["Flight"]		= bdata.Flight
 		GEnt.BulletDataC["FlightTime"]	= 0
 		GEnt.BulletDataC["FrArea"]		= bdata.FrArea
@@ -241,7 +241,7 @@ do
 		GEnt.BulletDataC["Id"]			= bdata.Id
 		GEnt.BulletDataC["KETransfert"]	= bdata.KETransfert
 		GEnt.BulletDataC["LimitVel"]		= 700
-		GEnt.BulletDataC["MuzzleVel"]		= 50
+		GEnt.BulletDataC["MuzzleVel"]		= 100
 		--GEnt.BulletDataC["MuzzleVel"]		= bdata.MuzzleVel * 20
 		GEnt.BulletDataC["Owner"]			= bdata.Owner
 		GEnt.BulletDataC["PenArea"]		= bdata.PenArea
@@ -252,30 +252,29 @@ do
 		GEnt.BulletDataC["PropMass"]		= bdata.PropMass
 		GEnt.BulletDataC["Ricochet"]		= 90--bdata.Ricochet
 
-		GEnt.BulletDataC.FuseLength = 5.0 --Cluster munitions shouldn't travel that far
 		--print(bdata.Ricochet)
 
 		GEnt.BulletDataC["RoundVolume"]	= bdata.RoundVolume
 		GEnt.BulletDataC["ShovePower"]	= bdata.ShovePower
-		GEnt.BulletDataC["Tracer"]		= 1
+		GEnt.BulletDataC["Tracer"]		= 0
 
 
 		--GEnt.BulletDataC["Type"]		= bdata.Type
 		GEnt.BulletDataC["Type"]		= "HEAT"
 
-			GEnt.BulletDataC["SlugMass"] 		= bdata.SlugMass / (Bomblets / 6)
-			GEnt.BulletDataC["SlugCaliber"] 	= bdata.SlugCaliber / (Bomblets / 6)
-			GEnt.BulletDataC["SlugDragCoef"] 	= bdata.SlugDragCoef / (Bomblets / 6)
-			GEnt.BulletDataC["SlugMV"] 		= bdata.SlugMV / (Bomblets / 6)
-			GEnt.BulletDataC["SlugPenArea"] 	= bdata.SlugPenArea / (Bomblets / 6)
-			GEnt.BulletDataC["SlugRicochet"] 	= bdata.SlugRicochet
-			GEnt.BulletDataC["ConeVol"] 		= bdata.SlugMass * 1000 / 7.9 / (Bomblets / 6)
-			GEnt.BulletDataC["CasingMass"] 	= GEnt.BulletDataC.ProjMass + GEnt.BulletDataC.FillerMass + (GEnt.BulletDataC.ConeVol * 1000 / 7.9)
-			GEnt.BulletDataC["BoomFillerMass"] = GEnt.BulletDataC.FillerMass / 1
+		GEnt.BulletDataC["SlugMass"] 		= bdata.SlugMass / Bomblets
+		GEnt.BulletDataC["SlugCaliber"] 	= bdata.SlugCaliber / Bomblets
+		GEnt.BulletDataC["SlugDragCoef"] 	= bdata.SlugDragCoef / Bomblets
+		GEnt.BulletDataC["SlugMV"] 			= bdata.SlugMV * 3
+		GEnt.BulletDataC["SlugPenArea"] 	= bdata.SlugPenArea
+		GEnt.BulletDataC["SlugRicochet"] 	= bdata.SlugRicochet
+		GEnt.BulletDataC["ConeVol"] 		= bdata.SlugMass * 1000 / 7.9 / Bomblets
+		GEnt.BulletDataC["CasingMass"] 	= GEnt.BulletDataC.ProjMass + GEnt.BulletDataC.FillerMass + (GEnt.BulletDataC.ConeVol * 1000 / 7.9)
+		GEnt.BulletDataC["BoomFillerMass"] = GEnt.BulletDataC.FillerMass
 
-			--local SlugEnergy = ACF_Kinetic( missile.BulletDataC.MuzzleVel * 39.37 + missile.BulletDataC.SlugMV * 39.37 , missile.BulletDataC.SlugMass, 999999 )
-			--local  MaxPen = (SlugEnergy.Penetration/missile.BulletDataC.SlugPenArea) * ACF.KEtoRHA
-			--print(MaxPen)
+		--local SlugEnergy = ACF_Kinetic( missile.BulletDataC.MuzzleVel * 39.37 + missile.BulletDataC.SlugMV * 39.37 , missile.BulletDataC.SlugMass, 999999 )
+		--local  MaxPen = (SlugEnergy.Penetration/missile.BulletDataC.SlugPenArea) * ACF.KEtoRHA
+		--print(MaxPen)
 
 		GEnt.FakeCrate = GEnt.FakeCrate or ents.Create("acf_fakecrate2")
 
@@ -296,12 +295,11 @@ do
 
 		for I = 1, CCount do
 			--print("Bobm")
-			timer.Simple(0.01 * I, function()
+			timer.Simple(0.012 * I, function()
 				if IsValid(GEnt) then
 					--Spread = ((GEnt:GetUp() * (2 * math.random() - 1)) + (GEnt:GetRight() * (2 * math.random() - 1))) * (I - 1) / 45
 					local Spread = VectorRand()
-					--Spread = Spread
-					Spread = Vector(Spread.x * math.abs(Spread.x), Spread.y * math.abs(Spread.y), Spread.z * math.abs(Spread.z))
+					--Spread = Vector(Spread.x * math.abs(Spread.x), Spread.y * math.abs(Spread.y), Spread.z * math.abs(Spread.z))
 					--GEnt.BulletDataC["Flight"] = (MuzzleVec + ( Spread * math.min((GEnt.BulletDataC.Bomblets/10) * 0.1 , 0.65))):GetNormalized() * GEnt.BulletDataC["MuzzleVel"] * 39.37 * math.Rand(0.5,1.0)
 					GEnt.BulletDataC["Flight"] = (MuzzleVec + ( Spread * 0.6)):GetNormalized() * GEnt.BulletDataC["MuzzleVel"] * 39.37 * math.Rand(0.5,1.0) --Fixed scatter pattern since we're using the detonate offset to control spread.
 

--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -43,9 +43,9 @@ function ENT:Initialize()
 	self.Sound = "npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav"
 	self.SoundPitch = 100
 
-	if not IsValid(self:CPPIGetOwner()) then
-		self:CPPISetOwner(game.GetWorld())
-	end
+	--if not IsValid(self:CPPIGetOwner()) then
+	--	self:CPPISetOwner(game.GetWorld())
+	--end
 
 	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -43,9 +43,9 @@ function ENT:Initialize()
 	self.Sound = "npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav"
 	self.SoundPitch = 100
 
-	if not IsValid(self:CPPIGetOwner()) then
-		self:CPPISetOwner(game.GetWorld())
-	end
+	--if not IsValid(self:CPPIGetOwner()) then
+	--	self:CPPISetOwner(game.GetWorld())
+	--end
 
 	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true

--- a/lua/entities/ace_crewseat_loader/init.lua
+++ b/lua/entities/ace_crewseat_loader/init.lua
@@ -45,14 +45,14 @@ function ENT:Initialize()
 	self.Sound = "npc/combine_soldier/die" .. tostring(random(1, 3)) .. ".wav"
 	self.SoundPitch = 100
 
-	if not IsValid(self:CPPIGetOwner()) then
-		self:CPPISetOwner(game.GetWorld())
-	end
+	--if not IsValid(self:CPPIGetOwner()) then
+	--	self:CPPISetOwner(game.GetWorld())
+	--end
 
 	self.NextLegalCheck	= ACF.CurTime + random(ACF.Legal.Min, ACF.Legal.Max) -- give any spawning issues time to iron themselves out
 	self.Legal = true
 	self.LegalIssues = ""
-	self.ACEPoints = 200
+	self.ACEPoints = 600
 
 	self.SpecialHealth	= false  --If true needs a special ACF_Activate function
 	self.SpecialDamage	= true  --If true needs a special ACF_OnDamage function

--- a/lua/entities/ace_missile/cl_init.lua
+++ b/lua/entities/ace_missile/cl_init.lua
@@ -5,7 +5,8 @@ include("shared.lua")
 
 function ENT:Initialize()
 
-	self.LightUpdate = CurTime() + 0.05
+	--self.LightUpdate = CurTime() + 0.05
+	self.LightSize = self:BoundingRadius() * 400
 
 end
 
@@ -13,19 +14,21 @@ function ENT:Draw()
 
 	self:DrawModel()
 
-	if CurTime() > self.LightUpdate then
-		self.LightUpdate = CurTime() + 0.05
+	local MotorActive = self:GetNW2Bool( "MissileActive" );
+	--if CurTime() > self.LightUpdate then
+	--	self.LightUpdate = CurTime() + 0.05
+	if MotorActive then
 		self:RenderMotorLight()
 	end
+	--end
 end
 
 function ENT:RenderMotorLight()
 
 	local idx = self:EntIndex()
-	local lightSize = self:GetNWFloat("LightSize") * 175
 	local colour = Color(255, 128, 48)
 	local pos = self:GetPos() - self:GetForward() * 64
 
-	ACF_RenderLight(idx, lightSize, colour, pos, 1)
-
+	ACF_RenderLight(idx, self.LightSize, colour, pos, 1)
+	--ACF_RenderLight(self:EntIndex(), 5000, Color(255, 196, 0), self:GetPos(), 0.1)
 end

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -464,17 +464,20 @@ function ENT:Think()
 		if self.CanDetonate == true then
 			local tr = util.QuickTrace(Pos + self.Flight * DeltaTime * -30, self.Flight * DeltaTime * 79, {self})
 
-			if tr.Hit then
+			if tr.Hit and (not tr.HitSky) and util.IsInWorld( tr.HitPos ) then
+					print("Impact")
 
-				debugoverlay.Cross(tr.StartPos, 10, 10, Color(255, 0, 0))
-				debugoverlay.Cross(tr.HitPos, 10, 10, Color(0, 255, 0))
+					debugoverlay.Cross(tr.StartPos, 10, 10, Color(255, 0, 0))
+					debugoverlay.Cross(tr.HitPos, 10, 10, Color(0, 255, 0))
 
-				self:SetPos(tr.HitPos + self:GetForward() * -30)
-				self:Detonate()
-				return
+					self:SetPos(tr.HitPos + self:GetForward() * -30)
+					self:Detonate()
+					return
+
 			end
 
 			if self.Fuse:GetDetonate(self, self.Guidance) or CT > self.ActivationTime + self.Lifetime then
+				print("Fused")
 				self:Detonate()
 				return
 			end
@@ -494,6 +497,7 @@ function ENT:Think()
 
 		self.Flight = self.Flight - (self.Flight:GetNormalized() * self.Drag * DMul * self.Flight:LengthSqr()) * DeltaTime --Simple drag multiplier
 
+		--[[
 		--Delete the missile if it was fired outside of the map
 		if not self:IsInWorld() then
 
@@ -506,6 +510,7 @@ function ENT:Think()
 			self:Remove()
 			return
 		end
+		]]--
 
 	end
 
@@ -711,7 +716,13 @@ function ENT:CanTool( _, _, _, _, _ ) --ply, trace, mode, tool, button
 end
 
 function ENT:CanProperty( _, _)
---	print("false")
+
+	if self.JustLaunched == true then
+		return true
+	else
+		return false
+	end
+
 	return false
 
 end

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -94,6 +94,15 @@ function ENT:Initialize()
 
 	self:SetNW2Bool("MissileActive", false)
 
+
+	--[[
+	self.LOSTraceData = {
+		mins = vector_origin,
+		maxs = vector_origin,
+		filter = {self},
+	}
+	--
+	]]
 end
 
 
@@ -464,8 +473,13 @@ function ENT:Think()
 		if self.CanDetonate == true then
 			local tr = util.QuickTrace(Pos + self.Flight * DeltaTime * -30, self.Flight * DeltaTime * 79, {self})
 
+			--[[
+			self.LOSTraceData.start = Pos + self.Flight * DeltaTime * -30
+			self.LOSTraceData.endpos = self.Flight * DeltaTime * 79
+			local tr = util.TraceHull(self.LOSTraceData)
+			]]--
+
 			if tr.Hit and (not tr.HitSky) and util.IsInWorld( tr.HitPos ) then
-					print("Impact")
 
 					debugoverlay.Cross(tr.StartPos, 10, 10, Color(255, 0, 0))
 					debugoverlay.Cross(tr.HitPos, 10, 10, Color(0, 255, 0))
@@ -477,7 +491,6 @@ function ENT:Think()
 			end
 
 			if self.Fuse:GetDetonate(self, self.Guidance) or CT > self.ActivationTime + self.Lifetime then
-				print("Fused")
 				self:Detonate()
 				return
 			end

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -92,6 +92,8 @@ function ENT:Initialize()
 	self.NextJamCheck		= 0
 	self.ResetJamDelay		= 1 --Periodically resets jamming strength to zero for the jammer to apply the highest noise available. This means the jamming won't always remain at full strength without a lot of networking.
 
+	self:SetNW2Bool("MissileActive", false)
+
 end
 
 
@@ -168,8 +170,6 @@ function ENT:Think()
 		end
 
 	end
-
-
 
 	--[[
 	local Sparks = EffectData()
@@ -281,11 +281,14 @@ function ENT:Think()
 					if self.UpdateFX then
 						self:StopParticles()
 						if TMul > 0 then
+							self:SetNW2Bool("MissileActive", true)
 							local effect = self.BoostEffect or ACF_GetGunValue(self.BulletData, "effectbooster")
 							if effect then
 								ParticleEffectAttach( effect, PATTACH_POINT_FOLLOW, self, self:LookupAttachment("exhaust") or 0 )
 								self.UpdateFX = false
 							end
+						else
+							self:SetNW2Bool("MissileActive", false)
 						end
 					end
 
@@ -328,11 +331,14 @@ function ENT:Think()
 					if self.UpdateFX then
 						self:StopParticles()
 						if TMul > 0 then
+							self:SetNW2Bool("MissileActive", true)
 							local effect = self.BoostEffect or ACF_GetGunValue(self.BulletData, "effect")
 							if effect then
 								ParticleEffectAttach( effect, PATTACH_POINT_FOLLOW, self, self:LookupAttachment("exhaust") or 0 )
 								self.UpdateFX = false
 							end
+						else
+							self:SetNW2Bool("MissileActive", false)
 						end
 					end
 

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -116,7 +116,7 @@ function ENT:ACF_OnDamage( Entity, Energy, FrArea, Angle, Inflictor, _, Type )	-
 			self.Inflictor = Inflictor
 		end
 
-		ACF_ScaledExplosion( self )
+		ACF_ScaledExplosion( self , true )
 
 		return HitRes
 	end
@@ -134,7 +134,7 @@ function ENT:ACF_OnDamage( Entity, Energy, FrArea, Angle, Inflictor, _, Type )	-
 
 		timer.Simple(math.Rand(0.1, 1), function()
 			if IsValid(self) then
-				ACF_ScaledExplosion( self )
+				ACF_ScaledExplosion( self , true )
 			end
 		end )
 

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -8,7 +8,7 @@ local GunClasses = ACF.Classes.GunClass
 local GunTable = ACF.Weapons.Guns
 
 --The distances these ents would have if its caliber was 10mm. Incremented by caliber size.
-local CrewLinkDistBase = 100
+local CrewLinkDistBase = 200
 local AmmoLinkDistBase = 512
 
 function ENT:Initialize()

--- a/lua/entities/gmod_wire_expression2/core/custom/acf.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acf.lua
@@ -46,6 +46,50 @@ local function isFuel(ent)
 	return ent:GetClass() == "acf_fueltank"
 end
 
+--Ripped from Armor Property Tool
+-- Calculates mass, armor, and health given prop area and desired ductility and thickness.
+local function CalcArmor( Area, Ductility, Thickness, Mat )
+
+	Mat = Mat or "RHA"
+
+	local MatData	= ACE_GetMaterialData( Mat )
+	local MassMod	= MatData.massMod
+
+	local mass		= Area * ( 1 + Ductility ) ^ 0.5 * Thickness * 0.00078 * MassMod
+	local armor		= ACF_CalcArmor( Area, Ductility, mass / MassMod )
+	local health		= ( Area + Area * Ductility ) / ACF.Threshold
+
+	return mass, armor, health
+
+end
+
+local function E2SetACEArmor(ent, armor, ductility, material)
+
+	ent.ACF = ent.ACF or {}
+
+	local duct = math.Clamp( ductility or (ent.ACF.Ductility * 100) or 80, -80, 80 )
+	local thickness = math.Clamp( armor or ent.ACF.Armour or 1, 0.1, 50000 )
+	local mat  = material or ent.ACF.Material or "RHA"
+
+	local mass		= CalcArmor( ent.ACF.Area, duct / 100, thickness , mat)
+
+	local phys = ent:GetPhysicsObject()
+	if IsValid( phys ) then phys:SetMass( mass ) end
+	duplicator.StoreEntityModifier( ent, "mass", { Mass = mass } )
+
+	ent.ACF.Ductility = duct / 100
+	duplicator.StoreEntityModifier( ent, "acfsettings", { Ductility = duct } )
+
+	local con = ent:GetContraption()
+	if con then ACE_RemPts(con, ent) end --Stupid roundabout fix. But only executed when the mat is changed. Hey if it works.
+
+	ent.ACF.Material = mat
+	duplicator.StoreEntityModifier( ent, "acfsettings", { Material = mat } )
+
+	if con then ACE_AddPts(con, ent) end
+
+end
+
 local radarTypes = {
 	acf_missileradar = true,
 	ace_irst = true,
@@ -1360,6 +1404,31 @@ do
 
 		return ret
 	end
+
+	__e2setcost(50)
+
+	-- Sets the ACF armor, ductility, and material of an entity
+	[nodiscard]
+	e2function void entity:aceSetArmorProperties(number thickness, number ductility, string material)
+		local ret = E2Lib.newE2Table()
+		
+		if not validPhysics(this) then return self:throw("Entity is not valid", ret) end
+		if restrictInfo(self.player, this) then return end
+
+		if not this.ACF then
+			local check = ACF_Check(this)
+
+			if not check then return end
+		end
+
+		local matData = ACE.ArmorTypes[material]
+		if not matData then return end
+
+		E2SetACEArmor(this, thickness, ductility, material)
+
+		return
+	end
+
 end
 
 -- Fuel functions

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_acf.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_acf.lua
@@ -115,6 +115,7 @@ E2Helper.Descriptions["acfPropDuctility"] = "Returns the ductility of an entity.
 E2Helper.Descriptions["acfEffectiveArmor"] = "Returns the effective armor of a given nominal armor value and angle, or from a trace hitting an entity."
 E2Helper.Descriptions["acfPropMaterial"] = "Returns the material of an entity."
 E2Helper.Descriptions["acfPropArmorData"] = "Returns a table with armor data of the prop. Keys:\nCurve = [N]\nEffectiveness = [N]\nHEATEffectiveness = [N]\nMaterial = [S]"
+E2Helper.Descriptions["aceSetArmorProperties"] = "Sets the armor properties of an entity. Keys:\nThickness = [N]\n Ductility = [N] from -80 to 80\nMaterial = [S] in shorthand"
 
 --fuel
 E2Helper.Descriptions["acfFuel"] = "Returns the remaining liters of fuel or kilowatt hours in an ACF fuel tank, or available to an engine."

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -531,14 +531,14 @@ do
 		return true,
 		{
 			entity,
-			sanitize(energy),
+			sanitize(energy or {}),
 			surface,
 			angle,
 			inflictor,
 			bone,
 			gun,
 			type,
-			hitRes,
+			sanitize(hitRes or {}),
 			sanitize(dmgInfo)
 		}
 	end)

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -509,6 +509,7 @@ do
 	end
 
 	--- This gets called every time an entity takes damage with ACF.
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnDamage
 	-- @class hook
 	-- @param Entity entity The entity that took damage
@@ -993,6 +994,7 @@ do
 
 	--- This gets called everytime a bullet is fired.
 	--- The bullet may be destroyed at the same time if it hits something very close.
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnBulletCreation
 	-- @class hook
 	-- @param number bulletIndex The index of the bullet fired
@@ -1009,6 +1011,7 @@ do
 	end)
 
 	--- This gets called everytime a bullet hit something (and is destroyed).
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnBulletHit
 	-- @class hook
 	-- @param number bulletIndex The index of the bullet that hit
@@ -1027,6 +1030,7 @@ do
 	end)
 
 	--- This gets called everytime a bullet ricochets off something.
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnBulletRicochet
 	-- @class hook
 	-- @param number bulletIndex The index of the bullet that ricocheted
@@ -1045,6 +1049,7 @@ do
 	end)
 
 	--- This gets called everytime a bullet penetrates something.
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnBulletPenetrated
 	-- @class hook
 	-- @param number bulletIndex The index of the bullet that penetrated
@@ -1063,6 +1068,7 @@ do
 	end)
 
 	--- This gets called everytime a bullet is removed for any reason.
+	--- Needs acf.trackBullets privilege to work.
 	-- @name ACFOnBulletRemoved
 	-- @class hook
 	-- @param number bulletIndex The index of the bullet that was removed

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -505,6 +505,43 @@ do
 			Material = mat
 		}
 	end
+
+	--- This gets called every time an entity takes damage with ACF.
+	-- @name ACFOnDamage
+	-- @class hook
+	-- @param Entity entity The entity that took damage
+	-- @param table energy The energy of the projectile that hit the entity
+	-- @param number surface The surface area of the projectile that hit the entity
+	-- @param number angle The angle of the projectile that hit the entity
+	-- @param Entity inflictor The entity that caused the damage
+	-- @param number bone The bone that was hit
+	-- @param Entity gun The gun that fired the projectile
+	-- @param string type The type of the projectile that hit the entity
+	-- @param table hitRes The hit resolution table
+	-- @param table dmgInfo The damage info table, containing health and armor changes, if available
+	-- @server
+	SF.hookAdd("ACFOnDamage", nil, function(_, entity, energy, surface, angle, inflictor, bone, gun, type, hitRes, oldACFTbl)
+		local dmgInfo = {}
+		if oldACFTbl and entity.ACF then
+			dmgInfo = {
+				health = (entity.ACF.Health or 0) - (oldACFTbl.Health or 0),
+				armour = (entity.ACF.Armour or 0) - (oldACFTbl.Armour or 0),
+			}
+		end
+		return true,
+		{
+			entity,
+			sanitize(energy),
+			surface,
+			angle,
+			inflictor,
+			bone,
+			gun,
+			type,
+			hitRes,
+			sanitize(dmgInfo)
+		}
+	end)
 end
 
 -- Weapon functions

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -949,6 +949,84 @@ do
 
 		return (this.BulletData["DragCoef"] or 0) / ACF.DragDiv
 	end
+
+	--- This gets called everytime a bullet is fired.
+	--- The bullet may be destroyed at the same time if it hits something very close.
+	-- @name ACFOnBulletCreation
+	-- @class hook
+	-- @param number bulletIndex The index of the bullet fired
+	-- @param table bulletData The data of the bullet fired
+	-- @server
+	SF.hookAdd("ACFOnBulletCreation", nil, function(_, bulletIndex, bulletData)
+		return true,
+		{
+			bulletIndex,
+			sanitize(bulletData or {}),
+		}
+	end)
+
+	--- This gets called everytime a bullet hit something (and is destroyed).
+	-- @name ACFOnBulletHit
+	-- @class hook
+	-- @param number bulletIndex The index of the bullet that hit
+	-- @param table bulletData The data of the bullet that hit
+	-- @param table flightRes The flight results of the bullet that hit
+	-- @server
+	SF.hookAdd("ACFOnBulletHit", nil, function(_, bulletIndex, bulletData, flightRes)
+		return true,
+			{
+				bulletIndex,
+			 	sanitize(bulletData or {}),
+				sanitize(flightRes or {})
+			}
+	end)
+
+	--- This gets called everytime a bullet ricochets off something.
+	-- @name ACFOnBulletRicochet
+	-- @class hook
+	-- @param number bulletIndex The index of the bullet that ricocheted
+	-- @param table bulletData The data of the bullet that ricocheted
+	-- @param table flightRes The flight results of the bullet that ricocheted
+	-- @server
+	SF.hookAdd("ACFOnBulletRicochet", nil, function(_, bulletIndex, bulletData, flightRes)
+		return true,
+		{
+			bulletIndex,
+			sanitize(bulletData or {}),
+			sanitize(flightRes or {})
+		}
+	end)
+
+	--- This gets called everytime a bullet penetrates something.
+	-- @name ACFOnBulletPenetrated
+	-- @class hook
+	-- @param number bulletIndex The index of the bullet that penetrated
+	-- @param table bulletData The data of the bullet that penetrated
+	-- @param table flightRes The flight results of the bullet that penetrated
+	-- @server
+	SF.hookAdd("ACFOnBulletPenetrated", nil, function(_, bulletIndex, bulletData, flightRes)
+		return true,
+		{
+			bulletIndex,
+			sanitize(bulletData or {}),
+			sanitize(flightRes or {})
+		}
+	end)
+
+	--- This gets called everytime a bullet is removed for any reason.
+	-- @name ACFOnBulletRemoved
+	-- @class hook
+	-- @param number bulletIndex The index of the bullet that was removed
+	-- @param table bulletData The data of the bullet that was removed
+	-- @server
+	SF.hookAdd("ACFOnBulletRemoved", nil, function(_, bulletIndex, bulletData)
+		return true,
+		{
+			bulletIndex,
+			sanitize(bulletData or {}),
+		}
+	end)
+
 end
 
 -- Mobility functions

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -992,6 +992,20 @@ do
 		return (this.BulletData["DragCoef"] or 0) / ACF.DragDiv
 	end
 
+	--- Returns the bullet data related to the index
+	--- Needs acf.trackBullets privilege to work.
+	-- @server
+	-- @param number index The index of the bullet
+	-- @return table The bullet data of the bullet or an empty table if the bullet doesn't exist
+	function acf_library.getBulletDataByIndex( index )
+		if not hasaccess(instance, nil, "acf.trackBullets") then
+			SF.Throw("You need the acf.trackBullets privilege to use this function", 2)
+			return {} -- Should not be needed but just in case
+		end
+		checkluatype(index, TYPE_NUMBER)
+		return sanitize( ACF.Bullet[ index ] or {} )
+	end
+
 	--- This gets called everytime a bullet is fired.
 	--- The bullet may be destroyed at the same time if it hits something very close.
 	--- Needs acf.trackBullets privilege to work.

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -10,12 +10,14 @@ local rad, cos = math.rad, math.cos
 
 local checkluatype = SF.CheckLuaType
 local checkpermission = SF.Permissions.check
+local hasaccess = SF.Permissions.hasAccess
 local registerprivilege = SF.Permissions.registerPrivilege
 
 registerprivilege("acf.createMobility", "Create acf engine", "Allows the user to create ACF engines and gearboxes", { usergroups = { default = 3 } })
 registerprivilege("acf.createFuelTank", "Create acf fuel tank", "Allows the user to create ACF fuel tanks", { usergroups = { default = 3 } })
 registerprivilege("acf.createGun", "Create acf gun", "Allows the user to create ACF guns", { usergroups = { default = 3 } })
 registerprivilege("acf.createAmmo", "Create acf ammo", "Allows the user to create ACF ammoboxes", { usergroups = { default = 3 } } )
+registerprivilege("acf.trackBullets", "Track ACF bullets", "Allows the user to track ACF bullets and the damage they deal to entities", { usergroups = { default = 1 } } )
 registerprivilege("entities.acf", "ACF", "Allows the user to control ACF components", { entities = {} })
 
 local function isEngine(ent)
@@ -521,6 +523,8 @@ do
 	-- @param table dmgInfo The damage info table, containing health and armor changes, if available
 	-- @server
 	SF.hookAdd("ACFOnDamage", nil, function(_, entity, energy, surface, angle, inflictor, bone, gun, type, hitRes, oldACFTbl)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		local dmgInfo = {}
 		if oldACFTbl and entity.ACF then
 			dmgInfo = {
@@ -995,6 +999,8 @@ do
 	-- @param table bulletData The data of the bullet fired
 	-- @server
 	SF.hookAdd("ACFOnBulletCreation", nil, function(_, bulletIndex, bulletData)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		return true,
 		{
 			bulletIndex,
@@ -1010,6 +1016,8 @@ do
 	-- @param table flightRes The flight results of the bullet that hit
 	-- @server
 	SF.hookAdd("ACFOnBulletHit", nil, function(_, bulletIndex, bulletData, flightRes)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		return true,
 			{
 				bulletIndex,
@@ -1026,6 +1034,8 @@ do
 	-- @param table flightRes The flight results of the bullet that ricocheted
 	-- @server
 	SF.hookAdd("ACFOnBulletRicochet", nil, function(_, bulletIndex, bulletData, flightRes)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		return true,
 		{
 			bulletIndex,
@@ -1042,6 +1052,8 @@ do
 	-- @param table flightRes The flight results of the bullet that penetrated
 	-- @server
 	SF.hookAdd("ACFOnBulletPenetrated", nil, function(_, bulletIndex, bulletData, flightRes)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		return true,
 		{
 			bulletIndex,
@@ -1057,6 +1069,8 @@ do
 	-- @param table bulletData The data of the bullet that was removed
 	-- @server
 	SF.hookAdd("ACFOnBulletRemoved", nil, function(_, bulletIndex, bulletData)
+		if not hasaccess(instance, nil, "acf.trackBullets") then return false end
+
 		return true,
 		{
 			bulletIndex,


### PR DESCRIPTION
-Added starfall and e2 functions to set the armor, ductility, and material of props
SF:
Entity:aceSetArmorProperties(thickness, ductility, material)
E2:
Ent:aceSetArmorProperties(Number Thickness, Number Ductility, String Material)

Added Cryx's ACE starfall hooks
- ACFOnBulletCreation (bulletIndex, bulletData)
- ACFOnBulletHit (bulletIndex, bulletData, flightRes)
- ACFOnBulletRicochet (bulletIndex, bulletData, flightRes)
- ACFOnBulletPenetrated (bulletIndex, bulletData, flightRes)
- ACFOnBulletRemoved (bulletIndex, bulletData)
- ACFOnDamage (entity, energy, surface, angle, inflictor, bone, gun, type, hitRes, dmgInfo)

-Buffed the reload speeds of manually loaded cannons. Nerfed the cost of loaders.
-Removed CPPI override causing issue with DPP prop protection
-Added Breech Autoloaders as a placeholder until the autoloader system is implemented. These cannons trade burst firerate and weight for cost and a consistent firerate in all conditions.
-Buffed the burst firerate of drum autoloaders.
-Added inertial guidance to spikes enabling lock on after launch. Increased the cost to compensate.
-Reduced the cost of turbine engines
-Considerably buffed the strength of both cluster munitions.
-Reduced the inaccuracy jittering of beam riding guidance
-Improved the accuracy of most cannons
-Increased the velocity of debris.
-Fixed fuel being removed after detonating
-Doubled the link radius for gunner crewmembers
-Added a glow to missile motors
-Gave missiles ability to pass through the skybox. This works as long as they don't exit the 800x800x800 meter limits.
