### PR TITLE
Prevent map debris

### DIFF
--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -1047,7 +1047,7 @@ function ACF_HEKill( Entity , HitVector , Energy , BlastPos )
 	local Debris
 
 	-- Create a debris only if the dead entity is greater than the specified scale.
-	if Entity:BoundingRadius() > ACF.DebrisScale then
+	if not IsUselessModel(Entity:GetModel()) and Entity:BoundingRadius() > ACF.DebrisScale then
 
 		Debris = ents.Create( "ace_debris" )
 		if IsValid(Debris) then


### PR DESCRIPTION
This small modification prevents map entities (that lack a real model) from generating debris when broken by ACE entities.
It should also serve as a safeguard for any invalid model.

For example, breakable map windows turned into errors when broken by ACE (see picture)
![20250226014752_1](https://github.com/user-attachments/assets/d5e61433-1ce5-4226-8093-c0f306410171)