### PR TITLE
Fixed E2 core parsing error

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acf.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acf.lua
@@ -1428,7 +1428,7 @@ do
 	__e2setcost(1)
 
 	-- Returns 1 if the ACF engine requires fuel to run
-	[nodiscard, deprecated = "All engines require fuel now."]
+	[nodiscard, deprecated = "All engines require fuel now"]
 	e2function number entity:acfFuelRequired()
 		return 1
 	end


### PR DESCRIPTION
Turns out E2 core preprocessor does not supports '.' in attribute values.