### PR TITLE
Improved Armor Cost Calculation

### DIFF
--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -3,23 +3,15 @@ name: GLuaFixer
 on:
   push:
     paths:
-    - 'lua/**'
-    - '!lua/entities/gmod_wire_expression2/**'
+      - 'lua/**'
+      - '!lua/entities/gmod_wire_expression2/**'
   pull_request:
     paths:
-    - 'lua/**'
-    - '!lua/entities/gmod_wire_expression2/**'
+      - 'lua/**'
+      - '!lua/entities/gmod_wire_expression2/**'
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v3
-    - name: Download GLuaFixer 1.26.0
-      run: curl -o glualint.zip -L https://github.com/FPtje/GLuaFixer/releases/download/1.26.0/glualint-1.26.0-x86_64-linux.zip
-    - name: Extract glualint.zip
-      run: unzip glualint.zip
-    - name: Remove blacklisted folders
-      run: rm -r lua/entities/gmod_wire_expression2/
-    - name: Initiate linting
-      run: ./glualint --output-format github lint .
+  Lint:
+    uses: FPtje/GLuaFixer/.github/workflows/glualint.yml@master
+    with:
+      config: .glualint.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/
+glualint.exe
+glualint.zip
+glualint-*

--- a/.glualint.json
+++ b/.glualint.json
@@ -22,7 +22,9 @@
     "lint_spaceBetweenParens": false,
     "lint_spaceBetweenBrackets": false,
     "lint_spaceBetweenBraces": false,
-    "lint_ignoreFiles": [],
+    "lint_ignoreFiles": [
+        "lua/entities/gmod_wire_expression2/**"
+    ],
     "lint_spaceBeforeComma": false,
     "lint_spaceAfterComma": false,
     "lint_maxLineLength": 0,

--- a/.glualint.json
+++ b/.glualint.json
@@ -23,7 +23,14 @@
     "lint_spaceBetweenBrackets": false,
     "lint_spaceBetweenBraces": false,
     "lint_ignoreFiles": [
-        "lua/entities/gmod_wire_expression2/**"
+        "./lua/entities/gmod_wire_expression2/**",
+        "lua/entities/gmod_wire_expression2/**",
+        "lua\\entities\\gmod_wire_expression2\\**",
+        ".\\lua\\entities\\gmod_wire_expression2\\**",
+        "**/gmod_wire_expression2/**",
+        "**\\gmod_wire_expression2\\**",
+        "**/lua/entities/gmod_wire_expression2/**",
+        "**\\lua\\entities\\gmod_wire_expression2\\**"
     ],
     "lint_spaceBeforeComma": false,
     "lint_spaceAfterComma": false,

--- a/.glualint.json
+++ b/.glualint.json
@@ -23,14 +23,7 @@
     "lint_spaceBetweenBrackets": false,
     "lint_spaceBetweenBraces": false,
     "lint_ignoreFiles": [
-        "./lua/entities/gmod_wire_expression2/**",
-        "lua/entities/gmod_wire_expression2/**",
-        "lua\\entities\\gmod_wire_expression2\\**",
-        ".\\lua\\entities\\gmod_wire_expression2\\**",
-        "**/gmod_wire_expression2/**",
-        "**\\gmod_wire_expression2\\**",
-        "**/lua/entities/gmod_wire_expression2/**",
-        "**\\lua\\entities\\gmod_wire_expression2\\**"
+        "lua/entities/gmod_wire_expression2/**"
     ],
     "lint_spaceBeforeComma": false,
     "lint_spaceAfterComma": false,

--- a/ARMOR_COST_SYSTEM_CHANGES.md
+++ b/ARMOR_COST_SYSTEM_CHANGES.md
@@ -1,0 +1,142 @@
+# ACE Armor Cost System Changes
+
+This document describes the recent armor cost pipeline changes, how the system now works end-to-end, the rationale, and the risk profile (including known exploit windows). It is intended to help maintainers evaluate adoption.
+
+Contents
+- Executive Summary
+- Goals and Scope
+- System Overview
+- Calculation Pipeline (Step-by-step)
+- What Changed (Detailed List)
+- Debug Visualization Behavior
+- Performance Profile
+- Possible Exploits and Edge Cases
+- Mitigation Options
+- Suggested Test Plan
+
+Executive Summary
+The new pipeline makes armor cost calculation consistent and deterministic by doing a single contraption-level scan on first initialization (unfreeze or first vehicle entry), then freezing the armor cost unless the vehicle is respawned. Subsequent changes mark the cost as dirty and display a visible warning in the readout rather than silently recalculating. This avoids expensive re-scans, removes inconsistent behavior from on-demand tools, and blocks most "spam-rescan" approaches that previously allowed players to search for favorable snapshots.
+
+Goals and Scope
+- Consistency: The same vehicle configuration yields the same armor cost across sessions and tools.
+- Performance: Avoid repeated trace-heavy scans during normal play.
+- Transparency: Show explicit warnings when costs are stale or uninitialized.
+- Exploit resistance: Make it harder to abuse timing-based recalculation without server admin intent.
+
+Scope
+- Contraption-level armor scanning and point rollups.
+- Tool readout behavior for armor summary.
+- Engine/ammo/missile point cost consistency fixes.
+- Debug overlays for armor scan visualization.
+
+System Overview
+The armor cost system is now split into two phases:
+1) Initialization scan: a single expensive scan computes front and side armor values and derives armor points. This is performed on first unfreeze or first vehicle entry (whichever happens first).
+2) Steady state: after initialization, any later changes to armor mark the contraption as dirty and display a warning. The cost is not recomputed until a respawn.
+
+This yields a stable cost snapshot used for legality checks and UI readouts, while still exposing when a player modified the vehicle afterward.
+
+Calculation Pipeline (Step-by-step)
+1) Contraption creation
+   - `ACE_InitPts` initializes point totals.
+   - `ACEArmorDirty = true` and `ACEArmorCalculated = false`.
+
+2) Initialization trigger (first scan)
+   - Triggered by `PlayerUnfrozeObject` or `PlayerEnteredVehicle` (first occurrence).
+   - A 0.1s delay is applied to allow reparenting or tool-side adjustments to settle.
+   - The scan runs once via `ACE_EnsureArmor`, computes:
+     - Front armor average (line-of-sight thickness to critical components).
+     - Side armor average (line-of-sight thickness, separate sample set).
+   - Final armor points: `(front + side * 2) * 4`.
+   - `ACEArmorCalculated = true`, `ACEArmorDirty = false`.
+
+3) After initialization
+   - Any changes (add/remove armor props, set mass) set `ACEArmorDirty = true`.
+   - Costs are not recomputed. The readout explicitly warns that costs are dirty and require a respawn.
+
+4) UI behavior
+   - Armor tool readout uses the cached values if initialized.
+   - If not initialized, it shows a warning: unfreeze or enter vehicle.
+   - If dirty after initialization, it shows a respawn warning.
+
+What Changed (Detailed List)
+1) Armor scan side weighting
+   - Side armor is now weighted only once. Previously, side was doubled in the scan and then doubled again when costing, over-weighting side by 4x.
+   - Current formula: `(front + side * 2) * 4`.
+
+2) Armor scan sampling and debug overlays
+   - Debug squares now render at actual trace hit points (armor surface), not just OBB corners.
+   - Marker size represents each sample’s share of the projected surface area.
+
+3) Engine cost consistency
+   - Engine cost is now recomputed on update using the same fallback cost formula and multiplier as initial spawn.
+   - This avoids "update path" vs "spawn path" point divergence.
+
+4) Ammo crate cost correctness
+   - Ammo cost now uses the freshly computed `AmmoMaxMass` instead of stale values.
+
+5) Missile guidance cost safety
+   - Guidance multipliers are now guarded with a safe fallback to avoid nil math and zeroing cost when unknown guidance is used.
+
+6) Scan triggering policy
+   - The scan no longer runs on tool use or legality checks.
+   - It runs once on unfreeze, or on first vehicle entry if that happens first.
+   - Changes afterward only mark the cost as dirty and warn.
+
+Debug Visualization Behavior
+- Debug overlays are tied to the scan execution itself.
+- Because scans are now single-shot and triggered on unfreeze/entry, debug overlays appear only when that initialization scan is performed (or when a manual debug scan is invoked).
+- This is expected and prevents debug overlays from encouraging repeated scans.
+
+Performance Profile
+Prior behavior:
+- Armor scanning could be triggered repeatedly by tools or legality checks.
+- Resulted in multiple trace hull runs per frame, inconsistent timing, and potential spam.
+
+Current behavior:
+- One scan per contraption at initialization.
+- No repeated scanning on normal gameplay.
+- Dirty changes become a warning rather than a rescan.
+- Reduced server load and more consistent gameplay performance.
+
+Possible Exploits and Edge Cases
+1) Post-init armor reduction
+   - Player initializes vehicle, then removes armor to reduce actual weight and still keep the old higher cost.
+   - Impact: vehicle pays more cost than needed, not a balance issue but could annoy players.
+
+2) Post-init armor increase
+   - Player initializes vehicle, then adds armor or changes materials to become tougher without cost increase.
+   - Impact: balance exploit if building is allowed after init.
+
+3) Unfreeze order manipulation
+   - Player attaches "dummy" armor before unfreeze to inflate cost, then removes it.
+   - Impact: opposite of exploit (cost too high), but may be used to avoid suspicion in legality systems.
+
+4) Entry-before-unfreeze timing
+   - If the player enters a seat before unfreeze, the scan will run at that time.
+   - This is intentional to guarantee initialization even if unfreeze never fires.
+
+5) Reparenting edge cases
+   - Some entities reparent on spawn; the 0.1s delay is intended to reduce mis-scans, but complex setups may still require a manual respawn.
+
+Mitigation Options
+If maintainers want to close exploit windows without reintroducing heavy scans:
+- Lock building after initialization
+  - Example: disallow tool use or physgun on contraption entities once `ACEArmorCalculated` is true.
+- Add an explicit "Recalculate Armor" admin command
+  - Only server admins can force a rescan for a contraption.
+- Enforce respawn on dirty
+  - If `ACEArmorDirty == true` for longer than a threshold, force a respawn or mark the contraption illegal.
+- Add a lightweight re-scan trigger
+  - Example: rescan only on vehicle freeze or after a build session ends.
+
+Suggested Test Plan
+- Spawn a vehicle, do not unfreeze, check armor tool: see "not initialized" warning.
+- Unfreeze vehicle: armor is computed and warning disappears.
+- Enter vehicle before unfreeze: armor computes on entry.
+- Add armor after init: see "dirty" warning; cost stays fixed.
+- Update engine/ammo/missile definitions and verify costs remain consistent after entity updates.
+- Enable `ace_armor_debugvis` and confirm squares appear at real hit points with scaled sizes during initialization scan.
+
+Summary for Adoption
+This system trades continuous recalculation for a consistent, stable cost snapshot. It is fast, avoids spam, and makes armor cost changes explicit to players. The remaining exploit window (post-init changes) is surfaced to users and can be hardened by server policy if desired, without reintroducing heavy tracing or inconsistent recalcs.

--- a/ARMOR_COST_SYSTEM_CHANGES.md
+++ b/ARMOR_COST_SYSTEM_CHANGES.md
@@ -92,7 +92,7 @@ crate_pts = round_pts * capacity * (rps_total / RpsRef) ^ RpsExp
 
 ### Current Constants
 - BaseRoundPts = 111.1
-- RefPen = 500
+- RefPen = 600
 - RefCaliber = 120
 - PenExp = 2
 - RpsRef = 1 / 7

--- a/ARMOR_COST_SYSTEM_CHANGES.md
+++ b/ARMOR_COST_SYSTEM_CHANGES.md
@@ -1,142 +1,199 @@
-# ACE Armor Cost System Changes
+# ACE Armor and Cost System (Current Behavior)
 
-This document describes the recent armor cost pipeline changes, how the system now works end-to-end, the rationale, and the risk profile (including known exploit windows). It is intended to help maintainers evaluate adoption.
+This document is a complete, no-context explanation of how the current ACE cost system works. It covers when calculations run, how armor and ammo are scored, what is shown in the readout, and which values can be tuned.
 
-Contents
-- Executive Summary
-- Goals and Scope
-- System Overview
-- Calculation Pipeline (Step-by-step)
-- What Changed (Detailed List)
-- Debug Visualization Behavior
-- Performance Profile
-- Possible Exploits and Edge Cases
-- Mitigation Options
-- Suggested Test Plan
+## Scope
+- Contraption-level armor scanning and scoring.
+- Ammo-driven firepower cost (guns and racks are zero-cost; ammo carries offense).
+- Engine, crew, and electronics point rollups.
+- Readout format, warnings, and debug behavior.
 
-Executive Summary
-The new pipeline makes armor cost calculation consistent and deterministic by doing a single contraption-level scan on first initialization (unfreeze or first vehicle entry), then freezing the armor cost unless the vehicle is respawned. Subsequent changes mark the cost as dirty and display a visible warning in the readout rather than silently recalculating. This avoids expensive re-scans, removes inconsistent behavior from on-demand tools, and blocks most "spam-rescan" approaches that previously allowed players to search for favorable snapshots.
+## Key Terms
+- Contraption: A set of constrained entities treated as one vehicle.
+- Critical component: Engine, ammo crate, fuel tank, or crew seat; used as sampling anchors for armor traces.
+- Initialized: Armor scan has been performed and cached.
+- Dirty: Contraption changed after initialization; armor cost is stale until respawn.
 
-Goals and Scope
-- Consistency: The same vehicle configuration yields the same armor cost across sessions and tools.
-- Performance: Avoid repeated trace-heavy scans during normal play.
-- Transparency: Show explicit warnings when costs are stale or uninitialized.
-- Exploit resistance: Make it harder to abuse timing-based recalculation without server admin intent.
+## High-Level Flow
+1) When a contraption is initialized (unfreeze, vehicle entry, or dupe paste), an armor scan runs once.
+2) The scan computes average front and side armor for the contraption.
+3) Armor points are calculated from those averages.
+4) Non-armor points are rebuilt, including ammo points based on penetration and total compatible ROF.
+5) If the contraption changes afterward, it is marked dirty and a warning appears. No re-scan occurs until respawn.
 
-Scope
-- Contraption-level armor scanning and point rollups.
-- Tool readout behavior for armor summary.
-- Engine/ammo/missile point cost consistency fixes.
-- Debug overlays for armor scan visualization.
+## When Calculations Run
+Initialization triggers:
+- Player unfreezes an entity in the contraption.
+- Player enters a vehicle seat in the contraption.
+- Advanced Duplicator paste (runs multiple delayed attempts to catch reparenting).
 
-System Overview
-The armor cost system is now split into two phases:
-1) Initialization scan: a single expensive scan computes front and side armor values and derives armor points. This is performed on first unfreeze or first vehicle entry (whichever happens first).
-2) Steady state: after initialization, any later changes to armor mark the contraption as dirty and display a warning. The cost is not recomputed until a respawn.
+Initialization details:
+- The scan is delayed briefly (default 0.1s) to allow reparenting and tool adjustments.
+- If the contraption is already initialized and not dirty, it is not recalculated.
 
-This yields a stable cost snapshot used for legality checks and UI readouts, while still exposing when a player modified the vehicle afterward.
+Dirty behavior:
+- Any armor-affecting change (mass/material changes, armor entity add/remove) sets ACEArmorDirty = true.
+- Dirty contraptions do not re-scan; the readout warns that a respawn is required.
 
-Calculation Pipeline (Step-by-step)
-1) Contraption creation
-   - `ACE_InitPts` initializes point totals.
-   - `ACEArmorDirty = true` and `ACEArmorCalculated = false`.
+## Armor Scan Algorithm
+### Entity Set
+- Primary source: contraption.ents (framework list).
+- Fallback: ACE.contraptionEnts filtered by contraption id.
+- Final fallback: base entity only.
 
-2) Initialization trigger (first scan)
-   - Triggered by `PlayerUnfrozeObject` or `PlayerEnteredVehicle` (first occurrence).
-   - A 0.1s delay is applied to allow reparenting or tool-side adjustments to settle.
-   - The scan runs once via `ACE_EnsureArmor`, computes:
-     - Front armor average (line-of-sight thickness to critical components).
-     - Side armor average (line-of-sight thickness, separate sample set).
-   - Final armor points: `(front + side * 2) * 4`.
-   - `ACEArmorCalculated = true`, `ACEArmorDirty = false`.
+### Facing Detection
+- The largest-caliber main gun is used to infer front/side directions.
+- If no gun is found, the base entity forward/right vectors are used.
 
-3) After initialization
-   - Any changes (add/remove armor props, set mass) set `ACEArmorDirty = true`.
-   - Costs are not recomputed. The readout explicitly warns that costs are dirty and require a respawn.
+### Sampling
+- Critical components (engine, ammo, fuel, crew) are used as sampling anchors.
+- Each component contributes multiple sample points (OBB corners + center).
+- Projected surface area is computed in front and side directions.
+- Samples are area-weighted to reduce bias from small parts.
 
-4) UI behavior
-   - Armor tool readout uses the cached values if initialized.
-   - If not initialized, it shows a warning: unfreeze or enter vehicle.
-   - If dirty after initialization, it shows a respawn warning.
+### Line-of-Sight Thickness
+For each sample point:
+- A hull trace is fired toward the component from the front direction.
+- A hull trace is fired from both left and right for the side direction (lowest valid value wins).
+- Armor thickness uses material effectiveness and slope correction.
+- MakeSpherical props and non-armor classes are skipped.
+- Effective armor blends KE/CHEM as: eff = 0.8 * KE + 0.2 * CHEM.
 
-What Changed (Detailed List)
-1) Armor scan side weighting
-   - Side armor is now weighted only once. Previously, side was doubled in the scan and then doubled again when costing, over-weighting side by 4x.
-   - Current formula: `(front + side * 2) * 4`.
+### Aggregation
+- Samples are grouped by a coarse region key to prevent stacking the same armor multiple times.
+- Weighted averages are computed for front and side.
 
-2) Armor scan sampling and debug overlays
-   - Debug squares now render at actual trace hit points (armor surface), not just OBB corners.
-   - Marker size represents each sample’s share of the projected surface area.
+### Armor Points
+Final armor points are calculated as:
+```
+armor_pts = (front_avg + side_avg * 2) * 4
+```
+Side armor is intentionally weighted 2x.
 
-3) Engine cost consistency
-   - Engine cost is now recomputed on update using the same fallback cost formula and multiplier as initial spawn.
-   - This avoids "update path" vs "spawn path" point divergence.
+## Ammo Cost Model (Firepower)
+Firepower is represented by ammo only. Guns and racks are zero-cost entities.
 
-4) Ammo crate cost correctness
-   - Ammo cost now uses the freshly computed `AmmoMaxMass` instead of stale values.
+### Steps
+1) Collect total ROF per ammo id from all guns in the contraption.
+   - Uses ReloadTime if present; otherwise RateOfFire in RPM.
+2) If a rack is compatible with the ammo, add rack ReloadTime to the total ROF.
+3) For each ammo crate, compute a per-round cost from penetration, caliber, and type.
+4) Multiply per-round cost by crate capacity and ROF factor.
 
-5) Missile guidance cost safety
-   - Guidance multipliers are now guarded with a safe fallback to avoid nil math and zeroing cost when unknown guidance is used.
+### Formula
+```
+round_pts = BaseRoundPts
+            * (max_pen / RefPen) ^ PenExp
+            * (caliber_mm / RefCaliber)
+            * type_factor
 
-6) Scan triggering policy
-   - The scan no longer runs on tool use or legality checks.
-   - It runs once on unfreeze, or on first vehicle entry if that happens first.
-   - Changes afterward only mark the cost as dirty and warn.
+crate_pts = round_pts * capacity * (rps_total / RpsRef) ^ RpsExp
+```
 
-Debug Visualization Behavior
-- Debug overlays are tied to the scan execution itself.
-- Because scans are now single-shot and triggered on unfreeze/entry, debug overlays appear only when that initialization scan is performed (or when a manual debug scan is invoked).
-- This is expected and prevents debug overlays from encouraging repeated scans.
+### Current Constants
+- BaseRoundPts = 111.1
+- RefPen = 500
+- RefCaliber = 120
+- PenExp = 2
+- RpsRef = 1 / 7
+- RpsExp = 0.5
 
-Performance Profile
-Prior behavior:
-- Armor scanning could be triggered repeatedly by tools or legality checks.
-- Resulted in multiple trace hull runs per frame, inconsistent timing, and potential spam.
+### Max Pen Source
+- If BulletData.MaxPen exists, it is used.
+- Otherwise the round type display data is queried (ACF.RoundTypes[type].getDisplayData).
+- If no MaxPen can be resolved, the crate contributes 0 points.
 
-Current behavior:
-- One scan per contraption at initialization.
-- No repeated scanning on normal gameplay.
-- Dirty changes become a warning rather than a rescan.
-- Reduced server load and more consistent gameplay performance.
+### Ammo Type Factors
+```
+AP=1
+APHE=1
+APDS=1
+APFSDS=1.05
+HVAP=1
+HEAT=0.75
+HEATFS=0.75
+THEAT=0.82
+THEATFS=0.82
+HESH=0.55
+HE=0.25
+HEFS=0.25
+HP=0.25
+CAP=1
+CHEAT=0.75
+CHE=0.25
+CHF=0
+SM=0
+FLR=0
+FL=1
+GLATGM=0.75
+GLATGM-HE=0.25
+Refill=0
+```
 
-Possible Exploits and Edge Cases
-1) Post-init armor reduction
-   - Player initializes vehicle, then removes armor to reduce actual weight and still keep the old higher cost.
-   - Impact: vehicle pays more cost than needed, not a balance issue but could annoy players.
+## Other Point Categories
+- Armor: contraption-level scan result only.
+- Engines: uses existing per-entity ACEPoints.
+- Ammo: calculated as above from crates.
+- Crew: uses per-entity ACEPoints (crew seats).
+- Electronics: uses per-entity ACEPoints.
+- Fuel: ignored (0 points).
+- Firepower: guns/racks are tracked for ROF only and cost 0 points.
 
-2) Post-init armor increase
-   - Player initializes vehicle, then adds armor or changes materials to become tougher without cost increase.
-   - Impact: balance exploit if building is allowed after init.
+## Readout Format
+The armor tool shows a cost breakdown and a summary. Example format:
+```
+<||============|[- Cost Breakdown -]|============||>
+Total Cost: 12826.6pts  -  2826.6 pts over
+Armor scan: front=548.49mm  side=70.97mm
+Armor: (22%) - 2761.7/12826.6
+Engines: (11%) - 1409/12826.6
+Ammo: (58%) - 7453.9/12826.6
+Crew: (9%) - 1202/12826.6
+Electronics: (0%) - 0/12826.6
+- Top Cost Items:
+Ammo: 42x140mm APFSDS - Pen: 857, RPS: 0.06 - 4936.1pts
+Ammo: 36x140mm HEATFS - Pen: 1300, RPS: 0.08 - 3432.5pts
+Engines: 20.7L Flat 6 Multifuel - 1409.0pts
+Crew: Alex Popov - 400.0pts
+<||============|[- Contraption Summary -]|============||>
+...
+```
 
-3) Unfreeze order manipulation
-   - Player attaches "dummy" armor before unfreeze to inflate cost, then removes it.
-   - Impact: opposite of exploit (cost too high), but may be used to avoid suspicion in legality systems.
+Top Cost Items behavior:
+- Sorted by points descending, stable by entity index.
+- Any item >= 300 pts is listed.
+- Ammo entries are formatted as: cap x caliber type - Pen: X, RPS: Y.
 
-4) Entry-before-unfreeze timing
-   - If the player enters a seat before unfreeze, the scan will run at that time.
-   - This is intentional to guarantee initialization even if unfreeze never fires.
+Warnings:
+- If not initialized: "Armor cost not initialized; unfreeze or enter vehicle."
+- If dirty: "Armor cost dirty; respawn to recalc."
 
-5) Reparenting edge cases
-   - Some entities reparent on spawn; the 0.1s delay is intended to reduce mis-scans, but complex setups may still require a manual respawn.
+## Debug and Diagnostics
+- `ace_armor_debugvis` draws debug boxes at armor hit locations during a scan.
+- Colors scale from green to red relative to the max LOS value in that scan.
+- Console prints a single-line summary if debug is enabled.
 
-Mitigation Options
-If maintainers want to close exploit windows without reintroducing heavy scans:
-- Lock building after initialization
-  - Example: disallow tool use or physgun on contraption entities once `ACEArmorCalculated` is true.
-- Add an explicit "Recalculate Armor" admin command
-  - Only server admins can force a rescan for a contraption.
-- Enforce respawn on dirty
-  - If `ACEArmorDirty == true` for longer than a threshold, force a respawn or mark the contraption illegal.
-- Add a lightweight re-scan trigger
-  - Example: rescan only on vehicle freeze or after a build session ends.
+## Performance and Consistency
+- One scan per contraption at initialization; no continuous tracing during play.
+- Cached values are deterministic for a given contraption state.
+- Dirty changes are explicit rather than silent re-scans.
 
-Suggested Test Plan
-- Spawn a vehicle, do not unfreeze, check armor tool: see "not initialized" warning.
-- Unfreeze vehicle: armor is computed and warning disappears.
-- Enter vehicle before unfreeze: armor computes on entry.
-- Add armor after init: see "dirty" warning; cost stays fixed.
-- Update engine/ammo/missile definitions and verify costs remain consistent after entity updates.
-- Enable `ace_armor_debugvis` and confirm squares appear at real hit points with scaled sizes during initialization scan.
+## Edge Cases and Limitations
+- If a gun or rack has no compatible ammo in the contraption, ammo ROF is zero and crates score 0 points.
+- If MaxPen cannot be resolved for a round type, that crate scores 0.
+- Main-gun direction inference can be wrong on unconventional builds; fallback uses base entity orientation.
+- Post-init modifications can change actual protection without updating cost; this is intentional and surfaced as a warning.
 
-Summary for Adoption
-This system trades continuous recalculation for a consistent, stable cost snapshot. It is fast, avoids spam, and makes armor cost changes explicit to players. The remaining exploit window (post-init changes) is surfaced to users and can be hardened by server policy if desired, without reintroducing heavy tracing or inconsistent recalcs.
+## Tuning Knobs
+- AmmoCostConfig: BaseRoundPts, RefPen, RefCaliber, PenExp, RpsRef, RpsExp.
+- AmmoTypeFactors: per-type multipliers.
+- Armor cost scale: `(front + side * 2) * 4`.
+- Initialization timing: delay in ACE_ScheduleInitArmor.
+
+## Suggested Test Checklist
+- Spawn a contraption, do not unfreeze: readout shows "not initialized" warning.
+- Unfreeze: armor initializes and warning disappears.
+- Enter vehicle before unfreeze: armor initializes on entry.
+- Modify armor after init: readout shows "dirty" warning and costs remain fixed.
+- Test ammo crates with and without compatible guns/racks; confirm ROF scaling and label formatting.
+- Enable `ace_armor_debugvis` and verify debug boxes render at trace hit locations.

--- a/COST_SYSTEM_CHANGES_README.md
+++ b/COST_SYSTEM_CHANGES_README.md
@@ -1,6 +1,6 @@
-# ACE Armor and Cost System (Current Behavior)
+# Improved ACE Armor and Cost System
 
-This document is a complete, no-context explanation of how the current ACE cost system works. It covers when calculations run, how armor and ammo are scored, what is shown in the readout, and which values can be tuned.
+This document is a complete, no-context explanation of how the new and improved ACE cost system works. It covers when calculations run, how armor and ammo are scored, what is shown in the readout, and which values can be tuned.
 
 ## Scope
 - Contraption-level armor scanning and scoring.
@@ -41,9 +41,15 @@ Dirty behavior:
 - Fallback: ACE.contraptionEnts filtered by contraption id.
 - Final fallback: base entity only.
 
-### Facing Detection
-- The largest-caliber main gun is used to infer front/side directions.
-- If no gun is found, the base entity forward/right vectors are used.
+### Facing and Up Direction
+- Up is derived from world gravity (physenv.GetGravity) and normalized.
+- Front uses the main gun forward (negated), flattened to the gravity plane.
+- If no gun exists or the vector is degenerate, base forward is used.
+- Side uses wheel axle axes when possible:
+  - Axis constraints between the baseplate and MakeSpherical wheels are collected.
+  - The axle axes are averaged and flattened to the gravity plane.
+- If no valid wheel axes are found, side falls back to cross(up, front), then base right.
+- The final basis is orthonormalized so front and side are perpendicular.
 
 ### Sampling
 - Critical components (engine, ammo, fuel, crew) are used as sampling anchors.
@@ -92,7 +98,7 @@ crate_pts = round_pts * capacity * (rps_total / RpsRef) ^ RpsExp
 
 ### Current Constants
 - BaseRoundPts = 111.1
-- RefPen = 500
+- RefPen = 600
 - RefCaliber = 120
 - PenExp = 2
 - RpsRef = 1 / 7
@@ -105,29 +111,29 @@ crate_pts = round_pts * capacity * (rps_total / RpsRef) ^ RpsExp
 
 ### Ammo Type Factors
 ```
-AP=1
-APHE=1
-APDS=1
-APFSDS=1.05
-HVAP=1
-HEAT=0.75
-HEATFS=0.75
-THEAT=0.82
-THEATFS=0.82
-HESH=0.55
-HE=0.25
-HEFS=0.25
-HP=0.25
-CAP=1
-CHEAT=0.75
-CHE=0.25
-CHF=0
-SM=0
-FLR=0
-FL=1
-GLATGM=0.75
-GLATGM-HE=0.25
-Refill=0
+AP = 0.5,
+APHE = 0.6,
+APDS = 0.9,
+APFSDS = 1.2,
+HVAP = 0.7,
+HEAT = 0.75,
+HEATFS = 0.9,
+THEAT = 0.95,
+THEATFS = 1.0,
+HESH = 0.4,
+HE = 0.2,
+HEFS = 0.3,
+HP = 0.1,
+CAP = 0.6,
+CHEAT = 0.8,
+CHE = 0.25,
+CHF = 0,
+SM = 0,
+FLR = 0,
+FL = 0.3,
+GLATGM = 0.75,
+["GLATGM-HE"] = 0.25,
+Refill = 0
 ```
 
 ## Other Point Categories
@@ -152,7 +158,6 @@ Crew: (9%) - 1202/12826.6
 Electronics: (0%) - 0/12826.6
 - Top Cost Items:
 Ammo: 42x140mm APFSDS - Pen: 857, RPS: 0.06 - 4936.1pts
-Ammo: 36x140mm HEATFS - Pen: 1300, RPS: 0.08 - 3432.5pts
 Engines: 20.7L Flat 6 Multifuel - 1409.0pts
 Crew: Alex Popov - 400.0pts
 <||============|[- Contraption Summary -]|============||>
@@ -181,7 +186,8 @@ Warnings:
 ## Edge Cases and Limitations
 - If a gun or rack has no compatible ammo in the contraption, ammo ROF is zero and crates score 0 points.
 - If MaxPen cannot be resolved for a round type, that crate scores 0.
-- Main-gun direction inference can be wrong on unconventional builds; fallback uses base entity orientation.
+- If no axis-constrained MakeSpherical wheels exist, side uses cross(up, front) and may be less reliable on unusual builds.
+- If the main gun is vertical, the front vector is flattened; extreme cases fall back to base forward.
 - Post-init modifications can change actual protection without updating cost; this is intentional and surfaced as a warning.
 
 ## Tuning Knobs

--- a/COST_SYSTEM_CHANGES_README.md
+++ b/COST_SYSTEM_CHANGES_README.md
@@ -1,205 +1,323 @@
-# Improved ACE Armor and Cost System
+# ACE Points System Reference
 
-This document is a complete, no-context explanation of how the new and improved ACE cost system works. It covers when calculations run, how armor and ammo are scored, what is shown in the readout, and which values can be tuned.
+This document describes the current points system as implemented in this repo. It is a standalone explanation of how points are calculated, cached, and displayed.
 
-## Scope
-- Contraption-level armor scanning and scoring.
-- Ammo-driven firepower cost (guns and racks are zero-cost; ammo carries offense).
-- Engine, crew, and electronics point rollups.
-- Readout format, warnings, and debug behavior.
+## Overview
+- A contraption is a constrained set of entities treated as one vehicle.
+- Armor points come from a line-of-sight (LOS) scan of the contraption, not from mass.
+- Non-armor points are a mix of per-entity ACEPoints and ammo scoring.
+- Guns and racks contribute rate-of-fire only; their direct point cost is zero.
+- Fuel tanks are ignored for points.
 
-## Key Terms
-- Contraption: A set of constrained entities treated as one vehicle.
-- Critical component: Engine, ammo crate, fuel tank, or crew seat; used as sampling anchors for armor traces.
-- Initialized: Armor scan has been performed and cached.
-- Dirty: Contraption changed after initialization; armor cost is stale until respawn.
+## Core Contraption State
+The legality system stores computed values on the contraption object:
+- ACEPoints: Total points for the contraption.
+- ACEPointsPerType: Per-category totals (Armor, Engines, Ammo, AmmoReady, AmmoBackup, Crew, Electronics, Firepower).
+- ACEPointsNonArmor: Non-armor subtotal.
+- ACEArmorFront / ACEArmorSide: Cached armor averages (mm) from the scan.
+- ACEArmorPoints: Armor points derived from the scan.
+- ACEArmorDirty: True when armor-affecting changes occur after initialization.
+- ACEArmorCalculated: True after the first successful scan.
+- ACENonArmorDirty: True when non-armor totals need rebuilding (ammo, guns, racks, etc.).
+- ACEAmmoCache: Cached ROF and ready-rack data for ammo scoring.
+- ACEPointsDetails: Readout details (ammo lines and trimmed items).
 
-## High-Level Flow
-1) When a contraption is initialized (unfreeze, vehicle entry, or dupe paste), an armor scan runs once.
-2) The scan computes average front and side armor for the contraption.
-3) Armor points are calculated from those averages.
-4) Non-armor points are rebuilt, including ammo points based on penetration and total compatible ROF.
-5) If the contraption changes afterward, it is marked dirty and a warning appears. No re-scan occurs until respawn.
+## Entity Classification
+Entity classes are mapped into categories via ACE_GetPtsType:
+- Armor: prop_physics, primitive_*, and any class not explicitly listed below.
+- Engines: acf_engine
+- Firepower: acf_gun, acf_rack (points zero, ROF only)
+- Ammo: acf_ammo (custom scoring)
+- Crew: ace_crewseat_driver, ace_crewseat_gunner, ace_crewseat_loader
+- Electronics: ace_* radar/IRST/ECM devices and acf_opticalcomputer
+- Ignore: acf_fueltank
+
+ACE_GetEntPoints returns 0 for armor, ammo, guns, racks, and fuel tanks. All other entities contribute their ACEPoints value.
 
 ## When Calculations Run
-Initialization triggers:
-- Player unfreezes an entity in the contraption.
-- Player enters a vehicle seat in the contraption.
-- Advanced Duplicator paste (runs multiple delayed attempts to catch reparenting).
+Initialization (armor scan) is scheduled by these hooks:
+- PlayerUnfrozeObject: when a player unfreezes part of the contraption.
+- PlayerEnteredVehicle: when a player enters a seat in the contraption.
+- AdvDupe_FinishPasting: multiple delayed passes to catch reparenting after paste.
 
-Initialization details:
-- The scan is delayed briefly (default 0.1s) to allow reparenting and tool adjustments.
-- If the contraption is already initialized and not dirty, it is not recalculated.
+Scheduling behavior:
+- ACE_ScheduleInitArmor coalesces multiple triggers and uses the largest requested delay.
+- Typical delay is 0.1 seconds. AdvDupe runs multiple delayed attempts.
+- If ACEArmorCalculated is true and ACEArmorDirty is false, the scan is skipped.
 
 Dirty behavior:
-- Any armor-affecting change (mass/material changes, armor entity add/remove) sets ACEArmorDirty = true.
-- Dirty contraptions do not re-scan; the readout warns that a respawn is required.
+- Any armor-affecting change sets ACEArmorDirty = true.
+- If the contraption is already initialized, dirty contraptions do not rescan.
+- The readout warns that a respawn is required to apply new armor values.
 
-## Armor Scan Algorithm
-### Entity Set
-- Primary source: contraption.ents (framework list).
-- Fallback: ACE.contraptionEnts filtered by contraption id.
-- Final fallback: base entity only.
+Non-armor rebuild behavior:
+- ACENonArmorDirty is set when ammo, guns, or racks change.
+- Non-armor totals are rebuilt on demand when dirty or missing.
 
-### Facing and Up Direction
-- Up is derived from world gravity (physenv.GetGravity) and normalized.
-- Front uses the main gun forward (negated), flattened to the gravity plane.
-- If no gun exists or the vector is degenerate, base forward is used.
-- Side uses wheel axle axes when possible:
-  - Axis constraints between the baseplate and MakeSpherical wheels are collected.
-  - The axle axes are averaged and flattened to the gravity plane.
-- If no valid wheel axes are found, side falls back to cross(up, front), then base right.
-- The final basis is orthonormalized so front and side are perpendicular.
+## Armor Scan
+Armor is estimated by tracing toward critical components and measuring LOS thickness.
 
-### Sampling
-- Critical components (engine, ammo, fuel, crew) are used as sampling anchors.
-- Each component contributes multiple sample points (OBB corners + center).
-- Projected surface area is computed in front and side directions.
-- Samples are area-weighted to reduce bias from small parts.
+### 1) Entity Set
+The scan uses the contraption entity list when available:
+- Primary: contraption.ents.
+- Fallback: base entity only.
 
-### Line-of-Sight Thickness
+Entities are sorted by EntIndex for determinism.
+
+### 2) Direction Basis
+A stable front/side/up basis is derived:
+- Up comes from world gravity (physenv.GetGravity), inverted and normalized.
+- Front comes from the main gun (largest caliber) forward vector, negated.
+- If no gun is found, base entity forward is used.
+- Front is flattened onto the gravity plane to avoid vertical bias.
+- Side is derived from Axis constraints between the base and MakeSpherical wheels.
+- If no wheel axis is found, side uses up x front.
+- If that fails, side falls back to base right.
+- The basis is orthonormalized to keep front and side perpendicular.
+
+### 3) Critical Components
+Armor is sampled around these components:
+- acf_ammo, acf_fueltank, acf_engine
+- ace_crewseat_driver, ace_crewseat_gunner, ace_crewseat_loader
+
+If no critical components exist, the scan returns 0 for both front and side.
+
+### 4) Sampling Points and Weights
+For each critical component:
+- Use OBB corners (scaled to 75 percent) plus the center.
+- Compute projected area in front and side directions.
+- Each sample carries an area-based weight (area / sample count).
+
+### 5) LOS Thickness
 For each sample point:
 - A hull trace is fired toward the component from the front direction.
-- A hull trace is fired from both left and right for the side direction (lowest valid value wins).
-- Armor thickness uses material effectiveness and slope correction.
-- MakeSpherical props and non-armor classes are skipped.
-- Effective armor blends KE/CHEM as: eff = 0.8 * KE + 0.2 * CHEM.
+- Two hull traces are fired for the side direction (left and right).
+- The smaller valid side thickness is used.
 
-### Aggregation
-- Samples are grouped by a coarse region key to prevent stacking the same armor multiple times.
-- Weighted averages are computed for front and side.
+LOS thickness accumulation:
+- Non-ACF props, MakeSpherical props, ignored classes, and clipped surfaces are skipped.
+- Each valid armor hit adds LOS thickness based on material effectiveness and slope:
+  - Effective = 0.8 * KE_effectiveness + 0.2 * CHEM_effectiveness.
+  - Slope correction uses ACF_GetHitAngle and ACF.SlopeEffectFactor.
+  - Curved armor uses its Curve value (power term).
+- The trace repeats until the target component is hit or no hits remain.
+- Samples that do not hit the target component are ignored.
 
-### Armor Points
-Final armor points are calculated as:
+### 6) Region Deduplication
+To avoid stacking multiple hits from the same area:
+- Hits are bucketed into a 2-unit grid in the scan plane.
+- For each region, only the maximum LOS value is kept.
+
+### 7) Averaging
+Front and side averages are weighted by projected area and accumulated across regions.
+The scan returns raw averages in millimeters.
+
+### Debug
+When ace_armor_debugvis is enabled:
+- Boxes are drawn at hit locations.
+- Color scales from green to red based on the maximum LOS in that scan.
+
+## Armor Points
+Armor points are calculated from the averaged results:
+
 ```
 armor_pts = (front_avg + side_avg * 2) * 4
 ```
-Side armor is intentionally weighted 2x.
 
-## Ammo Cost Model (Firepower)
-Firepower is represented by ammo only. Guns and racks are zero-cost entities.
+Side armor is intentionally weighted 2x. Points are stored in ACEArmorPoints and ACEPointsPerType.Armor.
 
-### Steps
-1) Collect total ROF per ammo id from all guns in the contraption.
-   - Uses ReloadTime if present; otherwise RateOfFire in RPM.
-2) If a rack is compatible with the ammo, add rack ReloadTime to the total ROF.
-3) For each ammo crate, compute a per-round cost from penetration, caliber, and type.
-4) Multiply per-round cost by crate capacity and ROF factor.
+## Non-Armor Points
+Non-armor points are computed by ACE_CalcNonArmorPoints:
+- Engines, Crew, Electronics: sum of ACEPoints on each entity.
+- Firepower: zero (guns/racks are tracked for ROF only).
+- Ammo: custom scoring per crate (see next section).
 
-### Formula
+The totals are written into ACEPointsPerType and cached in ACEPointsNonArmor.
+
+## Ammo Scoring
+Ammo points are derived from ammo crates, compatible guns, and rack ROF.
+
+### Required Inputs
+For each crate:
+- BulletData (bdata) must exist.
+- Capacity must be greater than zero.
+- Max penetration or blast mass must be available.
+- A compatible gun or rack must exist to supply ROF.
+
+If any of these are missing, the crate scores 0 points.
+
+### Penetration and Blast Inputs
+Max penetration is resolved in this order:
+1) BulletData.MaxPen or MaxPen2 (takes the max).
+2) ACF.RoundTypes[Type].getDisplayData (MaxPen/MaxPen2).
+3) HE blast penetration from filler mass (BoomFillerMass or FillerMass),
+   using ACF.HEPower and ACF.HEBlastPenetration.
+
+Blast mass is taken from BoomFillerMass or FillerMass.
+
+Caliber (mm) is derived from:
+- Caliber, SlugCaliber, SlugCaliber2, JetCaliber (max), or
+- ACF_GetGunValue(Id, "caliber") fallback.
+
+Values are converted from cm to mm (x10).
+
+### Rate of Fire
+ROF is the sum of:
+- All guns with matching ammo Id (ReloadTime or RateOfFire/60).
+- All compatible racks (ReloadTime only).
+
+If ROF is 0, the crate scores 0 points.
+
+### Threat and Round Cost
+Penetration and blast are combined into a single threat factor:
+
 ```
-round_pts = BaseRoundPts
-            * (max_pen / RefPen) ^ PenExp
-            * (caliber_mm / RefCaliber)
-            * type_factor
+penFactor   = (maxPen / RefPen) ^ PenExp
+blastFactor = (blastMass / RefBlastMass) ^ BlastExp
+threat      = penFactor + blastFactor * BlastWeight
 
-crate_pts = round_pts * capacity * (rps_total / RpsRef) ^ RpsExp
+roundPts = BaseRoundPts * threat * (calMm / RefCaliber) * TypeFactor
+rpsFactor = (rpsTotal / RpsRef) ^ RpsExp
 ```
 
-### Current Constants
-- BaseRoundPts = 111.1
-- RefPen = 600
-- RefCaliber = 120
-- PenExp = 2
-- RpsRef = 1 / 7
-- RpsExp = 0.5
+### Ready Rack vs Backup Ammo
+Ready rounds and stowed rounds have different costs.
 
-### Max Pen Source
-- If BulletData.MaxPen exists, it is used.
-- Otherwise the round type display data is queried (ACF.RoundTypes[type].getDisplayData).
-- If no MaxPen can be resolved, the crate contributes 0 points.
+Ready rack cap (per ammo Id group):
+- Base: ReadyRackBase / caliber_mm
+- Clamp to [ReadyRackMin, ReadyRackMax]
+- If caliber is below ReadyRackPivot, apply a low-caliber boost:
+  baseCap *= 1 + ReadyRackLowBoost * ((pivot - cal) / pivot)
+- Clamp to total rounds in the group
+
+Ready allocation across crates:
+- Each ammo Id group shares a single readyCap.
+- Ready rounds are distributed proportionally by crate capacity.
+- Fractional remainder is distributed deterministically.
+
+Cost breakdown per crate:
+```
+readyCost = roundPts * readyCount * rpsFactor
+stowCost  = roundPts * stowCount * StowFactor * rpsFactor
+```
+
+Optional tail discount:
+- If TailFactor and TailStartMultiplier are set, rounds beyond
+  readyCap * TailStartMultiplier reduce effective rounds.
 
 ### Ammo Type Factors
+Ammo type factors are applied directly to roundPts:
+
 ```
-AP = 0.5,
-APHE = 0.6,
-APDS = 0.9,
-APFSDS = 1.2,
-HVAP = 0.7,
-HEAT = 0.75,
-HEATFS = 0.9,
-THEAT = 0.95,
-THEATFS = 1.0,
-HESH = 0.4,
-HE = 0.2,
-HEFS = 0.3,
-HP = 0.1,
-CAP = 0.6,
-CHEAT = 0.8,
-CHE = 0.25,
-CHF = 0,
-SM = 0,
-FLR = 0,
-FL = 0.3,
-GLATGM = 0.75,
-["GLATGM-HE"] = 0.25,
+AP = 0.5
+APHE = 0.6
+APDS = 0.9
+APFSDS = 1.2
+HVAP = 0.7
+HEAT = 0.75
+HEATFS = 0.9
+THEAT = 0.95
+THEATFS = 1.0
+HESH = 0.4
+HE = 0.5
+HEFS = 0.6
+HP = 0.1
+CAP = 0.6
+CHEAT = 0.8
+CHE = 0.25
+CHF = 0
+SM = 0
+FLR = 0
+FL = 0.3
+GLATGM = 0.75
+GLATGM-HE = 0.25
 Refill = 0
 ```
 
-## Other Point Categories
-- Armor: contraption-level scan result only.
-- Engines: uses existing per-entity ACEPoints.
-- Ammo: calculated as above from crates.
-- Crew: uses per-entity ACEPoints (crew seats).
-- Electronics: uses per-entity ACEPoints.
-- Fuel: ignored (0 points).
-- Firepower: guns/racks are tracked for ROF only and cost 0 points.
+## Caches and Performance
+### Non-Armor Cache
+Contraption.ACEAmmoCache stores:
+- GunRpsById
+- Racks
+- ReadyAlloc
 
-## Readout Format
-The armor tool shows a cost breakdown and a summary. Example format:
-```
-<||============|[- Cost Breakdown -]|============||>
-Total Cost: 12826.6pts  -  2826.6 pts over
-Armor scan: front=548.49mm  side=70.97mm
-Armor: (22%) - 2761.7/12826.6
-Engines: (11%) - 1409/12826.6
-Ammo: (58%) - 7453.9/12826.6
-Crew: (9%) - 1202/12826.6
-Electronics: (0%) - 0/12826.6
-- Top Cost Items:
-Ammo: 42x140mm APFSDS - Pen: 857, RPS: 0.06 - 4936.1pts
-Engines: 20.7L Flat 6 Multifuel - 1409.0pts
-Crew: Alex Popov - 400.0pts
-<||============|[- Contraption Summary -]|============||>
-...
-```
+When ACENonArmorDirty is false, ammo scoring uses this cached data.
 
-Top Cost Items behavior:
-- Sorted by points descending, stable by entity index.
-- Any item >= 300 pts is listed.
-- Ammo entries are formatted as: cap x caliber type - Pen: X, RPS: Y.
+### Dupe Armor Cache
+Armor scan results can be cached per duplication:
+- ACE.DupeArmorCache stores { Front, Side } by a hash of dupe content.
+- Hash inputs include class, model, bounds, and armor data.
+- ace_dupe_armor_cache_ttl (default 1800 seconds) clears the cache periodically.
+- ace_dupe_armor_cache_clear manually clears the cache.
+
+## Readout and UX
+The armor tool readout reports:
+- Total points and per-category percentages.
+- Armor scan front/side values in mm.
+- Ammo lines grouped by caliber and type, split into READY/BACKUP.
+- Contraption mass, material breakdown, and power-to-weight.
 
 Warnings:
-- If not initialized: "Armor cost not initialized; unfreeze or enter vehicle."
-- If dirty: "Armor cost dirty; respawn to recalc."
+- "ARMOR COST NOT INITIALIZED" if no scan has occurred.
+- "Armor cost dirty" if the contraption was modified after initialization.
 
-## Debug and Diagnostics
-- `ace_armor_debugvis` draws debug boxes at armor hit locations during a scan.
-- Colors scale from green to red relative to the max LOS value in that scan.
-- Console prints a single-line summary if debug is enabled.
+Preview mode (double-tap R):
+- Double-tap reload within ACE.ArmorPreviewTapWindow (default 0.35s).
+- Runs a hypothetical scan and non-armor rebuild.
+- Does not apply points to the contraption.
+- Cooldown is ACE.ArmorPreviewCooldown (default 5s).
 
-## Performance and Consistency
-- One scan per contraption at initialization; no continuous tracing during play.
-- Cached values are deterministic for a given contraption state.
-- Dirty changes are explicit rather than silent re-scans.
+## Global Warnings
+When a contraption exceeds limits, the system broadcasts a global chat message:
+- Over points limit (ACF.PointsLimit).
+- Over max weight (ACF.MaxWeight).
 
-## Edge Cases and Limitations
-- If a gun or rack has no compatible ammo in the contraption, ammo ROF is zero and crates score 0 points.
-- If MaxPen cannot be resolved for a round type, that crate scores 0.
-- If no axis-constrained MakeSpherical wheels exist, side uses cross(up, front) and may be less reliable on unusual builds.
-- If the main gun is vertical, the front vector is flattened; extreme cases fall back to base forward.
-- Post-init modifications can change actual protection without updating cost; this is intentional and surfaced as a warning.
+When a contraption is modified after initialization, a global warning is sent
+once per scan, and it resets after a successful rescan.
 
-## Tuning Knobs
-- AmmoCostConfig: BaseRoundPts, RefPen, RefCaliber, PenExp, RpsRef, RpsExp.
-- AmmoTypeFactors: per-type multipliers.
-- Armor cost scale: `(front + side * 2) * 4`.
-- Initialization timing: delay in ACE_ScheduleInitArmor.
+## Configuration Summary
+Key tuning values live in lua/autorun/acf_globals.lua:
 
-## Suggested Test Checklist
-- Spawn a contraption, do not unfreeze: readout shows "not initialized" warning.
-- Unfreeze: armor initializes and warning disappears.
-- Enter vehicle before unfreeze: armor initializes on entry.
-- Modify armor after init: readout shows "dirty" warning and costs remain fixed.
-- Test ammo crates with and without compatible guns/racks; confirm ROF scaling and label formatting.
-- Enable `ace_armor_debugvis` and verify debug boxes render at trace hit locations.
+```
+ACF.PointsLimit = 10000
+ACF.MaxWeight = 200000
+
+ACE.AmmoCostConfig = {
+    BaseRoundPts = 80,
+    RefPen = 600,
+    RefCaliber = 120,
+    PenExp = 1.6,
+    RefBlastMass = 6,
+    BlastExp = 1.1,
+    BlastWeight = 0.25,
+    RpsRef = 1 / 7,
+    RpsExp = 0.5,
+    ReadyRackBase = 2400,
+    ReadyRackMin = 10,
+    ReadyRackMax = 200,
+    ReadyRackPivot = 60,
+    ReadyRackLowBoost = 0.5,
+    StowFactor = 0.35,
+    TailFactor = 0,
+    TailStartMultiplier = 2
+}
+
+ACE.ArmorPreviewTapWindow = 0.35
+ACE.ArmorPreviewCooldown = 5
+
+ace_armor_debugvis (cvar)
+ace_dupe_armor_cache_ttl (cvar)
+```
+
+Entity ACEPoints are computed in the entity definitions (for example
+acf_engine and acf_gun) and then summed by the contraption system.
+
+## Known Behaviors and Edge Cases
+- If no critical components exist, armor scan returns 0 front/side.
+- If the main gun points straight up/down, the front vector is flattened.
+- If no wheel axis is found, side uses cross(up, front), then base right.
+- Non-ACF props, MakeSpherical wheels, and clipped surfaces are ignored in LOS.
+- Ammo with no compatible gun/rack, missing penetration, or zero type factor
+  contributes 0 points.
+- Classes not explicitly categorized are treated as Armor and only affect
+  points through the armor scan.

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -373,19 +373,19 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 
 	-- Spall armor factor bias
 	local ArmorMul	= MatData.ArmorMul or 1
-	
+
 	-- Cal of 3 = 30mm.
 	local Minimum_Caliber = 3
 
-	if SpallMul > 0 and Caliber > Minimum_Caliber then 
-	
+	if SpallMul > 0 and Caliber > Minimum_Caliber then
+
 		local WeightFactor = MatData.massMod or 1
 		-- local Max_Spall_Mass = 10
 
 		local Velocityfactor = 0.5
 		local Max_Spall_Vel = 7000
 		local MassFactor = 10
-		
+
 		local Max_Spalls = 128
 
 		-- print("KE: " .. KE)
@@ -402,10 +402,10 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 		SpallWeight = SpallWeight * MassFactor
 		local SpallArea = 4 * (TotalWeight / SpallWeight)
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
-		
+
 
 		-- print("AR: " .. SpallArea)
-		
+
 		-- print("TW: " .. TotalWeight)
 
 		-- print("SW: " .. SpallWeight)
@@ -579,7 +579,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 
 	-- Spall armor factor bias
 	local ArmorMul	= MatData.ArmorMul or 1
-	
+
 	local UsedArmor	= Armour * ArmorMul
 
 	if SpallMul > 0 and ( HEFiller / 300 ) > UsedArmor then
@@ -589,7 +589,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 
 		local Velocityfactor = 0.2
 		local Max_Spall_Vel = 7000
-		
+
 		local Max_Spalls = 128
 
 		-- print("HE: " .. HEFiller)
@@ -605,9 +605,9 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		local SpallVel = ((HEFiller * Velocityfactor) / SpallWeight)
 		local SpallArea = (TotalWeight / SpallWeight)
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
-		
+
 		-- print("AR: " .. SpallArea)
-		
+
 		-- print("TW: " .. TotalWeight)
 
 		-- print("SW: " .. SpallWeight)
@@ -616,7 +616,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		-- print("VEL: " .. SpallVel)
 
 		-- PrintTable(Filter)
-		
+
 		for i = 1,Spall do
 
 			ACE.CurSpallIndex = ACE.CurSpallIndex + 1
@@ -626,12 +626,12 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 
 			-- Normal Trace creation
 			local Index = ACE.CurSpallIndex
-			
+
 			ACE.Spall[Index]			= {}
 			ACE.Spall[Index].start	= HitPos
 			ACE.Spall[Index].endpos	= HitPos + ((fNormal * 2500 + HitVec):GetNormalized() + VectorRand() / 3):GetNormalized() * math.max( SpallVel / 8, 600) --I got bored of spall not going across the tank
 			ACE.Spall[Index].filter	= table.Copy(Temp_Filter)
-			
+
 			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor, SpallVel)
 
 			--little sound optimization
@@ -670,7 +670,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
-			
+
 				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
@@ -685,8 +685,8 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		local MatData	= ACE_GetMaterialData( Mat )
 
 		local spall_resistance = MatData.spallresist
-		
-		-- The clamp is due to that if the material spall resist/armor is below 1 then it multiplies the penetration. 
+
+		-- The clamp is due to that if the material spall resist/armor is below 1 then it multiplies the penetration.
 		-- ^ Clamp keeps the variable at 1 or higher.
 		-- Such as why I have ceramic/textolite resistence set to 1 as that means spall doesnt lose energy when hitting it.
 		-- Two/three reasons why this is good ^:
@@ -702,9 +702,9 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		if ACE.CritEnts[ SpallRes.Entity:GetClass() ] then
 			SpallEnergy.Penetration = (SpallEnergy.Penetration / Entity_Crit_Hit_Factor)
 		end
-		
+
 		SpallEnergy.Penetration = math.floor(SpallEnergy.Penetration)
-		
+
 		-- print(SpallEnergy.Penetration)
 
 		-- Applies the damage to the impacted entity
@@ -727,24 +727,24 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
-				
+
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
 			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
-			
+
 			SpallRes = util.TraceLine(ACE.Spall[Index])
 
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
 			-- Blue trace means spall trace that overpenned and killed something.
-			
+
 			-- Retry
 			ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
-		else 
-			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )	
+		else
+			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )
 			-- Red trace means spall trace that did hit something.
 		end
 

--- a/lua/acf/server/sv_contraption.lua
+++ b/lua/acf/server/sv_contraption.lua
@@ -316,4 +316,25 @@ end
 
 timer.Create( "PeriodicCleanup", 3, 0, ACE_refreshdata )
 
-hook.Add("AdvDupe_FinishPasting", "ACE_refresh", ACE_refreshdata)
+hook.Add("AdvDupe_FinishPasting", "ACE_refresh", function(dupeInfo)
+	local dupe = istable(dupeInfo) and dupeInfo[1]
+	local created = dupe and dupe.CreatedEntities
+	if not created then return end
+
+	local flagName = "_ACEAdvDupeRefresh"
+	local first
+	for _, ent in pairs(created) do
+		if IsValid(ent) then
+			first = ent
+			break
+		end
+	end
+	if not first or first[flagName] then return end
+	for _, ent in pairs(created) do
+		if IsValid(ent) then
+			ent[flagName] = true
+		end
+	end
+
+	ACE_refreshdata(dupeInfo)
+end)

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -11,6 +11,11 @@ function ACE_DoContraptionLegalCheck(CheckEnt) --In the future could allow true/
 	local Contraption = CheckEnt:GetContraption() or {}
 	if table.IsEmpty(Contraption) then return end
 
+	-- Recompute armor points on-demand when performing a legality check.
+	if ACE_EnsureArmor then
+		ACE_EnsureArmor(Contraption, CheckEnt)
+	end
+
 	ACE_CheckLegalCont(Contraption)
 
 end
@@ -20,6 +25,11 @@ function ACE_CheckLegalCont(Contraption)
 	Contraption.OTWarnings = Contraption.OTWarnings or {} --Used to remember all the one time warnings.
 	--Flag test
 	local HasWarned = false
+
+	-- Make sure armor points are up to date before evaluating limits.
+	if Contraption.ACEArmorDirty and Contraption.GetACEBaseplate then
+		ACE_EnsureArmor(Contraption, Contraption:GetACEBaseplate())
+	end
 
 	HasWarned = Contraption.OTWarnings.WarnedOverPoints or false
 	if Contraption.ACEPoints > ACF.PointsLimit and not HasWarned then
@@ -49,32 +59,361 @@ function ACE_CheckLegalCont(Contraption)
 end
 
 
+-- Optional hook to override per-prop point cost (e.g., trace-based armor checks).
+local function ACE_ApplyArmorOverride(ent, basePoints)
+	local override = hook.Run("ACE_CustomArmorPointOverride", ent, basePoints)
+
+	if override ~= nil then return override end
+
+	return basePoints
+end
+
+local armorDebugCvar = CreateConVar("ace_armor_debugvis", "0", FCVAR_ARCHIVE, "Draw debug overlays for armor scan results.")
+
+-- Best-effort contraption scanner for average frontal/side armor by surface area.
+-- Mirrors the E2 "FINAL Frontal Armor Surface Area Scanner" logic in a simplified per-prop form.
+local function ACE_CalcContraptionArmor(ent)
+	if not IsValid(ent) then return 0, 0 end
+
+	local contraption = ent.GetContraption and ent:GetContraption() or nil
+	local contraptionId = contraption and ACE_GetContraptionIndex and ACE_GetContraptionIndex(contraption) or (ent.ACF and ent.ACF.ContraptionId)
+	local contraptionEnts = {}
+
+	-- Prefer cfw contraption ents if available.
+	if contraption and contraption.ents then
+		for candidate in pairs(contraption.ents) do
+			if IsValid(candidate) then
+				contraptionEnts[#contraptionEnts + 1] = candidate
+			end
+		end
+	elseif contraptionId then
+		-- Fallback: match by contraption id we stored earlier.
+		for _, candidate in ipairs(ACE.contraptionEnts or {}) do
+			if not IsValid(candidate) then continue end
+			local candACF = candidate.ACF
+			if not candACF or candACF.ContraptionId ~= contraptionId then continue end
+			contraptionEnts[#contraptionEnts + 1] = candidate
+		end
+	end
+
+	-- Fallback: include the entity itself if nothing was found.
+	if #contraptionEnts == 0 then
+		contraptionEnts[1] = ent
+		--ACE_DebugArmor("No contraption set; falling back to single-entity scan for " .. tostring(ent))
+	end
+
+	-- Pick the main gun (largest caliber).
+	local mainGun
+	for _, candidate in ipairs(contraptionEnts) do
+		if IsValid(candidate) and candidate:GetClass() == "acf_gun" and candidate:GetModel() != "20mmsl" and candidate:GetModel() != "40mmsl" then
+			if not mainGun or (candidate.Caliber or 0) > (mainGun.Caliber or 0) then
+				mainGun = candidate
+			end
+		end
+	end
+
+	-- Direction setup.
+	local frontDir
+	local sideDir
+	if IsValid(mainGun) then
+		frontDir = -mainGun:GetForward()
+		sideDir = mainGun:GetRight()
+	else
+		frontDir = ent:GetForward() * -1
+		sideDir = ent:GetRight()
+	end
+
+	local function getBoundsWorld(prop)
+		local mins, maxs = prop:OBBMins(), prop:OBBMaxs()
+		local corners = {
+			Vector(mins.x, mins.y, mins.z),
+			Vector(mins.x, mins.y, maxs.z),
+			Vector(mins.x, maxs.y, mins.z),
+			Vector(mins.x, maxs.y, maxs.z),
+			Vector(maxs.x, mins.y, mins.z),
+			Vector(maxs.x, mins.y, maxs.z),
+			Vector(maxs.x, maxs.y, mins.z),
+			Vector(maxs.x, maxs.y, maxs.z)
+		}
+
+		for i, v in ipairs(corners) do
+			corners[i] = prop:LocalToWorld(v)
+		end
+
+		return corners
+	end
+
+	local function findUp(prop)
+		local corners = getBoundsWorld(prop)
+		local best, bestZ = corners[1], corners[1].z
+		for i = 2, #corners do
+			if corners[i].z > bestZ then
+				best = corners[i]
+				bestZ = corners[i].z
+			end
+		end
+		return prop:WorldToLocal(best)
+	end
+
+	local function findLeft(prop, sideDir, basePos)
+		local corners = getBoundsWorld(prop)
+		local target = basePos + sideDir * 1000
+		local best, bestDist = corners[1], corners[1]:Distance(target)
+		for i = 2, #corners do
+			local d = corners[i]:Distance(target)
+			if d < bestDist then
+				best = corners[i]
+				bestDist = d
+			end
+		end
+		return prop:WorldToLocal(best)
+	end
+
+	-- Critical components (targets)
+	local criticals = {}
+	for _, cent in ipairs(contraptionEnts) do
+		if not IsValid(cent) then continue end
+		local cls = cent:GetClass()
+		if cls == "acf_ammo" or cls == "acf_fueltank" or cls == "acf_engine" or cls == "ace_crewseat_gunner" or cls == "ace_crewseat_loader" or cls == "ace_crewseat_driver" then
+			criticals[#criticals + 1] = cent
+		end
+	end
+
+	local ignoredArmor = {
+		acf_gun = true,
+		acf_rack = true,
+		ace_crewseat_gunner = true,
+		ace_crewseat_loader = true,
+		ace_crewseat_driver = true
+	}
+
+	local function projectedArea(comp, dir)
+		dir = dir:GetNormalized()
+		local upHint = math.abs(dir.z) < 0.99 and Vector(0, 0, 1) or Vector(1, 0, 0)
+		local u = dir:Cross(upHint):GetNormalized()
+		local v = dir:Cross(u):GetNormalized()
+
+		local corners = getBoundsWorld(comp)
+		local minU, maxU = math.huge, -math.huge
+		local minV, maxV = math.huge, -math.huge
+
+		for _, wpos in ipairs(corners) do
+			local pu = wpos:Dot(u)
+			local pv = wpos:Dot(v)
+			if pu < minU then minU = pu end
+			if pu > maxU then maxU = pu end
+			if pv < minV then minV = pv end
+			if pv > maxV then maxV = pv end
+		end
+
+		return (maxU - minU) * (maxV - minV)
+	end
+
+	local function losFiltered(startPos, endPos, targetComp)
+		local filter = {}
+		local total = 0
+		local dir = (endPos - startPos):GetNormalized()
+		local dbg = armorDebugCvar:GetBool()
+		local hitTarget = false
+		local hullMins = Vector(-2, -2, -2)
+		local hullMaxs = Vector(2, 2, 2)
+
+		for _ = 1, 128 do
+			local tr = util.TraceHull({
+				start = startPos,
+				endpos = endPos,
+				mins = hullMins,
+				maxs = hullMaxs,
+				filter = filter,
+				mask = MASK_SOLID
+			})
+
+			if not tr.Hit then break end
+
+			local hitEnt = tr.Entity
+			if not IsValid(hitEnt) then break end
+
+			-- Ignore spheres made with MakeSpherical (no meaningful armor)
+			if hitEnt.RenderOverride and tostring(hitEnt.RenderOverride):find("MakeSpherical") then
+				filter[#filter + 1] = hitEnt
+				startPos = tr.HitPos + dir * 0.1
+				goto continue
+			end
+
+			if hitEnt == targetComp then
+				hitTarget = true
+				break
+			end
+
+			local cls = hitEnt:GetClass()
+			local skipArmor = ignoredArmor[cls] or not ACF_Check(hitEnt)
+			if skipArmor then
+				filter[#filter + 1] = hitEnt
+				startPos = tr.HitPos + dir * 0.1
+			else
+				if ACF_CheckClips(hitEnt, tr.HitPos) then
+					filter[#filter + 1] = hitEnt
+					startPos = tr.HitPos + dir * 0.1
+				else
+					local Mat = hitEnt.ACF.Material or "RHA"
+					local MatData = ACE_GetMaterialData(Mat)
+					local armor = hitEnt.ACF.Armour or 0
+					local armorData = hitEnt.acfPropArmorData and hitEnt:acfPropArmorData()
+					local eff = (armorData and armorData.Effectiveness) or (MatData and MatData.effectiveness) or 1
+					local curve = (armorData and armorData.Curve) or 1
+					local ang = ACF_GetHitAngle(tr.HitNormal, dir)
+					local los
+
+					if ang >= 89 then
+						los = (armor ^ curve) * eff
+					else
+						local cosAng = math.max(math.cos(math.rad(ang)), 0.01)
+						los = (armor / (cosAng ^ ACF.SlopeEffectFactor)) ^ curve
+						los = los * eff
+					end
+
+					total = total + los
+
+					if dbg and los > 100 then
+						debugoverlay.Text(tr.HitPos, string.format("LOS %.1f", los), 30, true)
+					end
+				end
+
+			filter[#filter + 1] = hitEnt
+			startPos = tr.HitPos + dir * 0.1
+		end
+		end
+
+		if not hitTarget then
+			return 0
+		end
+
+		return total
+	end
+
+	local countFront, countSide = 0, 0
+	local accumFront, accumSide = 0, 0
+
+	for _, comp in ipairs(criticals) do
+		local center = comp:WorldSpaceCenter()
+		local size = comp:OBBMaxs() - comp:OBBMins()
+		local up = comp:GetUp()
+		local right = comp:GetRight()
+
+		local frontArea = projectedArea(comp, frontDir)
+		local sideArea  = projectedArea(comp, sideDir)
+		local sampleCount = 5
+		local weightF = frontArea / sampleCount
+		local weightS = sideArea / sampleCount
+
+		local halfUp = up * (size.z * 0.5 * 0.95)
+		local halfRight = right * (size.y * 0.5 * 0.95)
+
+		local samples = {
+			center,
+			center + halfUp,
+			center - halfUp,
+			center + halfRight,
+			center - halfRight
+		}
+
+		for _, pt in ipairs(samples) do
+			local frontStart = pt - frontDir * 500
+			local frontEnd   = pt 
+			local sideStart  = pt - sideDir * 500
+			local sideEnd    = pt 
+
+			-- Front: take the forward trace only.
+			local frontVal = losFiltered(frontStart, frontEnd, comp)
+
+			-- Side: trace from both directions and take the lesser valid value.
+			local sideValA  = losFiltered(sideStart, sideEnd, comp)
+			local sideValB  = losFiltered(pt + sideDir * 500, pt - sideDir * 50, comp)
+			local sideVal = math.min(sideValA > 0 and sideValA or math.huge, sideValB > 0 and sideValB or math.huge)
+			if sideVal == math.huge then sideVal = 0 end
+
+			-- Area-weighted averaging; only include weights if we got a hit.
+			if frontVal > 0 then
+				accumFront = accumFront + frontVal * weightF
+				countFront = countFront + weightF
+			end
+
+			if sideVal > 0 then
+				accumSide = accumSide + sideVal * weightS
+				countSide = countSide + weightS
+			end
+
+			if armorDebugCvar:GetBool() then
+				debugoverlay.Text(pt, string.format("F %.1f | S %.1f", frontVal or 0, sideVal or 0), 30, true)
+			end
+		end
+	end
+
+	local avgFront = countFront > 0 and (accumFront / countFront) or 0
+	local avgSide = countSide > 0 and (accumSide / countSide) or 0
+
+	-- Side weighting (x2) per request.
+	return avgFront, avgSide * 2
+	end
+
+function ACE_GetArmorScan(ent)
+	return ACE_CalcContraptionArmor(ent)
+end
+
+-- Ensure contraption armor points are up to date and reflected in totals.
+function ACE_EnsureArmor(Contraption, baseEnt)
+	if not Contraption then return end
+	if not Contraption.ACEArmorDirty then return end
+
+	local base = baseEnt
+	if (not IsValid(base)) and Contraption.GetACEBaseplate then
+		base = Contraption:GetACEBaseplate()
+	end
+
+	local front = 0
+	if IsValid(base) then
+		local f, s = ACE_CalcContraptionArmor(base)
+		front = f
+		Contraption.ACEArmorFront = f
+		Contraption.ACEArmorSide = s
+	end
+
+	local side = Contraption.ACEArmorSide or 0
+	-- Final armor cost: (front + side*2) * 4
+	local newArmorPts = (front + side * 2) * 4
+	local oldArmor = Contraption.ACEPointsPerType and Contraption.ACEPointsPerType.Armor or 0
+
+	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
+	Contraption.ACEPointsPerType.Armor = newArmorPts
+
+	Contraption.ACEArmorPoints = newArmorPts
+	Contraption.ACEArmorDirty = false
+
+	local nonArmor = Contraption.ACEPointsNonArmor or 0
+	Contraption.ACEPoints = nonArmor + newArmorPts
+
+	if armorDebugCvar:GetBool() then
+		print(string.format("[ACE ArmorDbg] Front=%.2f Side=%.2f Pts(x4)=%.2f", front or 0, side or 0, newArmorPts))
+		if IsValid(base) then
+			debugoverlay.Text(base:WorldSpaceCenter(), string.format("F %.2f | S %.2f | Pts(x4) %.2f", front or 0, side or 0, newArmorPts), 30, true)
+		end
+	end
+end
 
 function ACE_GetEntPoints(Ent, MassOverride)
 	local Points = 0 --Use the specially assigned points if it has them
+	--[[ Old mass/material-based point calculation retained for reference.
+	if IsValid(Ent) then
+		-- legacy mass/material calc here...
+	end
+	]]
 
+	if not IsValid(Ent) then return 0 end
 
-	if IsValid(Ent) then --Used to exclude entities with special points. Could exploit this by using said entities as armor. Now it's in addition to.
-
-		if not MassOverride then
-			local phys = Ent:GetPhysicsObject()
-			if IsValid(phys) then
-				Points = phys:GetMass() / 1000 * ACF.PointsPerTon
-				local EACF = Ent.ACF or {}
-				local Mat = EACF.Material or "RHA"
-				local DuctMul = 1 / ( 1 + (EACF.Ductility or 1) ) ^ 0.5 --Counteracts the weight bonus from ductility.
-
-				Points = Points * (ACE.MatCostTables[Mat] or 1) * DuctMul
-			end
-		else
-			Points = MassOverride / 1000 * ACF.PointsPerTon
-			local EACF = Ent.ACF or {}
-			local Mat = EACF.Material or "RHA"
-			local DuctMul = 1 / ( 1 + (EACF.Ductility or 1) ) ^ 0.5 --Counteracts the weight bonus from ductility.
-
-			Points = Points * (ACE.MatCostTables[Mat] or 1) * DuctMul
-		end
-
+	local class = Ent:GetClass()
+	if class == "prop_physics" or class == "primitive_shape" or class == "primitive_airfoil" or class == "primitive_rail_slider" or class == "primitive_slider" or class == "primitive_ladder" then
+		-- Armor cost is handled at contraption-level (E2-style scan). Per-prop points are zero.
+		return 0
 	end
 
 	Points = Points + (Ent.ACEPoints or 0)
@@ -83,8 +422,6 @@ function ACE_GetEntPoints(Ent, MassOverride)
 end
 
 do
-
-
 	--Used for setweight update checks. This is such a hacky way to do things.
 	local PHYS    = FindMetaTable("PhysObj")
 	local ACE_Override_SetMass = ACE_Override_SetMass or PHYS.SetMass
@@ -151,6 +488,9 @@ do
 
 	local function ACE_InitPts(Class)
 		Class.ACEPoints = 0
+		Class.ACEPointsNonArmor = 0
+		Class.ACEArmorPoints = 0
+		Class.ACEArmorDirty = true
 
 		Class.ACEPointsPerType = {}
 		Class.ACEPointsPerType.Armor = 0
@@ -169,18 +509,19 @@ do
 	function ACE_AddPts(Class, Ent)
 		if not IsValid(Ent) then return end
 
-		--local Mass = PhysObj:GetMass()
-
 		local AcePts = ACE_GetEntPoints(Ent)
 
 		Ent._AcePts     = AcePts
 
-		Class.ACEPoints = Class.ACEPoints + AcePts
-
 		local EClass = ACE_getPtsType(Ent:GetClass())
-		Class.ACEPointsPerType[EClass] = Class.ACEPointsPerType[EClass] + AcePts
 
-		--print(Class.ACEPoints)
+		if EClass == "Armor" then
+			Class.ACEArmorDirty = true
+		else
+			Class.ACEPoints = Class.ACEPoints + AcePts
+			Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + AcePts
+			Class.ACEPointsPerType[EClass] = Class.ACEPointsPerType[EClass] + AcePts
+		end
 	end
 	hook.Add("cfw.contraption.entityAdded", "ACE_AddPoints", ACE_AddPts)
 	hook.Add("cfw.family.added", "ACE_AddPoints", ACE_AddPts)
@@ -188,13 +529,19 @@ do
 	function ACE_RemPts(Class, Ent)
 		if not IsValid(Ent) then return end
 
-		local AcePts = ACE_GetEntPoints(Ent)
+		local EClass = ACE_getPtsType(Ent:GetClass())
+
+		if EClass == "Armor" then
+			Class.ACEArmorDirty = true
+			return
+		end
+
+		local AcePts = Ent._AcePts or 0 -- avoid heavy recalcs on removal
 
 		Class.ACEPoints = Class.ACEPoints - AcePts
+		Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) - AcePts
 
-		local EClass = ACE_getPtsType(Ent:GetClass())
 		Class.ACEPointsPerType[EClass] = Class.ACEPointsPerType[EClass] - AcePts
-		--print(EClass .. ": " .. Class.ACEPointsPerType[EClass])
 	end
 
 	hook.Add("cfw.contraption.entityRemoved", "ACE_RemPoints", ACE_RemPts)

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -102,16 +102,6 @@ function ACE_CheckLegalCont(Contraption)
 
 end
 
-
--- Optional hook to override per-prop point cost (e.g., trace-based armor checks).
-local function ACE_ApplyArmorOverride(ent, basePoints)
-	local override = hook.Run("ACE_CustomArmorPointOverride", ent, basePoints)
-
-	if override ~= nil then return override end
-
-	return basePoints
-end
-
 local armorDebugCvar = CreateConVar("ace_armor_debugvis", "0", FCVAR_ARCHIVE, "Draw debug overlays for armor scan results.")
 
 -- Best-effort contraption scanner for average frontal/side armor by surface area.
@@ -149,10 +139,12 @@ local function ACE_CalcContraptionArmor(ent)
 	-- Pick the main gun (largest caliber).
 	local mainGun
 	for _, candidate in ipairs(contraptionEnts) do
-		if IsValid(candidate) and candidate:GetClass() == "acf_gun" and candidate:GetModel() != "models/launcher/20mmsl.mdl" and candidate:GetModel() != "models/launcher/40mmsl.mdl" then
-			if not mainGun or (candidate.Caliber or 0) > (mainGun.Caliber or 0) then
-				mainGun = candidate
-			end
+		if IsValid(candidate)
+			and candidate:GetClass() == "acf_gun"
+			and candidate:GetModel() ~= "models/launcher/20mmsl.mdl"
+			and candidate:GetModel() ~= "models/launcher/40mmsl.mdl"
+			and (not mainGun or (candidate.Caliber or 0) > (mainGun.Caliber or 0)) then
+			mainGun = candidate
 		end
 	end
 
@@ -185,32 +177,6 @@ local function ACE_CalcContraptionArmor(ent)
 		end
 
 		return corners
-	end
-
-	local function findUp(prop)
-		local corners = getBoundsWorld(prop)
-		local best, bestZ = corners[1], corners[1].z
-		for i = 2, #corners do
-			if corners[i].z > bestZ then
-				best = corners[i]
-				bestZ = corners[i].z
-			end
-		end
-		return prop:WorldToLocal(best)
-	end
-
-	local function findLeft(prop, sideDir, basePos)
-		local corners = getBoundsWorld(prop)
-		local target = basePos + sideDir * 1000
-		local best, bestDist = corners[1], corners[1]:Distance(target)
-		for i = 2, #corners do
-			local d = corners[i]:Distance(target)
-			if d < bestDist then
-				best = corners[i]
-				bestDist = d
-			end
-		end
-		return prop:WorldToLocal(best)
 	end
 
 	-- Critical components (targets)
@@ -255,27 +221,6 @@ local function ACE_CalcContraptionArmor(ent)
 		local area = (maxU - minU) * (maxV - minV)
 
 		return area, halfU, halfV
-	end
-
-	-- Move a point onto the outer face of an OBB along a given direction.
-	local function pushPointToFace(comp, dir, pos)
-		dir = dir:GetNormalized()
-		local center = comp:WorldSpaceCenter()
-		local centerDot = center:Dot(dir)
-
-		local maxDiff = -math.huge
-		local minDiff = math.huge
-		for _, corner in ipairs(getBoundsWorld(comp)) do
-			local diff = corner:Dot(dir) - centerDot
-			if diff > maxDiff then maxDiff = diff end
-			if diff < minDiff then minDiff = diff end
-		end
-
-		local targetDiff = maxDiff
-		local ptDiff = pos:Dot(dir) - centerDot
-		local delta = targetDiff - ptDiff
-
-		return pos + dir * delta
 	end
 
 	local function losFiltered(startPos, endPos, targetComp)
@@ -407,9 +352,9 @@ local function ACE_CalcContraptionArmor(ent)
 
 		for _, pt in ipairs(samples) do
 			local frontStart = pt - frontDir * 500
-			local frontEnd   = pt 
+			local frontEnd   = pt
 			local sideStart  = pt - sideDir * 500
-			local sideEnd    = pt 
+			local sideEnd    = pt
 
 			-- Front: take the forward trace only.
 			local frontVal, frontHitPos, frontHitNormal = losFiltered(frontStart, frontEnd, comp)
@@ -511,8 +456,6 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 	local side = Contraption.ACEArmorSide or 0
 	-- Final armor cost: (front + side*2) * 4
 	local newArmorPts = (front + side * 2) * 4
-	local oldArmor = Contraption.ACEPointsPerType and Contraption.ACEPointsPerType.Armor or 0
-
 	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
 	Contraption.ACEPointsPerType.Armor = newArmorPts
 
@@ -531,7 +474,7 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 	end
 end
 
-function ACE_GetEntPoints(Ent, MassOverride)
+function ACE_GetEntPoints(Ent)
 	local Points = 0 --Use the specially assigned points if it has them
 	--[[ Old mass/material-based point calculation retained for reference.
 	if IsValid(Ent) then
@@ -610,7 +553,7 @@ do
 		local ent     = self:GetEntity()
 		local oldPointValue = ent._AcePts or 0 -- The 'or 0' handles cases of ents connected before they had a physObj
 
-		ent._AcePts = ACE_GetEntPoints(ent,mass)
+	ent._AcePts = ACE_GetEntPoints(ent)
 
 		ACE_Override_SetMass(self,mass)
 

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -1,5 +1,16 @@
 
 
+ACE = ACE or {}
+
+local ArmorClasses = {
+	prop_physics = true,
+	primitive_shape = true,
+	primitive_airfoil = true,
+	primitive_rail_slider = true,
+	primitive_slider = true,
+	primitive_ladder = true
+}
+
 function ACE_DoContraptionLegalCheck(CheckEnt) --In the future could allow true/false to stop the vehicle from working.
 
 	CheckEnt.CanLegalCheck = CheckEnt.CanLegalCheck or false
@@ -11,13 +22,51 @@ function ACE_DoContraptionLegalCheck(CheckEnt) --In the future could allow true/
 	local Contraption = CheckEnt:GetContraption() or {}
 	if table.IsEmpty(Contraption) then return end
 
-	-- Recompute armor points on-demand when performing a legality check.
-	if ACE_EnsureArmor then
-		ACE_EnsureArmor(Contraption, CheckEnt)
-	end
-
 	ACE_CheckLegalCont(Contraption)
 
+end
+
+do
+	local function ACE_GetContraptionFromEntity(ent)
+		if not IsValid(ent) then return end
+		if not ent.GetContraption then return end
+
+		local con = ent:GetContraption()
+		if not con or not con.ents or table.IsEmpty(con.ents) then return end
+
+		return con
+	end
+
+	local function ACE_ScheduleInitArmor(con)
+		if not con then return end
+		if con.ACEArmorCalculated then return end
+		if not con.ACEArmorDirty then return end
+		if con.ACEArmorInitQueued then return end
+
+		con.ACEArmorInitQueued = true
+		timer.Simple(0.1, function()
+			con.ACEArmorInitQueued = nil
+			if not con or con.ACEArmorCalculated or not con.ACEArmorDirty then return end
+			if not con.GetACEBaseplate then return end
+
+			local base = con:GetACEBaseplate()
+			if IsValid(base) then
+				ACE_EnsureArmor(con, base)
+			end
+		end)
+	end
+
+	hook.Add("PlayerUnfrozeObject", "ACE_ArmorInitOnUnfreeze", function(_, ent)
+		local con = ACE_GetContraptionFromEntity(ent)
+		if not con then return end
+		ACE_ScheduleInitArmor(con)
+	end)
+
+	hook.Add("PlayerEnteredVehicle", "ACE_ArmorInitOnEntry", function(_, veh)
+		local con = ACE_GetContraptionFromEntity(veh)
+		if not con then return end
+		ACE_ScheduleInitArmor(con)
+	end)
 end
 
 function ACE_CheckLegalCont(Contraption)
@@ -25,11 +74,6 @@ function ACE_CheckLegalCont(Contraption)
 	Contraption.OTWarnings = Contraption.OTWarnings or {} --Used to remember all the one time warnings.
 	--Flag test
 	local HasWarned = false
-
-	-- Make sure armor points are up to date before evaluating limits.
-	if Contraption.ACEArmorDirty and Contraption.GetACEBaseplate then
-		ACE_EnsureArmor(Contraption, Contraption:GetACEBaseplate())
-	end
 
 	HasWarned = Contraption.OTWarnings.WarnedOverPoints or false
 	if Contraption.ACEPoints > ACF.PointsLimit and not HasWarned then
@@ -105,7 +149,7 @@ local function ACE_CalcContraptionArmor(ent)
 	-- Pick the main gun (largest caliber).
 	local mainGun
 	for _, candidate in ipairs(contraptionEnts) do
-		if IsValid(candidate) and candidate:GetClass() == "acf_gun" and candidate:GetModel() != "20mmsl" and candidate:GetModel() != "40mmsl" then
+		if IsValid(candidate) and candidate:GetClass() == "acf_gun" and candidate:GetModel() != "models/launcher/20mmsl.mdl" and candidate:GetModel() != "models/launcher/40mmsl.mdl" then
 			if not mainGun or (candidate.Caliber or 0) > (mainGun.Caliber or 0) then
 				mainGun = candidate
 			end
@@ -210,7 +254,7 @@ local function ACE_CalcContraptionArmor(ent)
 		local halfV = (maxV - minV) * 0.5
 		local area = (maxU - minU) * (maxV - minV)
 
-		return area, halfU, halfV, u, v
+		return area, halfU, halfV
 	end
 
 	-- Move a point onto the outer face of an OBB along a given direction.
@@ -240,6 +284,8 @@ local function ACE_CalcContraptionArmor(ent)
 		local dir = (endPos - startPos):GetNormalized()
 		local dbg = armorDebugCvar:GetBool()
 		local hitTarget = false
+		local hitPos
+		local hitNormal
 		local hullMins = Vector(-2, -2, -2)
 		local hullMaxs = Vector(2, 2, 2)
 
@@ -267,6 +313,10 @@ local function ACE_CalcContraptionArmor(ent)
 
 			if not skip and hitEnt == targetComp then
 				hitTarget = true
+				if not hitPos then
+					hitPos = tr.HitPos
+					hitNormal = tr.HitNormal
+				end
 				break
 			end
 
@@ -303,6 +353,10 @@ local function ACE_CalcContraptionArmor(ent)
 				end
 
 				total = total + los
+				if not hitPos then
+					hitPos = tr.HitPos
+					hitNormal = tr.HitNormal
+				end
 
 				if dbg and los > 100 then
 					debugoverlay.Text(tr.HitPos, string.format("LOS %.1f", los), 30, true)
@@ -317,7 +371,7 @@ local function ACE_CalcContraptionArmor(ent)
 			return 0
 		end
 
-		return total
+		return total, hitPos, hitNormal
 	end
 
 	local countFront, countSide = 0, 0
@@ -329,8 +383,8 @@ local function ACE_CalcContraptionArmor(ent)
 		local up = comp:GetUp()
 		local right = comp:GetRight()
 
-			local frontArea, frontHalfU, frontHalfV, frontU, frontV = projectedData(comp, frontDir)
-			local sideArea, sideHalfU, sideHalfV, sideU, sideV = projectedData(comp, sideDir)
+		local frontArea, frontHalfU, frontHalfV = projectedData(comp, frontDir)
+		local sideArea, sideHalfU, sideHalfV = projectedData(comp, sideDir)
 
 		local halfUp = up * (size.z * 0.5 * 0.95)
 		local halfRight = right * (size.y * 0.5 * 0.95)
@@ -345,8 +399,11 @@ local function ACE_CalcContraptionArmor(ent)
 		local sampleCount = #samples
 		local weightF = sampleCount > 0 and (frontArea / sampleCount) or 0
 		local weightS = sampleCount > 0 and (sideArea / sampleCount) or 0
-
-		local frontAng = frontDir:Angle()
+		local sampleScale = sampleCount > 0 and (1 / math.sqrt(sampleCount)) or 0
+		local frontHalfUSample = (frontHalfU or 0) * sampleScale
+		local frontHalfVSample = (frontHalfV or 0) * sampleScale
+		local sideHalfUSample = (sideHalfU or 0) * sampleScale
+		local sideHalfVSample = (sideHalfV or 0) * sampleScale
 
 		for _, pt in ipairs(samples) do
 			local frontStart = pt - frontDir * 500
@@ -355,14 +412,26 @@ local function ACE_CalcContraptionArmor(ent)
 			local sideEnd    = pt 
 
 			-- Front: take the forward trace only.
-			local frontVal = losFiltered(frontStart, frontEnd, comp)
+			local frontVal, frontHitPos, frontHitNormal = losFiltered(frontStart, frontEnd, comp)
 
 			-- Side: trace from both directions and take the lesser valid value.
-			local sideValA  = losFiltered(sideStart, sideEnd, comp)
-			local sideValB  = losFiltered(pt + sideDir * 500, pt - sideDir * 50, comp)
-			local sideVal = math.min(sideValA > 0 and sideValA or math.huge, sideValB > 0 and sideValB or math.huge)
-			if sideVal == math.huge then sideVal = 0 end
-			local sideDirUsed = sideVal > 0 and ((sideValA > 0 and sideValA <= sideValB) and sideDir or -sideDir) or sideDir
+			local sideValA, sideHitPosA, sideHitNormalA  = losFiltered(sideStart, sideEnd, comp)
+			local sideValB, sideHitPosB, sideHitNormalB  = losFiltered(pt + sideDir * 500, pt - sideDir * 50, comp)
+			local sideVal = 0
+			local sideDirUsed = sideDir
+			local sideHitPos
+			local sideHitNormal
+			if sideValA > 0 and (sideValB <= 0 or sideValA <= sideValB) then
+				sideVal = sideValA
+				sideDirUsed = sideDir
+				sideHitPos = sideHitPosA
+				sideHitNormal = sideHitNormalA
+			elseif sideValB > 0 then
+				sideVal = sideValB
+				sideDirUsed = -sideDir
+				sideHitPos = sideHitPosB
+				sideHitNormal = sideHitNormalB
+			end
 
 			-- Area-weighted averaging; only include weights if we got a hit.
 			if frontVal > 0 then
@@ -375,39 +444,43 @@ local function ACE_CalcContraptionArmor(ent)
 				countSide = countSide + weightS
 			end
 
-				if armorDebugCvar:GetBool() then
-					local function colorFromVal(v)
-						local ratio = math.min(math.max((v or 0) / 500, 0), 1)
-						return 255 * ratio, 255 * (1 - ratio)
-					end
+			if armorDebugCvar:GetBool() then
+				local function colorFromVal(v)
+					local ratio = math.min(math.max((v or 0) / 500, 0), 1)
+					return 255 * ratio, 255 * (1 - ratio)
+				end
 
-						local thickness = 0.01
-						local frontHalfUSample = frontHalfU * 0.5
-						local frontHalfVSample = frontHalfV * 0.5
-						local sideHalfUSample = sideHalfU * 0.5
-						local sideHalfVSample = sideHalfV * 0.5
+				local thickness = 0.1
+				local markerSize = math.max(2, math.min(size.x, size.y, size.z) * 0.05)
 
-						if frontArea > 0 then
-							local r, g = colorFromVal(frontVal)
-							local frontPos = pushPointToFace(comp, -frontDir, pt)
-							debugoverlay.BoxAngles(frontPos, Vector(-thickness, -frontHalfUSample, -frontHalfVSample), Vector(thickness, frontHalfUSample, frontHalfVSample), frontAng, 30, Color(r, g, 0, 0.01))
-						end
+				local function drawMarker(hitPos, hitNormal, fallbackNormal, val, halfU, halfV)
+					if not hitPos then return end
+					local normal = hitNormal or fallbackNormal
+					if not normal then return end
+					local r, g = colorFromVal(val)
+					local ang = normal:Angle()
+					local pos = hitPos + normal * 0.1
+					local u = halfU or markerSize
+					local v = halfV or markerSize
+					debugoverlay.BoxAngles(pos, Vector(-thickness, -u, -v), Vector(thickness, u, v), ang, 30, Color(r, g, 0, 0.1))
+				end
 
-						if sideArea > 0 then
-							local r, g = colorFromVal(sideVal)
-							local sidePos = pushPointToFace(comp, sideDirUsed, pt)
-							local sideAng = sideDirUsed:Angle()
-							debugoverlay.BoxAngles(sidePos, Vector(-thickness, -sideHalfUSample, -sideHalfVSample), Vector(thickness, sideHalfUSample, sideHalfVSample), sideAng, 30, Color(r, g, 0, 0.01))
-						end
-					end
+				if frontArea > 0 and frontVal > 0 then
+					drawMarker(frontHitPos, frontHitNormal, -frontDir, frontVal, frontHalfUSample, frontHalfVSample)
+				end
+
+				if sideArea > 0 and sideVal > 0 then
+					drawMarker(sideHitPos, sideHitNormal, -sideDirUsed, sideVal, sideHalfUSample, sideHalfVSample)
 				end
 			end
+		end
+	end
 
 	local avgFront = countFront > 0 and (accumFront / countFront) or 0
 	local avgSide = countSide > 0 and (accumSide / countSide) or 0
 
-	-- Side weighting (x2) per request.
-	return avgFront, avgSide * 2
+	-- Side weighting is handled in the cost calculation.
+	return avgFront, avgSide
 	end
 
 function ACE_GetArmorScan(ent)
@@ -415,9 +488,12 @@ function ACE_GetArmorScan(ent)
 end
 
 -- Ensure contraption armor points are up to date and reflected in totals.
-function ACE_EnsureArmor(Contraption, baseEnt)
+function ACE_EnsureArmor(Contraption, baseEnt, force)
 	if not Contraption then return end
-	if not Contraption.ACEArmorDirty then return end
+	if not force then
+		if not Contraption.ACEArmorDirty then return end
+		if Contraption.ACEArmorCalculated and Contraption.ACEArmorDirty then return end
+	end
 
 	local base = baseEnt
 	if (not IsValid(base)) and Contraption.GetACEBaseplate then
@@ -442,6 +518,7 @@ function ACE_EnsureArmor(Contraption, baseEnt)
 
 	Contraption.ACEArmorPoints = newArmorPts
 	Contraption.ACEArmorDirty = false
+	Contraption.ACEArmorCalculated = true
 
 	local nonArmor = Contraption.ACEPointsNonArmor or 0
 	Contraption.ACEPoints = nonArmor + newArmorPts
@@ -465,7 +542,7 @@ function ACE_GetEntPoints(Ent, MassOverride)
 	if not IsValid(Ent) then return 0 end
 
 	local class = Ent:GetClass()
-	if class == "prop_physics" or class == "primitive_shape" or class == "primitive_airfoil" or class == "primitive_rail_slider" or class == "primitive_slider" or class == "primitive_ladder" then
+	if ArmorClasses[class] then
 		-- Armor cost is handled at contraption-level (E2-style scan). Per-prop points are zero.
 		return 0
 	end
@@ -479,21 +556,6 @@ do
 	--Used for setweight update checks. This is such a hacky way to do things.
 	local PHYS    = FindMetaTable("PhysObj")
 	local ACE_Override_SetMass = ACE_Override_SetMass or PHYS.SetMass
-	function PHYS:SetMass(mass)
-
-		local ent     = self:GetEntity()
-		local oldPointValue = ent._AcePts or 0 -- The 'or 0' handles cases of ents connected before they had a physObj
-
-		ent._AcePts = ACE_GetEntPoints(ent,mass)
-
-		ACE_Override_SetMass(self,mass)
-
-		local con = ent:GetContraption()
-
-		if con then
-			con.ACEPoints = con.ACEPoints + (ent._AcePts - oldPointValue)
-		end
-	end
 
 	local FirepowerEnts = {
 		["acf_rack"]                  = true,
@@ -518,26 +580,55 @@ do
 	}
 
 	local function ACE_getPtsType(ClassName)
-		local RetVal = "Armor"
-
-		if ClassName == "prop_physics" then
-			--Do nothing. Bypass to skip all the later checks for most common parts.
-			RetVal = "Armor" --In circumstances like these, I HATE LINTER. Useless redundant callout but I have to have it to prevent the chain from being empty.
-		elseif ClassName == "acf_engine" then
-			RetVal = "Engines"
-		elseif FirepowerEnts[ClassName] then
-			RetVal = "Firepower"
-		elseif ClassName == "acf_fueltank" then
-			RetVal = "Fuel"
-		elseif ClassName == "acf_ammo" then
-			RetVal = "Ammo"
-		elseif CrewEnts[ClassName] then
-			RetVal = "Crew"
-		elseif ElectronicEnts[ClassName] then
-			RetVal = "Electronics"
+		if ArmorClasses[ClassName] then
+			return "Armor"
+		end
+		if ClassName == "acf_engine" then
+			return "Engines"
+		end
+		if FirepowerEnts[ClassName] then
+			return "Firepower"
+		end
+		if ClassName == "acf_fueltank" then
+			return "Fuel"
+		end
+		if ClassName == "acf_ammo" then
+			return "Ammo"
+		end
+		if CrewEnts[ClassName] then
+			return "Crew"
+		end
+		if ElectronicEnts[ClassName] then
+			return "Electronics"
 		end
 
-		return RetVal
+		return "Armor"
+	end
+
+	function PHYS:SetMass(mass)
+
+		local ent     = self:GetEntity()
+		local oldPointValue = ent._AcePts or 0 -- The 'or 0' handles cases of ents connected before they had a physObj
+
+		ent._AcePts = ACE_GetEntPoints(ent,mass)
+
+		ACE_Override_SetMass(self,mass)
+
+		local con = ent:GetContraption()
+		if not con then return end
+
+		local delta = ent._AcePts - oldPointValue
+		local eclass = ACE_getPtsType(ent:GetClass())
+
+		if eclass == "Armor" then
+			con.ACEArmorDirty = true
+			return
+		end
+
+		con.ACEPoints = (con.ACEPoints or 0) + delta
+		con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) + delta
+		con.ACEPointsPerType = con.ACEPointsPerType or {}
+		con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) + delta
 	end
 
 	local function ACE_InitPts(Class)
@@ -545,6 +636,7 @@ do
 		Class.ACEPointsNonArmor = 0
 		Class.ACEArmorPoints = 0
 		Class.ACEArmorDirty = true
+		Class.ACEArmorCalculated = false
 
 		Class.ACEPointsPerType = {}
 		Class.ACEPointsPerType.Armor = 0

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -71,8 +71,8 @@ local AmmoTypeFactors = {
 	THEAT = 0.95,
 	THEATFS = 1.0,
 	HESH = 0.4,
-	HE = 0.2,
-	HEFS = 0.3,
+	HE = 0.5,
+	HEFS = 0.6,
 	HP = 0.1,
 	CAP = 0.6,
 	CHEAT = 0.8,
@@ -89,12 +89,23 @@ local AmmoTypeFactors = {
 -- Normalization constants for the ammo formula; tune these to rebalance without
 -- rewriting the math.
 local AmmoCostConfig = {
-	BaseRoundPts = 80,
-	RefPen = 600,
-	RefCaliber = 120,
-	PenExp = 2,
-	RpsRef = 1 / 7,
-	RpsExp = 0.5
+	BaseRoundPts = 80, -- Base points per round before scaling.
+	RefPen = 600, -- Reference penetration (mm) for pen scaling.
+	RefCaliber = 120, -- Reference caliber (mm) for caliber scaling.
+	PenExp = 1.6, -- Penetration curve exponent.
+	RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
+	BlastExp = 1.1, -- Blast curve exponent.
+	BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
+	RpsRef = 1 / 7, -- Reference rounds per second for ROF scaling.
+	RpsExp = 0.5, -- ROF curve exponent.
+	ReadyRackBase = 2400, -- Ready rack baseline: base / caliber(mm).
+	ReadyRackMin = 10, -- Minimum ready rounds per gun group.
+	ReadyRackMax = 200, -- Maximum ready rounds per gun group.
+	ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
+	ReadyRackLowBoost = 0.5, -- Boost factor applied below pivot (0.5 = +50%).
+	StowFactor = 0.35, -- Cost multiplier for stowed rounds.
+	TailFactor = 0, -- Extra discount per round beyond tail start (0 disables).
+	TailStartMultiplier = 2 -- Tail start = readyCap * multiplier.
 }
 
 ACE.AmmoTypeFactors = AmmoTypeFactors
@@ -132,31 +143,90 @@ local function ACE_GetAmmoTypeFactor(ammoType)
 	return AmmoTypeFactors[ammoType] or 1
 end
 
+local function ACE_GetReadyRackCap(calMm, totalRounds)
+	local readyBase = AmmoCostConfig.ReadyRackBase or 0
+	local readyMax = AmmoCostConfig.ReadyRackMax or 0
+	if readyBase <= 0 or readyMax <= 0 then return 0 end
+
+	local readyMin = AmmoCostConfig.ReadyRackMin or 0
+	local pivot = AmmoCostConfig.ReadyRackPivot or 0
+	local lowBoost = AmmoCostConfig.ReadyRackLowBoost or 0
+
+	local baseCap = readyBase / math.max(calMm, 1)
+	if pivot > 0 and lowBoost > 0 and calMm < pivot then
+		local ratio = (pivot - calMm) / pivot
+		baseCap = baseCap * (1 + lowBoost * ratio)
+	end
+
+	local cap = math.Clamp(baseCap, readyMin, readyMax)
+	if totalRounds and totalRounds > 0 then
+		cap = math.min(cap, totalRounds)
+	end
+
+	return math.floor(cap + 0.5)
+end
+
 local function ACE_GetAmmoMaxPen(bulletData)
 	if not bulletData then return 0 end
-	if bulletData.MaxPen then return bulletData.MaxPen end
+
+	local maxPen = tonumber(bulletData.MaxPen) or 0
+	if bulletData.MaxPen2 then
+		maxPen = math.max(maxPen, tonumber(bulletData.MaxPen2) or 0)
+	end
+
+	if maxPen > 0 then
+		return maxPen
+	end
+
+	local function getBlastPen(data)
+		local filler = data.BoomFillerMass or data.FillerMass or 0
+		local hePower = ACF and ACF.HEPower or 0
+		local blastDiv = ACF and ACF.HEBlastPenetration or 0
+		if filler <= 0 or hePower <= 0 or blastDiv <= 0 then return 0 end
+		return (filler * hePower) / blastDiv
+	end
 
 	local roundType = bulletData.Type
 	local round = roundType and ACF.RoundTypes and ACF.RoundTypes[roundType]
 	if round and round.getDisplayData then
 		local ok, display = pcall(round.getDisplayData, bulletData)
 		if ok and istable(display) then
-			return display.MaxPen or 0
+			maxPen = math.max(maxPen, display.MaxPen or 0, display.MaxPen2 or 0)
 		end
 	end
 
-	return 0
+	if maxPen <= 0 then
+		maxPen = getBlastPen(bulletData)
+	end
+
+	return maxPen
 end
 
 local function ACE_GetAmmoCaliberMm(bulletData)
 	if not bulletData then return 0 end
 
-	local cal = bulletData.Caliber
-	if not cal and bulletData.Id then
-		cal = ACF_GetGunValue(bulletData.Id, "caliber")
+	local cal = bulletData.Caliber or 0
+	local slug = bulletData.SlugCaliber or 0
+	local slug2 = bulletData.SlugCaliber2 or 0
+	local jet = bulletData.JetCaliber or 0
+	local best = math.max(cal, slug, slug2, jet)
+
+	if best <= 0 and bulletData.Id then
+		best = ACF_GetGunValue(bulletData.Id, "caliber") or 0
 	end
 
-	return (cal or 0) * 10
+	return best * 10
+end
+
+local function ACE_GetAmmoBlastMass(bulletData)
+	if not bulletData then return 0 end
+
+	local mass = tonumber(bulletData.BoomFillerMass) or 0
+	if mass <= 0 then
+		mass = tonumber(bulletData.FillerMass) or 0
+	end
+
+	return mass
 end
 
 local function ACE_GetGunRps(ent)
@@ -176,7 +246,7 @@ local function ACE_GetRackRps(ent)
 	return 0
 end
 
-local function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks)
+local function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 	if not IsValid(crate) then return 0 end
 
 	local bdata = crate.BulletData
@@ -186,7 +256,8 @@ local function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks)
 	if rounds <= 0 then return 0 end
 
 	local maxPen = ACE_GetAmmoMaxPen(bdata)
-	if maxPen <= 0 then return 0 end
+	local blastMass = ACE_GetAmmoBlastMass(bdata)
+	if maxPen <= 0 and blastMass <= 0 then return 0 end
 
 	local calMm = ACE_GetAmmoCaliberMm(bdata)
 	if calMm <= 0 then return 0 end
@@ -212,21 +283,61 @@ local function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks)
 	if rpsTotal <= 0 then return 0 end
 
 	local penFactor = (maxPen / AmmoCostConfig.RefPen) ^ AmmoCostConfig.PenExp
+	local blastFactor = 0
+	local blastRef = AmmoCostConfig.RefBlastMass
+	if blastMass > 0 and blastRef and blastRef > 0 then
+		blastFactor = (blastMass / blastRef) ^ AmmoCostConfig.BlastExp
+	end
+	local threatFactor = penFactor + blastFactor * AmmoCostConfig.BlastWeight
+	if threatFactor <= 0 then return 0 end
 	local calFactor = calMm / AmmoCostConfig.RefCaliber
 	local rpsFactor = (rpsTotal / AmmoCostConfig.RpsRef) ^ AmmoCostConfig.RpsExp
-	local roundPts = AmmoCostConfig.BaseRoundPts * penFactor * calFactor * typeFactor
+	local roundPts = AmmoCostConfig.BaseRoundPts * threatFactor * calFactor * typeFactor
+	local stowFactor = AmmoCostConfig.StowFactor or 1
+	local tailFactor = AmmoCostConfig.TailFactor or 0
+	local tailStartMul = AmmoCostConfig.TailStartMultiplier or 0
+	local effectiveRounds = rounds
+	local readyCap = ACE_GetReadyRackCap(calMm, rounds)
+	local readyCount = rounds
+	local stowCount = 0
+
+	if readyCap > 0 then
+		readyCount = readyCap
+		stowCount = math.max(rounds - readyCount, 0)
+		effectiveRounds = readyCount + stowCount * stowFactor
+		if tailFactor > 0 and tailStartMul > 0 then
+			local tailStart = readyCap * tailStartMul
+			local tail = math.max(rounds - tailStart, 0)
+			if tail > 0 then
+				effectiveRounds = effectiveRounds - tail * tailFactor
+			end
+		end
+		if effectiveRounds < 0 then
+			effectiveRounds = 0
+		end
+	end
 
 	local name = ACF_GetGunValue(ammoId, "name") or tostring(ammoId)
+	if readyAlloc and readyAlloc[crate] then
+		readyCount = math.min(readyAlloc[crate], rounds)
+		stowCount = math.max(rounds - readyCount, 0)
+	end
+	local readyCost = roundPts * readyCount * rpsFactor
+	local stowCost = roundPts * stowCount * stowFactor * rpsFactor
 	local detail = {
 		Name = name,
 		Type = bdata.Type or "",
 		Caliber = calMm,
 		Capacity = rounds,
 		MaxPen = maxPen,
-		Rps = rpsTotal
+		Rps = rpsTotal,
+		ReadyCount = readyCount,
+		StowCount = stowCount,
+		ReadyCost = readyCost,
+		StowCost = stowCost
 	}
 
-	return roundPts * rounds * rpsFactor, detail
+	return readyCost + stowCost, detail
 end
 
 -- Rate-limit legal checks per entity to prevent spam and allow future policy hooks.
@@ -984,13 +1095,140 @@ local function ACE_GetContraptionEntities(Contraption, fallbackEnt)
 	return ents
 end
 
-local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
-	if not Contraption then return end
+local function ACE_BuildAmmoReadyAlloc(ents)
+	local readyBase = AmmoCostConfig.ReadyRackBase or 0
+	local readyMax = AmmoCostConfig.ReadyRackMax or 0
+	if readyBase <= 0 or readyMax <= 0 then return nil end
+
+	local groups = {}
+
+	for _, ent in ipairs(ents) do
+		if not IsValid(ent) then continue end
+		if ent:GetClass() ~= "acf_ammo" then continue end
+
+		local bdata = ent.BulletData
+		if not bdata then continue end
+
+		local rounds = ent.Capacity or 0
+		if rounds <= 0 then continue end
+
+		local ammoId = bdata.Id
+		if not ammoId then continue end
+
+		local calMm = ACE_GetAmmoCaliberMm(bdata)
+		if calMm <= 0 then continue end
+
+		local group = groups[ammoId]
+		if not group then
+			group = {
+				calMm = calMm,
+				total = 0,
+				entries = {}
+			}
+			groups[ammoId] = group
+		end
+
+		group.total = group.total + rounds
+		group.entries[#group.entries + 1] = {
+			ent = ent,
+			rounds = rounds
+		}
+	end
+
+	local alloc = {}
+
+	for _, group in pairs(groups) do
+		local total = group.total or 0
+		if total <= 0 then continue end
+
+		local readyCap = ACE_GetReadyRackCap(group.calMm, total)
+		if readyCap <= 0 then continue end
+
+		local entries = {}
+		local remaining = readyCap
+		for _, entry in ipairs(group.entries) do
+			local raw = readyCap * entry.rounds / total
+			local base = math.floor(raw)
+			remaining = remaining - base
+			entries[#entries + 1] = {
+				ent = entry.ent,
+				rounds = entry.rounds,
+				ready = base,
+				frac = raw - base
+			}
+		end
+
+		table.sort(entries, function(a, b)
+			if a.frac == b.frac then
+				if a.rounds == b.rounds then
+					return tostring(a.ent) < tostring(b.ent)
+				end
+				return a.rounds < b.rounds
+			end
+			return a.frac > b.frac
+		end)
+
+		for _, entry in ipairs(entries) do
+			if remaining <= 0 then break end
+			if entry.ready < entry.rounds then
+				entry.ready = entry.ready + 1
+				remaining = remaining - 1
+			end
+		end
+
+		for _, entry in ipairs(entries) do
+			alloc[entry.ent] = entry.ready
+		end
+	end
+
+	if next(alloc) == nil then return nil end
+	return alloc
+end
+
+function ACE_GetAmmoCratePointsForContraption(crate, Contraption, fallbackEnt)
+	if not IsValid(crate) then return 0 end
+
+	local ents = ACE_GetContraptionEntities(Contraption, fallbackEnt or crate)
+	local gunRpsById = {}
+	local racks = {}
+	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents)
+
+	for _, ent in ipairs(ents) do
+		if not IsValid(ent) then continue end
+		local cls = ent:GetClass()
+		if cls == "acf_gun" then
+			local id = ent.Id
+			local rps = ACE_GetGunRps(ent)
+			if id and rps > 0 then
+				gunRpsById[id] = (gunRpsById[id] or 0) + rps
+			end
+		elseif cls == "acf_rack" then
+			racks[#racks + 1] = ent
+		end
+	end
+
+	return ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
+end
+
+function ACE_CalcNonArmorPoints(Contraption, baseEnt)
+	if not Contraption then
+		return 0, {
+			Engines = 0,
+			Firepower = 0,
+			Ammo = 0,
+			Crew = 0,
+			Electronics = 0
+		}, { Items = {} }
+	end
 
 	local totals = {
 		Engines = 0,
 		Firepower = 0,
 		Ammo = 0,
+		AmmoReady = 0,
+		AmmoBackup = 0,
+		AmmoReadyRounds = 0,
+		AmmoBackupRounds = 0,
 		Crew = 0,
 		Electronics = 0
 	}
@@ -999,6 +1237,23 @@ local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
 	local gunRpsById = {}
 	local racks = {}
 	local detailItems = {}
+	local ammoLines = {}
+	local function addAmmoLine(state, caliber, ammoType, count)
+		if not count or count <= 0 then return end
+		local calKey = caliber and math.floor(caliber + 0.5) or 0
+		if calKey <= 0 then return end
+		local typeKey = ammoType ~= "" and ammoType or "Ammo"
+		local key = string.format("%s|%d|%s", state, calKey, typeKey)
+		if not ammoLines[key] then
+			ammoLines[key] = {
+				State = state,
+				Caliber = calKey,
+				Type = typeKey,
+				Count = 0
+			}
+		end
+		ammoLines[key].Count = ammoLines[key].Count + count
+	end
 	local minDetailPts = 300
 
 	local function getEntityLabel(ent)
@@ -1030,31 +1285,40 @@ local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
 			racks[#racks + 1] = ent
 		end
 	end
+	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents)
 
 	for _, ent in ipairs(ents) do
 		if not IsValid(ent) then continue end
 
 		local cls = ent:GetClass()
 		if cls == "acf_ammo" then
-			local pts, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks)
+			local pts, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks, readyAlloc)
 			if pts > 0 then
 				nonArmor = nonArmor + pts
 				totals.Ammo = (totals.Ammo or 0) + pts
 				if detail then
+					totals.AmmoReady = (totals.AmmoReady or 0) + (detail.ReadyCost or 0)
+					totals.AmmoBackup = (totals.AmmoBackup or 0) + (detail.StowCost or 0)
+					totals.AmmoReadyRounds = (totals.AmmoReadyRounds or 0) + (detail.ReadyCount or 0)
+					totals.AmmoBackupRounds = (totals.AmmoBackupRounds or 0) + (detail.StowCount or 0)
+
 					local ammoType = detail.Type ~= "" and detail.Type or "Ammo"
-					local cap = math.floor((detail.Capacity or 0) + 0.5)
-					local cal = math.floor((detail.Caliber or 0) + 0.5)
-					local pen = math.floor((detail.MaxPen or 0) + 0.5)
-					local rps = detail.Rps or 0
-					local label = string.format(
-						"%dx%.0fmm %s - Pen: %.0f, RPS: %.2f",
-						cap,
-						cal,
-						ammoType,
-						pen,
-						rps
-					)
-					addDetail("Ammo", label, pts, ent)
+					local readyCount = math.floor((detail.ReadyCount or 0) + 0.5)
+					local stowCount = math.floor((detail.StowCount or 0) + 0.5)
+					local readyCost = detail.ReadyCost or 0
+					local stowCost = detail.StowCost or 0
+
+					if readyCount > 0 then
+						local label = string.format("Ready rack %s x%d", ammoType, readyCount)
+						addDetail("Ammo", label, readyCost, ent)
+					end
+					if stowCount > 0 then
+						local label = string.format("Backup ammo %s x%d", ammoType, stowCount)
+						addDetail("Ammo", label, stowCost, ent)
+					end
+
+					addAmmoLine("READY", detail.Caliber, ammoType, readyCount)
+					addAmmoLine("BACKUP", detail.Caliber, ammoType, stowCount)
 				end
 			end
 			continue
@@ -1090,12 +1354,32 @@ local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
 		end
 	end
 
+	local ammoList = {}
+	for _, entry in pairs(ammoLines) do
+		if entry.Count and entry.Count > 0 then
+			ammoList[#ammoList + 1] = {
+				State = entry.State,
+				Caliber = entry.Caliber,
+				Type = entry.Type,
+				Count = math.floor(entry.Count + 0.5)
+			}
+		end
+	end
+
+	return nonArmor, totals, { Items = trimmed, AmmoLines = ammoList }
+end
+
+local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
+	if not Contraption then return end
+
+	local nonArmor, totals, details = ACE_CalcNonArmorPoints(Contraption, baseEnt)
+
 	Contraption.ACEPointsNonArmor = nonArmor
 	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
 	for key, value in pairs(totals) do
 		Contraption.ACEPointsPerType[key] = value
 	end
-	Contraption.ACEPointsDetails = { Items = trimmed }
+	Contraption.ACEPointsDetails = details
 end
 
 -- Rebuild armor points when dirty and synchronize totals for the breakdown.
@@ -1236,6 +1520,10 @@ do
 		Class.ACEPointsPerType.Engines = 0
 		Class.ACEPointsPerType.Firepower = 0
 		Class.ACEPointsPerType.Ammo = 0
+		Class.ACEPointsPerType.AmmoReady = 0
+		Class.ACEPointsPerType.AmmoBackup = 0
+		Class.ACEPointsPerType.AmmoReadyRounds = 0
+		Class.ACEPointsPerType.AmmoBackupRounds = 0
 		Class.ACEPointsPerType.Crew = 0
 		Class.ACEPointsPerType.Electronics = 0
 	end

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -520,8 +520,17 @@ do
 end
 
 
+
+local function ACE_HasArmorInit(Contraption)
+	if not Contraption then return false end
+	if Contraption.ACEArmorCalculated then return true end
+	local lastCalc = Contraption.ACEArmorLastCalc or 0
+	return lastCalc > 0
+end
+
+
 local function ACE_NotifyContraptionModified(Contraption)
-	if not Contraption or not Contraption.ACEArmorCalculated then return end
+	if not ACE_HasArmorInit(Contraption) then return end
 
 	Contraption.OTWarnings = Contraption.OTWarnings or {}
 	if Contraption.OTWarnings.WarnedModified then return end
@@ -543,6 +552,10 @@ function ACE_CheckLegalCont(Contraption)
 	-- Track one-time warning flags per contraption to avoid repeated spam.
 	Contraption.OTWarnings = Contraption.OTWarnings or {}
 	local HasWarned = false
+
+	if Contraption.ACEArmorDirty then
+		ACE_NotifyContraptionModified(Contraption)
+	end
 
 	HasWarned = Contraption.OTWarnings.WarnedOverPoints or false
 	if Contraption.ACEPoints > ACF.PointsLimit and not HasWarned then
@@ -1562,6 +1575,7 @@ do
 		if Ent._ACEPointsConRef == conRef then
 			if EClass == "Armor" then
 				Class.ACEArmorDirty = true
+				ACE_NotifyContraptionModified(Class)
 			else
 				local delta = newPts - oldPts
 				if delta ~= 0 then

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -11,13 +11,207 @@ local ArmorClasses = {
 	primitive_ladder = true
 }
 
-function ACE_DoContraptionLegalCheck(CheckEnt) --In the future could allow true/false to stop the vehicle from working.
+local FirepowerEnts = {
+	["acf_rack"]                  = true,
+	["acf_gun"]                   = true
+}
+local CrewEnts = {
+	["ace_crewseat_gunner"]                  = true,
+	["ace_crewseat_loader"]                  = true,
+	["ace_crewseat_driver"]                  = true
+}
+local ElectronicEnts = {
+	["ace_rwr_dir"]                  = true,
+	["ace_rwr_sphere"]               = true,
+	["acf_missileradar"]             = true,
+	["acf_opticalcomputer"]          = true,
+	["ace_ecm"]                      = true,
+	["ace_trackingradar"]            = true,
+	["ace_searchradar"]              = true,
+	["ace_irst"]                     = true,
+	["ace_sonar"]                    = true,
+	["ace_crewseat_driver"]          = true
+}
+
+local function ACE_GetPtsType(ClassName)
+	if ArmorClasses[ClassName] then
+		return "Armor"
+	end
+	if ClassName == "acf_engine" then
+		return "Engines"
+	end
+	if ClassName == "acf_fueltank" then
+		return "Ignore"
+	end
+	if FirepowerEnts[ClassName] then
+		return "Firepower"
+	end
+	if ClassName == "acf_ammo" then
+		return "Ammo"
+	end
+	if CrewEnts[ClassName] then
+		return "Crew"
+	end
+	if ElectronicEnts[ClassName] then
+		return "Electronics"
+	end
+
+	return "Armor"
+end
+
+-- Ammo scoring model.
+-- Per-round cost scales with max penetration, caliber, and ammo type factor.
+-- Total crate cost multiplies per-round cost by capacity and summed compatible ROF.
+local AmmoTypeFactors = {
+	AP = 0.5,
+	APHE = 0.6,
+	APDS = 0.9,
+	APFSDS = 1.2,
+	HVAP = 0.7,
+	HEAT = 0.75,
+	HEATFS = 0.9,
+	THEAT = 0.95,
+	THEATFS = 1.0,
+	HESH = 0.4,
+	HE = 0.2,
+	HEFS = 0.3,
+	HP = 0.1,
+	CAP = 0.6,
+	CHEAT = 0.8,
+	CHE = 0.25,
+	CHF = 0,
+	SM = 0,
+	FLR = 0,
+	FL = 0.3,
+	GLATGM = 0.75,
+	["GLATGM-HE"] = 0.25,
+	Refill = 0
+}
+
+-- Normalization constants for the ammo formula; tune these to rebalance without
+-- rewriting the math.
+local AmmoCostConfig = {
+	BaseRoundPts = 111.1,
+	RefPen = 600,
+	RefCaliber = 120,
+	PenExp = 2,
+	RpsRef = 1 / 7,
+	RpsExp = 0.5
+}
+
+ACE.AmmoTypeFactors = AmmoTypeFactors
+ACE.AmmoCostConfig = AmmoCostConfig
+
+local function ACE_GetAmmoTypeFactor(ammoType)
+	return AmmoTypeFactors[ammoType] or 1
+end
+
+local function ACE_GetAmmoMaxPen(bulletData)
+	if not bulletData then return 0 end
+	if bulletData.MaxPen then return bulletData.MaxPen end
+
+	local roundType = bulletData.Type
+	local round = roundType and ACF.RoundTypes and ACF.RoundTypes[roundType]
+	if round and round.getDisplayData then
+		local ok, display = pcall(round.getDisplayData, bulletData)
+		if ok and istable(display) then
+			return display.MaxPen or 0
+		end
+	end
+
+	return 0
+end
+
+local function ACE_GetAmmoCaliberMm(bulletData)
+	if not bulletData then return 0 end
+
+	local cal = bulletData.Caliber
+	if not cal and bulletData.Id then
+		cal = ACF_GetGunValue(bulletData.Id, "caliber")
+	end
+
+	return (cal or 0) * 10
+end
+
+local function ACE_GetGunRps(ent)
+	local reload = ent.ReloadTime
+	if reload and reload > 0 then return 1 / reload end
+
+	local rof = ent.RateOfFire
+	if rof and rof > 0 then return rof / 60 end
+
+	return 0
+end
+
+local function ACE_GetRackRps(ent)
+	local reload = ent.ReloadTime
+	if reload and reload > 0 then return 1 / reload end
+
+	return 0
+end
+
+local function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks)
+	if not IsValid(crate) then return 0 end
+
+	local bdata = crate.BulletData
+	if not bdata then return 0 end
+
+	local rounds = crate.Capacity or 0
+	if rounds <= 0 then return 0 end
+
+	local maxPen = ACE_GetAmmoMaxPen(bdata)
+	if maxPen <= 0 then return 0 end
+
+	local calMm = ACE_GetAmmoCaliberMm(bdata)
+	if calMm <= 0 then return 0 end
+
+	local typeFactor = ACE_GetAmmoTypeFactor(bdata.Type)
+	if typeFactor <= 0 then return 0 end
+
+	local ammoId = bdata.Id
+	if not ammoId then return 0 end
+
+	local rpsTotal = gunRpsById[ammoId] or 0
+	if racks and ACF_CanLinkRack then
+		for _, rack in ipairs(racks) do
+			if IsValid(rack) and rack.Id then
+				local ok = ACF_CanLinkRack(rack.Id, ammoId, bdata, rack)
+				if ok then
+					rpsTotal = rpsTotal + ACE_GetRackRps(rack)
+				end
+			end
+		end
+	end
+
+	if rpsTotal <= 0 then return 0 end
+
+	local penFactor = (maxPen / AmmoCostConfig.RefPen) ^ AmmoCostConfig.PenExp
+	local calFactor = calMm / AmmoCostConfig.RefCaliber
+	local rpsFactor = (rpsTotal / AmmoCostConfig.RpsRef) ^ AmmoCostConfig.RpsExp
+	local roundPts = AmmoCostConfig.BaseRoundPts * penFactor * calFactor * typeFactor
+
+	local name = ACF_GetGunValue(ammoId, "name") or tostring(ammoId)
+	local detail = {
+		Name = name,
+		Type = bdata.Type or "",
+		Caliber = calMm,
+		Capacity = rounds,
+		MaxPen = maxPen,
+		Rps = rpsTotal
+	}
+
+	return roundPts * rounds * rpsFactor, detail
+end
+
+-- Rate-limit legal checks per entity to prevent spam and allow future policy hooks.
+function ACE_DoContraptionLegalCheck(CheckEnt)
 
 	CheckEnt.CanLegalCheck = CheckEnt.CanLegalCheck or false
 	if not CheckEnt.CanLegalCheck then return end
 
 	CheckEnt.CanLegalCheck = false
-	timer.Simple(3, function() if IsValid(CheckEnt) then CheckEnt.CanLegalCheck = true end end) --Reallows the legal check after 3 seconds to prevent spam.
+	-- Re-enable checks after a short cooldown.
+	timer.Simple(3, function() if IsValid(CheckEnt) then CheckEnt.CanLegalCheck = true end end)
 
 	local Contraption = CheckEnt:GetContraption() or {}
 	if table.IsEmpty(Contraption) then return end
@@ -37,42 +231,103 @@ do
 		return con
 	end
 
-	local function ACE_ScheduleInitArmor(con)
-		if not con then return end
-		if con.ACEArmorCalculated then return end
-		if not con.ACEArmorDirty then return end
-		if con.ACEArmorInitQueued then return end
+	local function ACE_IsContraptionFrozen(con)
+		if not con or not con.GetACEBaseplate then return false end
 
-		con.ACEArmorInitQueued = true
-		timer.Simple(0.1, function()
-			con.ACEArmorInitQueued = nil
-			if not con or con.ACEArmorCalculated or not con.ACEArmorDirty then return end
+		local base = con:GetACEBaseplate()
+		if not IsValid(base) then return false end
+
+		local phys = base:GetPhysicsObject()
+		if not IsValid(phys) then return false end
+
+		return not phys:IsMotionEnabled()
+	end
+
+	local function ACE_GetArmorTimerId(con)
+		if con.ACEArmorTimerId then return con.ACEArmorTimerId end
+		local index = ACE_GetContraptionIndex and ACE_GetContraptionIndex(con) or tostring(con)
+		con.ACEArmorTimerId = "ACE_ArmorInit_" .. index
+
+		return con.ACEArmorTimerId
+	end
+
+	local function ACE_ScheduleInitArmor(con, delay, force)
+		if not con then return end
+
+		if not force and con.ACEArmorCalculated and not con.ACEArmorDirty then return end
+
+		local requestedDelay = delay or 0.1
+		local queuedDelay = con.ACEArmorQueuedDelay or 0
+		local nextDelay = math.max(requestedDelay, queuedDelay)
+
+		con.ACEArmorQueuedDelay = nextDelay
+		con.ACEArmorQueuedForce = con.ACEArmorQueuedForce or force
+
+		timer.Create(ACE_GetArmorTimerId(con), nextDelay, 1, function()
+			if not con then return end
+			local useForce = con.ACEArmorQueuedForce
+			con.ACEArmorQueuedForce = nil
+			con.ACEArmorQueuedDelay = nil
+
 			if not con.GetACEBaseplate then return end
+			if not useForce and con.ACEArmorCalculated and not con.ACEArmorDirty then return end
 
 			local base = con:GetACEBaseplate()
 			if IsValid(base) then
-				ACE_EnsureArmor(con, base)
+				ACE_EnsureArmor(con, base, useForce)
+				con.ACEArmorLastCalc = CurTime()
 			end
 		end)
+	end
+
+	local function ACE_ScheduleInitArmorFromEntities(entities, delay, force, skipFrozen)
+		if not istable(entities) then return end
+		local scheduled = {}
+
+		for _, ent in pairs(entities) do
+			if not IsValid(ent) then continue end
+			local con = ACE_GetContraptionFromEntity(ent)
+			if not con or scheduled[con] then continue end
+			if skipFrozen and ACE_IsContraptionFrozen(con) then continue end
+			scheduled[con] = true
+			ACE_ScheduleInitArmor(con, delay, force)
+		end
 	end
 
 	hook.Add("PlayerUnfrozeObject", "ACE_ArmorInitOnUnfreeze", function(_, ent)
 		local con = ACE_GetContraptionFromEntity(ent)
 		if not con then return end
-		ACE_ScheduleInitArmor(con)
+		ACE_ScheduleInitArmor(con, 0.1, false)
 	end)
 
 	hook.Add("PlayerEnteredVehicle", "ACE_ArmorInitOnEntry", function(_, veh)
 		local con = ACE_GetContraptionFromEntity(veh)
 		if not con then return end
-		ACE_ScheduleInitArmor(con)
+		ACE_ScheduleInitArmor(con, 0.1, false)
+	end)
+
+	hook.Add("AdvDupe_FinishPasting", "ACE_ArmorInitOnDupePaste", function(dupeInfo)
+		local dupe = istable(dupeInfo) and dupeInfo[1]
+		local created = dupe and dupe.CreatedEntities
+		if not created then return end
+
+		timer.Simple(0, function()
+			ACE_ScheduleInitArmorFromEntities(created, 0.05, false, true)
+		end)
+
+		timer.Simple(0.5, function()
+			ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true)
+			timer.Simple(0.8, function()
+				ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true)
+			end)
+		end)
 	end)
 end
 
 function ACE_CheckLegalCont(Contraption)
 
-	Contraption.OTWarnings = Contraption.OTWarnings or {} --Used to remember all the one time warnings.
-	--Flag test
+	-- Track one-time warning flags per contraption to avoid repeated spam.
+	Contraption.OTWarnings = Contraption.OTWarnings or {}
 	local HasWarned = false
 
 	HasWarned = Contraption.OTWarnings.WarnedOverPoints or false
@@ -86,7 +341,6 @@ function ACE_CheckLegalCont(Contraption)
 		Contraption.OTWarnings.WarnedOverPoints = true
 	end
 
-	--HasWarned = Contraption.OTWarnings.WarnedOverWeight or false
 	if Contraption.totalMass > ACF.MaxWeight and not HasWarned then
 		local Ply = Contraption:GetACEBaseplate():CPPIGetOwner()
 		local AboveAmt = Contraption.totalMass - ACF.MaxWeight
@@ -97,15 +351,13 @@ function ACE_CheckLegalCont(Contraption)
 		Contraption.OTWarnings.WarnedOverWeight = true
 	end
 
-	--chatMessageGlobal( message, color)
-
-
 end
 
 local armorDebugCvar = CreateConVar("ace_armor_debugvis", "0", FCVAR_ARCHIVE, "Draw debug overlays for armor scan results.")
 
--- Best-effort contraption scanner for average frontal/side armor by surface area.
--- Mirrors the E2 "FINAL Frontal Armor Surface Area Scanner" logic in a simplified per-prop form.
+-- Estimate contraption frontal/side armor using line-of-sight traces.
+-- Samples multiple points on critical components and weights by projected area
+-- to stabilize results across irregular geometry.
 local function ACE_CalcContraptionArmor(ent)
 	if not IsValid(ent) then return 0, 0 end
 
@@ -113,7 +365,7 @@ local function ACE_CalcContraptionArmor(ent)
 	local contraptionId = contraption and ACE_GetContraptionIndex and ACE_GetContraptionIndex(contraption) or (ent.ACF and ent.ACF.ContraptionId)
 	local contraptionEnts = {}
 
-	-- Prefer cfw contraption ents if available.
+	-- Prefer the framework contraption list when available for a complete entity set.
 	if contraption and contraption.ents then
 		for candidate in pairs(contraption.ents) do
 			if IsValid(candidate) then
@@ -121,7 +373,7 @@ local function ACE_CalcContraptionArmor(ent)
 			end
 		end
 	elseif contraptionId then
-		-- Fallback: match by contraption id we stored earlier.
+		-- Fallback to cached entities that match the stored contraption id.
 		for _, candidate in ipairs(ACE.contraptionEnts or {}) do
 			if not IsValid(candidate) then continue end
 			local candACF = candidate.ACF
@@ -130,25 +382,32 @@ local function ACE_CalcContraptionArmor(ent)
 		end
 	end
 
-	-- Fallback: include the entity itself if nothing was found.
+	-- As a last resort, scan only the base entity.
 	if #contraptionEnts == 0 then
 		contraptionEnts[1] = ent
-		--ACE_DebugArmor("No contraption set; falling back to single-entity scan for " .. tostring(ent))
+	end
+	if #contraptionEnts > 1 then
+		table.sort(contraptionEnts, function(a, b)
+			return a:EntIndex() < b:EntIndex()
+		end)
 	end
 
-	-- Pick the main gun (largest caliber).
+	-- Use the largest-caliber gun to infer vehicle facing when available.
 	local mainGun
 	for _, candidate in ipairs(contraptionEnts) do
 		if IsValid(candidate)
 			and candidate:GetClass() == "acf_gun"
 			and candidate:GetModel() ~= "models/launcher/20mmsl.mdl"
 			and candidate:GetModel() ~= "models/launcher/40mmsl.mdl"
-			and (not mainGun or (candidate.Caliber or 0) > (mainGun.Caliber or 0)) then
+			and candidate:GetModel() ~= "models/launcher/40mmgl.mdl"
+			and (not mainGun
+				or (candidate.Caliber or 0) > (mainGun.Caliber or 0)
+				or ((candidate.Caliber or 0) == (mainGun.Caliber or 0) and candidate:EntIndex() < mainGun:EntIndex())) then
 			mainGun = candidate
 		end
 	end
 
-	-- Direction setup.
+	-- Establish scan directions (front/side) from the chosen reference.
 	local frontDir
 	local sideDir
 	if IsValid(mainGun) then
@@ -158,6 +417,10 @@ local function ACE_CalcContraptionArmor(ent)
 		frontDir = ent:GetForward() * -1
 		sideDir = ent:GetRight()
 	end
+
+	local debugDraw = armorDebugCvar:GetBool()
+	local debugEntries = debugDraw and {} or nil
+	local debugMaxVal = 0
 
 	local function getBoundsWorld(prop)
 		local mins, maxs = prop:OBBMins(), prop:OBBMaxs()
@@ -173,13 +436,13 @@ local function ACE_CalcContraptionArmor(ent)
 		}
 
 		for i, v in ipairs(corners) do
-			corners[i] = prop:LocalToWorld(v)
+			corners[i] = prop:LocalToWorld(v * 0.75)
 		end
 
 		return corners
 	end
 
-	-- Critical components (targets)
+	-- Critical components used as sampling anchors for armor estimation.
 	local criticals = {}
 	for _, cent in ipairs(contraptionEnts) do
 		if not IsValid(cent) then continue end
@@ -197,11 +460,16 @@ local function ACE_CalcContraptionArmor(ent)
 		ace_crewseat_driver = true
 	}
 
-	local function projectedData(comp, dir)
+	local function basisFromDir(dir)
 		dir = dir:GetNormalized()
 		local upHint = math.abs(dir.z) < 0.99 and Vector(0, 0, 1) or Vector(1, 0, 0)
 		local u = dir:Cross(upHint):GetNormalized()
 		local v = dir:Cross(u):GetNormalized()
+		return u, v
+	end
+
+	local function projectedData(comp, dir)
+		local u, v = basisFromDir(dir)
 
 		local corners = getBoundsWorld(comp)
 		local minU, maxU = math.huge, -math.huge
@@ -223,6 +491,30 @@ local function ACE_CalcContraptionArmor(ent)
 		return area, halfU, halfV
 	end
 
+	local frontU, frontV = basisFromDir(frontDir)
+	local sideU, sideV = basisFromDir(sideDir)
+	local regionSnap = 2
+	local origin = ent:WorldSpaceCenter()
+
+	local function regionKey(pos, u, v)
+		if not pos then return nil end
+		local rel = pos - origin
+		local ku = math.floor(rel:Dot(u) / regionSnap + 0.5)
+		local kv = math.floor(rel:Dot(v) / regionSnap + 0.5)
+		return ku .. ":" .. kv
+	end
+
+	local function updateRegion(regions, key, val, weight)
+		if not key or val <= 0 then return end
+		local entry = regions[key]
+		if not entry or val > entry.val then
+			regions[key] = {
+				val = val,
+				weight = weight
+			}
+		end
+	end
+
 	local function losFiltered(startPos, endPos, targetComp)
 		local filter = {}
 		local total = 0
@@ -231,8 +523,8 @@ local function ACE_CalcContraptionArmor(ent)
 		local hitTarget = false
 		local hitPos
 		local hitNormal
-		local hullMins = Vector(-2, -2, -2)
-		local hullMaxs = Vector(2, 2, 2)
+		local hullMins = Vector(-3, -3, -3)
+		local hullMaxs = Vector(3, 3, 3)
 
 		for _ = 1, 128 do
 			local tr = util.TraceHull({
@@ -251,7 +543,7 @@ local function ACE_CalcContraptionArmor(ent)
 
 			local skip = false
 
-			-- Ignore spheres made with MakeSpherical (no meaningful armor)
+			-- Ignore MakeSpherical props that skew LOS thickness without directional armor.
 			if hitEnt.RenderOverride and tostring(hitEnt.RenderOverride):find("MakeSpherical") then
 				skip = true
 			end
@@ -284,7 +576,11 @@ local function ACE_CalcContraptionArmor(ent)
 				local MatData = ACE_GetMaterialData(Mat)
 				local armor = hitEnt.ACF.Armour or 0
 				local armorData = hitEnt.acfPropArmorData and hitEnt:acfPropArmorData()
-				local eff = (armorData and armorData.Effectiveness) or (MatData and MatData.effectiveness) or 1
+				local effKE = (armorData and armorData.Effectiveness) or (MatData and MatData.effectiveness) or 1
+				local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
+					or (MatData and (MatData.HEATeffectiveness or MatData.effectiveness))
+					or effKE
+				local eff = effKE * 0.8 + effCHEM * 0.2
 				local curve = (armorData and armorData.Curve) or 1
 				local ang = ACF_GetHitAngle(tr.HitNormal, dir)
 				local los
@@ -319,8 +615,8 @@ local function ACE_CalcContraptionArmor(ent)
 		return total, hitPos, hitNormal
 	end
 
-	local countFront, countSide = 0, 0
-	local accumFront, accumSide = 0, 0
+	local frontRegions = {}
+	local sideRegions = {}
 
 	for _, comp in ipairs(criticals) do
 		local center = comp:WorldSpaceCenter()
@@ -339,7 +635,7 @@ local function ACE_CalcContraptionArmor(ent)
 			center + halfUp - halfRight,
 			center - halfUp + halfRight,
 			center - halfUp - halfRight,
-			center -- center sample for coverage
+			center -- Center sample improves coverage.
 		}
 		local sampleCount = #samples
 		local weightF = sampleCount > 0 and (frontArea / sampleCount) or 0
@@ -349,17 +645,18 @@ local function ACE_CalcContraptionArmor(ent)
 		local frontHalfVSample = (frontHalfV or 0) * sampleScale
 		local sideHalfUSample = (sideHalfU or 0) * sampleScale
 		local sideHalfVSample = (sideHalfV or 0) * sampleScale
+		local markerSize = debugDraw and math.max(2, math.min(size.x, size.y, size.z) * 0.05) or 0
 
 		for _, pt in ipairs(samples) do
-			local frontStart = pt - frontDir * 500
+			local frontStart = pt - frontDir * 200
 			local frontEnd   = pt
-			local sideStart  = pt - sideDir * 500
+			local sideStart  = pt - sideDir * 100
 			local sideEnd    = pt
 
-			-- Front: take the forward trace only.
+			-- Frontal thickness uses the forward trace from the sample point.
 			local frontVal, frontHitPos, frontHitNormal = losFiltered(frontStart, frontEnd, comp)
 
-			-- Side: trace from both directions and take the lesser valid value.
+			-- Side thickness samples both lateral directions and uses the smaller valid LOS.
 			local sideValA, sideHitPosA, sideHitNormalA  = losFiltered(sideStart, sideEnd, comp)
 			local sideValB, sideHitPosB, sideHitNormalB  = losFiltered(pt + sideDir * 500, pt - sideDir * 50, comp)
 			local sideVal = 0
@@ -378,53 +675,84 @@ local function ACE_CalcContraptionArmor(ent)
 				sideHitNormal = sideHitNormalB
 			end
 
-			-- Area-weighted averaging; only include weights if we got a hit.
+			-- Accumulate area-weighted averages only when a valid hit is found.
 			if frontVal > 0 then
-				accumFront = accumFront + frontVal * weightF
-				countFront = countFront + weightF
+				local key = regionKey(frontHitPos, frontU, frontV)
+				updateRegion(frontRegions, key, frontVal, weightF)
 			end
 
 			if sideVal > 0 then
-				accumSide = accumSide + sideVal * weightS
-				countSide = countSide + weightS
+				local key = regionKey(sideHitPos, sideU, sideV)
+				updateRegion(sideRegions, key, sideVal, weightS)
 			end
 
-			if armorDebugCvar:GetBool() then
-				local function colorFromVal(v)
-					local ratio = math.min(math.max((v or 0) / 500, 0), 1)
-					return 255 * ratio, 255 * (1 - ratio)
-				end
-
-				local thickness = 0.1
-				local markerSize = math.max(2, math.min(size.x, size.y, size.z) * 0.05)
-
-				local function drawMarker(hitPos, hitNormal, fallbackNormal, val, halfU, halfV)
-					if not hitPos then return end
-					local normal = hitNormal or fallbackNormal
-					if not normal then return end
-					local r, g = colorFromVal(val)
-					local ang = normal:Angle()
-					local pos = hitPos + normal * 0.1
-					local u = halfU or markerSize
-					local v = halfV or markerSize
-					debugoverlay.BoxAngles(pos, Vector(-thickness, -u, -v), Vector(thickness, u, v), ang, 30, Color(r, g, 0, 0.1))
-				end
-
+			if debugDraw then
 				if frontArea > 0 and frontVal > 0 then
-					drawMarker(frontHitPos, frontHitNormal, -frontDir, frontVal, frontHalfUSample, frontHalfVSample)
+					debugEntries[#debugEntries + 1] = {
+						pos = frontHitPos,
+						normal = frontHitNormal,
+						fallbackNormal = -frontDir,
+						val = frontVal,
+						halfU = frontHalfUSample,
+						halfV = frontHalfVSample,
+						markerSize = markerSize
+					}
+					if frontVal > debugMaxVal then debugMaxVal = frontVal end
 				end
 
 				if sideArea > 0 and sideVal > 0 then
-					drawMarker(sideHitPos, sideHitNormal, -sideDirUsed, sideVal, sideHalfUSample, sideHalfVSample)
+					debugEntries[#debugEntries + 1] = {
+						pos = sideHitPos,
+						normal = sideHitNormal,
+						fallbackNormal = -sideDirUsed,
+						val = sideVal,
+						halfU = sideHalfUSample,
+						halfV = sideHalfVSample,
+						markerSize = markerSize
+					}
+					if sideVal > debugMaxVal then debugMaxVal = sideVal end
 				end
 			end
 		end
 	end
 
+	if debugDraw and debugEntries and debugMaxVal > 0 then
+		local function colorFromVal(v)
+			local ratio = math.min(math.max((v or 0) / debugMaxVal, 0), 1)
+			return 255 * ratio, 255 * (1 - ratio)
+		end
+
+		local thickness = 0.1
+		for _, entry in ipairs(debugEntries) do
+			if not entry.pos then continue end
+			local normal = entry.normal or entry.fallbackNormal
+			if not normal then continue end
+			local r, g = colorFromVal(entry.val)
+			local ang = normal:Angle()
+			local pos = entry.pos + normal * 0.1
+			local u = entry.halfU or entry.markerSize
+			local v = entry.halfV or entry.markerSize
+			debugoverlay.BoxAngles(pos, Vector(-thickness, -u, -v), Vector(thickness, u, v), ang, 30, Color(r, g, 0, 0.1))
+		end
+	end
+
+	local countFront, countSide = 0, 0
+	local accumFront, accumSide = 0, 0
+
+	for _, entry in pairs(frontRegions) do
+		accumFront = accumFront + entry.val * entry.weight
+		countFront = countFront + entry.weight
+	end
+
+	for _, entry in pairs(sideRegions) do
+		accumSide = accumSide + entry.val * entry.weight
+		countSide = countSide + entry.weight
+	end
+
 	local avgFront = countFront > 0 and (accumFront / countFront) or 0
 	local avgSide = countSide > 0 and (accumSide / countSide) or 0
 
-	-- Side weighting is handled in the cost calculation.
+	-- Return raw averages; side weighting is applied when converting to points.
 	return avgFront, avgSide
 	end
 
@@ -432,7 +760,139 @@ function ACE_GetArmorScan(ent)
 	return ACE_CalcContraptionArmor(ent)
 end
 
--- Ensure contraption armor points are up to date and reflected in totals.
+local function ACE_GetContraptionEntities(Contraption, fallbackEnt)
+	local ents = {}
+
+	if Contraption and Contraption.ents then
+		for ent in pairs(Contraption.ents) do
+			if IsValid(ent) then
+				ents[#ents + 1] = ent
+			end
+		end
+	end
+
+	if #ents == 0 and IsValid(fallbackEnt) then
+		ents[1] = fallbackEnt
+	end
+
+	return ents
+end
+
+local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
+	if not Contraption then return end
+
+	local totals = {
+		Engines = 0,
+		Firepower = 0,
+		Ammo = 0,
+		Crew = 0,
+		Electronics = 0
+	}
+	local nonArmor = 0
+	local ents = ACE_GetContraptionEntities(Contraption, baseEnt)
+	local gunRpsById = {}
+	local racks = {}
+	local detailItems = {}
+	local minDetailPts = 300
+
+	local function getEntityLabel(ent)
+		local label = ent:GetNWString("WireName")
+		if label and label ~= "" then return label end
+		if ent.Name and ent.Name ~= "" then return ent.Name end
+		return ent:GetClass()
+	end
+
+	local function addDetail(category, label, pts, ent)
+		detailItems[#detailItems + 1] = {
+			category = category,
+			label = label,
+			pts = pts,
+			idx = IsValid(ent) and ent:EntIndex() or 0
+		}
+	end
+
+	for _, ent in ipairs(ents) do
+		if not IsValid(ent) then continue end
+		local cls = ent:GetClass()
+		if cls == "acf_gun" then
+			local id = ent.Id
+			local rps = ACE_GetGunRps(ent)
+			if id and rps > 0 then
+				gunRpsById[id] = (gunRpsById[id] or 0) + rps
+			end
+		elseif cls == "acf_rack" then
+			racks[#racks + 1] = ent
+		end
+	end
+
+	for _, ent in ipairs(ents) do
+		if not IsValid(ent) then continue end
+
+		local cls = ent:GetClass()
+		if cls == "acf_ammo" then
+			local pts, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks)
+			if pts > 0 then
+				nonArmor = nonArmor + pts
+				totals.Ammo = (totals.Ammo or 0) + pts
+				if detail then
+					local ammoType = detail.Type ~= "" and detail.Type or "Ammo"
+					local cap = math.floor((detail.Capacity or 0) + 0.5)
+					local cal = math.floor((detail.Caliber or 0) + 0.5)
+					local pen = math.floor((detail.MaxPen or 0) + 0.5)
+					local rps = detail.Rps or 0
+					local label = string.format(
+						"%dx%.0fmm %s - Pen: %.0f, RPS: %.2f",
+						cap,
+						cal,
+						ammoType,
+						pen,
+						rps
+					)
+					addDetail("Ammo", label, pts, ent)
+				end
+			end
+			continue
+		end
+
+		local eclass = ACE_GetPtsType(cls)
+		if eclass == "Ignore" then continue end
+		if eclass == "Armor" then continue end
+
+		local pts = ACE_GetEntPoints(ent)
+		if pts ~= 0 then
+			nonArmor = nonArmor + pts
+			totals[eclass] = (totals[eclass] or 0) + pts
+			addDetail(eclass, getEntityLabel(ent), pts, ent)
+		end
+	end
+
+	table.sort(detailItems, function(a, b)
+		if a.pts == b.pts then
+			return a.idx < b.idx
+		end
+		return a.pts > b.pts
+	end)
+
+	local trimmed = {}
+	for _, entry in ipairs(detailItems) do
+		if entry.pts >= minDetailPts then
+			trimmed[#trimmed + 1] = {
+				Category = entry.category,
+				Label = entry.label,
+				Points = math.Round(entry.pts, 1)
+			}
+		end
+	end
+
+	Contraption.ACEPointsNonArmor = nonArmor
+	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
+	for key, value in pairs(totals) do
+		Contraption.ACEPointsPerType[key] = value
+	end
+	Contraption.ACEPointsDetails = { Items = trimmed }
+end
+
+-- Rebuild armor points when dirty and synchronize totals for the breakdown.
 function ACE_EnsureArmor(Contraption, baseEnt, force)
 	if not Contraption then return end
 	if not force then
@@ -453,8 +913,10 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 		Contraption.ACEArmorSide = s
 	end
 
+	ACE_RebuildNonArmorPoints(Contraption, base)
+
 	local side = Contraption.ACEArmorSide or 0
-	-- Final armor cost: (front + side*2) * 4
+	-- Convert armor averages to points; side armor counts double to reflect exposure.
 	local newArmorPts = (front + side * 2) * 4
 	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
 	Contraption.ACEPointsPerType.Armor = newArmorPts
@@ -475,10 +937,11 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 end
 
 function ACE_GetEntPoints(Ent)
-	local Points = 0 --Use the specially assigned points if it has them
-	--[[ Old mass/material-based point calculation retained for reference.
+	local Points = 0 -- Base for per-entity point adjustments.
+	--[[ Legacy mass/material-based point calculation (deprecated).
+	     Kept for reference if the scoring model is revisited in the future.
 	if IsValid(Ent) then
-		-- legacy mass/material calc here...
+		-- legacy mass/material calculation would go here
 	end
 	]]
 
@@ -486,7 +949,13 @@ function ACE_GetEntPoints(Ent)
 
 	local class = Ent:GetClass()
 	if ArmorClasses[class] then
-		-- Armor cost is handled at contraption-level (E2-style scan). Per-prop points are zero.
+		-- Armor is scored at the contraption level; individual props contribute zero here.
+		return 0
+	end
+	if class == "acf_fueltank" then
+		return 0
+	end
+	if class == "acf_ammo" or class == "acf_gun" or class == "acf_rack" then
 		return 0
 	end
 
@@ -496,62 +965,14 @@ function ACE_GetEntPoints(Ent)
 end
 
 do
-	--Used for setweight update checks. This is such a hacky way to do things.
+	-- Hook PhysObj:SetMass so point totals update when props are modified.
 	local PHYS    = FindMetaTable("PhysObj")
 	local ACE_Override_SetMass = ACE_Override_SetMass or PHYS.SetMass
-
-	local FirepowerEnts = {
-		["acf_rack"]                  = true,
-		["acf_gun"]                   = true
-	}
-	local CrewEnts = {
-		["ace_crewseat_gunner"]                  = true,
-		["ace_crewseat_loader"]                  = true,
-		["ace_crewseat_driver"]                   = true
-	}
-	local ElectronicEnts = {
-		["ace_rwr_dir"]                  = true,
-		["ace_rwr_sphere"]                  = true,
-		["acf_missileradar"]                  = true,
-		["acf_opticalcomputer"]                  = true,
-		["ace_ecm"]                  = true,
-		["ace_trackingradar"]                  = true,
-		["ace_searchradar"]                  = true,
-		["ace_irst"]                  = true,
-		["ace_sonar"]                  = true,
-		["ace_crewseat_driver"]                   = true
-	}
-
-	local function ACE_getPtsType(ClassName)
-		if ArmorClasses[ClassName] then
-			return "Armor"
-		end
-		if ClassName == "acf_engine" then
-			return "Engines"
-		end
-		if FirepowerEnts[ClassName] then
-			return "Firepower"
-		end
-		if ClassName == "acf_fueltank" then
-			return "Fuel"
-		end
-		if ClassName == "acf_ammo" then
-			return "Ammo"
-		end
-		if CrewEnts[ClassName] then
-			return "Crew"
-		end
-		if ElectronicEnts[ClassName] then
-			return "Electronics"
-		end
-
-		return "Armor"
-	end
 
 	function PHYS:SetMass(mass)
 
 		local ent     = self:GetEntity()
-		local oldPointValue = ent._AcePts or 0 -- The 'or 0' handles cases of ents connected before they had a physObj
+		local oldPointValue = ent._AcePts or 0 -- Default to zero if no cached points exist yet.
 
 	ent._AcePts = ACE_GetEntPoints(ent)
 
@@ -561,8 +982,9 @@ do
 		if not con then return end
 
 		local delta = ent._AcePts - oldPointValue
-		local eclass = ACE_getPtsType(ent:GetClass())
+		local eclass = ACE_GetPtsType(ent:GetClass())
 
+		if eclass == "Ignore" then return end
 		if eclass == "Armor" then
 			con.ACEArmorDirty = true
 			return
@@ -585,7 +1007,6 @@ do
 		Class.ACEPointsPerType.Armor = 0
 		Class.ACEPointsPerType.Engines = 0
 		Class.ACEPointsPerType.Firepower = 0
-		Class.ACEPointsPerType.Fuel = 0
 		Class.ACEPointsPerType.Ammo = 0
 		Class.ACEPointsPerType.Crew = 0
 		Class.ACEPointsPerType.Electronics = 0
@@ -598,18 +1019,54 @@ do
 	function ACE_AddPts(Class, Ent)
 		if not IsValid(Ent) then return end
 
-		local AcePts = ACE_GetEntPoints(Ent)
+		local conRef = Class
+		local EClass = ACE_GetPtsType(Ent:GetClass())
+		local newPts = ACE_GetEntPoints(Ent)
+		local oldPts = Ent._AcePts or 0
 
-		Ent._AcePts     = AcePts
+		if EClass == "Ignore" then
+			if Ent._ACEPointsConRef and Ent._ACEPointsConRef ~= conRef then
+				ACE_RemPts(Ent._ACEPointsConRef, Ent)
+			end
 
-		local EClass = ACE_getPtsType(Ent:GetClass())
+			Ent._ACEPointsConRef = conRef
+			Ent._ACEPointsConKey = ACE_GetContraptionIndex and ACE_GetContraptionIndex(conRef) or nil
+			Ent._AcePts = 0
+			return
+		end
+
+		if Ent._ACEPointsConRef == conRef then
+			if EClass == "Armor" then
+				Class.ACEArmorDirty = true
+			else
+				local delta = newPts - oldPts
+				if delta ~= 0 then
+					Class.ACEPoints = (Class.ACEPoints or 0) + delta
+					Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + delta
+					Class.ACEPointsPerType = Class.ACEPointsPerType or {}
+					Class.ACEPointsPerType[EClass] = (Class.ACEPointsPerType[EClass] or 0) + delta
+				end
+			end
+
+			Ent._AcePts = newPts
+			return
+		end
+
+		if Ent._ACEPointsConRef and Ent._ACEPointsConRef ~= conRef then
+			ACE_RemPts(Ent._ACEPointsConRef, Ent)
+		end
+
+		Ent._ACEPointsConRef = conRef
+		Ent._ACEPointsConKey = ACE_GetContraptionIndex and ACE_GetContraptionIndex(conRef) or nil
+		Ent._AcePts = newPts
 
 		if EClass == "Armor" then
 			Class.ACEArmorDirty = true
 		else
-			Class.ACEPoints = Class.ACEPoints + AcePts
-			Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + AcePts
-			Class.ACEPointsPerType[EClass] = Class.ACEPointsPerType[EClass] + AcePts
+			Class.ACEPoints = (Class.ACEPoints or 0) + newPts
+			Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + newPts
+			Class.ACEPointsPerType = Class.ACEPointsPerType or {}
+			Class.ACEPointsPerType[EClass] = (Class.ACEPointsPerType[EClass] or 0) + newPts
 		end
 	end
 	hook.Add("cfw.contraption.entityAdded", "ACE_AddPoints", ACE_AddPts)
@@ -618,14 +1075,19 @@ do
 	function ACE_RemPts(Class, Ent)
 		if not IsValid(Ent) then return end
 
-		local EClass = ACE_getPtsType(Ent:GetClass())
+		if Ent._ACEPointsConRef and Ent._ACEPointsConRef ~= Class then return end
+		Ent._ACEPointsConKey = nil
+		Ent._ACEPointsConRef = nil
 
+		local EClass = ACE_GetPtsType(Ent:GetClass())
+
+		if EClass == "Ignore" then return end
 		if EClass == "Armor" then
 			Class.ACEArmorDirty = true
 			return
 		end
 
-		local AcePts = Ent._AcePts or 0 -- avoid heavy recalcs on removal
+		local AcePts = Ent._AcePts or 0 -- Use cached points to avoid heavy recalculation on removal.
 
 		Class.ACEPoints = Class.ACEPoints - AcePts
 		Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) - AcePts

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -1,5 +1,3 @@
-
-
 ACE = ACE or {}
 
 local ArmorClasses = {
@@ -91,7 +89,7 @@ local AmmoTypeFactors = {
 -- Normalization constants for the ammo formula; tune these to rebalance without
 -- rewriting the math.
 local AmmoCostConfig = {
-	BaseRoundPts = 111.1,
+	BaseRoundPts = 80,
 	RefPen = 600,
 	RefCaliber = 120,
 	PenExp = 2,
@@ -101,6 +99,34 @@ local AmmoCostConfig = {
 
 ACE.AmmoTypeFactors = AmmoTypeFactors
 ACE.AmmoCostConfig = AmmoCostConfig
+
+ACE.DupeArmorCache = ACE.DupeArmorCache or {}
+ACE.DupeArmorCacheVersion = ACE.DupeArmorCacheVersion or 1
+ACE.DupeArmorCacheLastClear = ACE.DupeArmorCacheLastClear or CurTime()
+
+local DupeArmorCacheTtl = CreateConVar(
+	"ace_dupe_armor_cache_ttl",
+	"1800",
+	FCVAR_ARCHIVE,
+	"Seconds between clearing the dupe armor cache (0 to disable)."
+)
+
+timer.Create("ACE_DupeArmorCacheGC", 60, 0, function()
+	local ttl = DupeArmorCacheTtl:GetFloat()
+	if ttl <= 0 then return end
+
+	local now = CurTime()
+	local last = ACE.DupeArmorCacheLastClear or now
+	if now - last < ttl then return end
+
+	ACE.DupeArmorCache = {}
+	ACE.DupeArmorCacheLastClear = now
+end)
+
+concommand.Add("ace_dupe_armor_cache_clear", function()
+	ACE.DupeArmorCache = {}
+	ACE.DupeArmorCacheLastClear = CurTime()
+end)
 
 local function ACE_GetAmmoTypeFactor(ammoType)
 	return AmmoTypeFactors[ammoType] or 1
@@ -221,6 +247,89 @@ function ACE_DoContraptionLegalCheck(CheckEnt)
 end
 
 do
+	local function ACE_GetDupeSignature(dupe, created)
+		if not dupe then return nil end
+		local function formatArmorKey(material, ductility, armour, maxArmour, mass)
+			return string.format(
+				"mat=%s|duct=%.3f|arm=%.2f|max=%.2f|mass=%.2f",
+				tostring(material or ""),
+				tonumber(ductility) or 0,
+				tonumber(armour) or 0,
+				tonumber(maxArmour) or 0,
+				tonumber(mass) or 0
+			)
+		end
+
+		local entData = dupe.Entities
+			or dupe.Ents
+			or dupe.EntityList
+			or (dupe.Dupe and dupe.Dupe.Entities)
+
+		if istable(entData) then
+			local parts = {}
+			for _, data in pairs(entData) do
+				if istable(data) then
+					local class = data.Class or data.class or "unknown"
+					local model = data.Model or data.model or ""
+					local mods = data.EntityMods or data.entitymods
+					local acfSettings = mods and mods.acfsettings
+					local massMod = mods and mods.mass
+					local acf = data.ACF or data.acf
+					local material = (acfSettings and (acfSettings.Material or acfSettings.material))
+						or (acf and (acf.Material or acf.material))
+					local ductility = (acfSettings and (acfSettings.Ductility or acfSettings.ductility))
+						or (acf and (acf.Ductility or acf.ductility))
+					local armour = acf and (acf.Armour or acf.Armor)
+					local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
+					local mass = massMod and (massMod.Mass or massMod.mass)
+					local armorKey = formatArmorKey(material, ductility, armour, maxArmour, mass)
+					parts[#parts + 1] = class .. "|" .. model .. "|" .. armorKey
+				end
+			end
+			table.sort(parts)
+			if #parts > 0 and util and util.SHA256 then
+				return tostring(ACE.DupeArmorCacheVersion) .. ":ents:" .. util.SHA256(table.concat(parts, ";"))
+			end
+		end
+
+		if istable(created) and util and util.SHA256 then
+			local parts = {}
+			for _, ent in pairs(created) do
+				if not IsValid(ent) then continue end
+				local class = ent:GetClass() or "unknown"
+				local model = ent:GetModel() or ""
+				local size = ent:OBBMaxs() - ent:OBBMins()
+				local sizeKey = string.format("%.1f,%.1f,%.1f", size.x, size.y, size.z)
+				local extra = ""
+				local acf = ent.ACF
+				local material = acf and acf.Material
+				local ductility = acf and acf.Ductility
+				local armour = acf and (acf.Armour or acf.Armor)
+				local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
+				local mass = 0
+				local phys = ent:GetPhysicsObject()
+				if IsValid(phys) then
+					mass = phys:GetMass()
+				end
+				local armorKey = formatArmorKey(material, ductility, armour, maxArmour, mass)
+				if class == "acf_gun" then
+					extra = tostring(ent.Id or "")
+				elseif class == "acf_ammo" then
+					extra = tostring(ent.BulletData and ent.BulletData.Id or "")
+				elseif class == "acf_engine" then
+					extra = tostring(ent.Id or "")
+				end
+				parts[#parts + 1] = class .. "|" .. model .. "|" .. sizeKey .. "|" .. extra .. "|" .. armorKey
+			end
+			table.sort(parts)
+			if #parts > 0 then
+				return tostring(ACE.DupeArmorCacheVersion) .. ":spawn:" .. util.SHA256(table.concat(parts, ";"))
+			end
+		end
+
+		return nil
+	end
+
 	local function ACE_GetContraptionFromEntity(ent)
 		if not IsValid(ent) then return end
 		if not ent.GetContraption then return end
@@ -251,10 +360,13 @@ do
 		return con.ACEArmorTimerId
 	end
 
-	local function ACE_ScheduleInitArmor(con, delay, force)
+	local function ACE_ScheduleInitArmor(con, delay, force, cacheKey)
 		if not con then return end
 
 		if not force and con.ACEArmorCalculated and not con.ACEArmorDirty then return end
+		if cacheKey and not con.ACEArmorCacheKey then
+			con.ACEArmorCacheKey = cacheKey
+		end
 
 		local requestedDelay = delay or 0.1
 		local queuedDelay = con.ACEArmorQueuedDelay or 0
@@ -280,7 +392,7 @@ do
 		end)
 	end
 
-	local function ACE_ScheduleInitArmorFromEntities(entities, delay, force, skipFrozen)
+	local function ACE_ScheduleInitArmorFromEntities(entities, delay, force, skipFrozen, cacheKey, cachedData)
 		if not istable(entities) then return end
 		local scheduled = {}
 
@@ -290,7 +402,13 @@ do
 			if not con or scheduled[con] then continue end
 			if skipFrozen and ACE_IsContraptionFrozen(con) then continue end
 			scheduled[con] = true
-			ACE_ScheduleInitArmor(con, delay, force)
+			if cacheKey and not con.ACEArmorCacheKey then
+				con.ACEArmorCacheKey = cacheKey
+			end
+			if cachedData then
+				con.ACEArmorCachedData = cachedData
+			end
+			ACE_ScheduleInitArmor(con, delay, force, cacheKey)
 		end
 	end
 
@@ -310,15 +428,31 @@ do
 		local dupe = istable(dupeInfo) and dupeInfo[1]
 		local created = dupe and dupe.CreatedEntities
 		if not created then return end
+		local cacheKey = ACE_GetDupeSignature(dupe, created)
+		local cached = cacheKey and ACE.DupeArmorCache and ACE.DupeArmorCache[cacheKey] or nil
+		local flagName = "_ACEAdvDupeArmorInit"
+		local first
+		for _, ent in pairs(created) do
+			if IsValid(ent) then
+				first = ent
+				break
+			end
+		end
+		if not first or first[flagName] then return end
+		for _, ent in pairs(created) do
+			if IsValid(ent) then
+				ent[flagName] = true
+			end
+		end
 
 		timer.Simple(0, function()
-			ACE_ScheduleInitArmorFromEntities(created, 0.05, false, true)
+			ACE_ScheduleInitArmorFromEntities(created, 0.05, false, true, cacheKey, cached)
 		end)
 
 		timer.Simple(0.5, function()
-			ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true)
+			ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true, cacheKey, cached)
 			timer.Simple(0.8, function()
-				ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true)
+				ACE_ScheduleInitArmorFromEntities(created, 0.1, false, true, cacheKey, cached)
 			end)
 		end)
 	end)
@@ -407,15 +541,87 @@ local function ACE_CalcContraptionArmor(ent)
 		end
 	end
 
-	-- Establish scan directions (front/side) from the chosen reference.
-	local frontDir
-	local sideDir
-	if IsValid(mainGun) then
-		frontDir = -mainGun:GetForward()
-		sideDir = mainGun:GetRight()
-	else
-		frontDir = ent:GetForward() * -1
-		sideDir = ent:GetRight()
+	-- Establish scan directions (front/side) using gun forward, gravity up, and wheel axes.
+	local function normalizeOrNil(vec)
+		if not vec then return nil end
+		local len = vec:Length()
+		if len <= 1e-6 then return nil end
+		return vec / len
+	end
+
+	local function flattenToPlane(vec, up)
+		if not vec or not up then return nil end
+		local flat = vec - up * vec:Dot(up)
+		return normalizeOrNil(flat)
+	end
+
+	local function getWorldUp()
+		local gravity = physenv and physenv.GetGravity and physenv.GetGravity() or Vector(0, 0, -1)
+		if gravity:LengthSqr() <= 1e-6 then return Vector(0, 0, 1) end
+		return (-gravity):GetNormalized()
+	end
+
+	local function isMakeSpherical(ent)
+		local override = ent and ent.RenderOverride
+		return override and tostring(override):find("MakeSpherical") ~= nil
+	end
+
+	local function getWheelAxisSide(base, up)
+		if not IsValid(base) or not constraint or not constraint.FindConstraints then return nil end
+		local cons = constraint.FindConstraints(base, "Axis")
+		if not istable(cons) or #cons == 0 then return nil end
+
+		local axisSum = Vector(0, 0, 0)
+		local count = 0
+
+		for _, con in ipairs(cons) do
+			if not con or (con.Ent1 ~= base and con.Ent2 ~= base) then continue end
+			local other = con.Ent1 == base and con.Ent2 or con.Ent1
+			if not IsValid(other) or not isMakeSpherical(other) then continue end
+
+			local localAxis = con.Ent1 == base and con.LNorm1 or con.LNorm2
+			if not localAxis then continue end
+
+			local axisWorld = base:LocalToWorld(localAxis) - base:GetPos()
+			axisWorld = axisWorld - up * axisWorld:Dot(up)
+			axisWorld = normalizeOrNil(axisWorld)
+			if axisWorld then
+				if count > 0 and axisWorld:Dot(axisSum) < 0 then
+					axisWorld = -axisWorld
+				end
+				axisSum = axisSum + axisWorld
+				count = count + 1
+			end
+		end
+
+		return count > 0 and normalizeOrNil(axisSum) or nil
+	end
+
+	local upDir = getWorldUp()
+	local rawFront = IsValid(mainGun) and -mainGun:GetForward() or nil
+	if not rawFront then
+		rawFront = ent:GetForward() * -1
+	end
+
+	local frontDir = flattenToPlane(rawFront, upDir) or normalizeOrNil(rawFront) or Vector(1, 0, 0)
+	local sideDir = getWheelAxisSide(ent, upDir)
+
+	if not sideDir then
+		sideDir = normalizeOrNil(upDir:Cross(frontDir))
+	end
+
+	if not sideDir then
+		sideDir = normalizeOrNil(ent:GetRight()) or Vector(0, 1, 0)
+	end
+
+	sideDir = normalizeOrNil(sideDir - frontDir * sideDir:Dot(frontDir)) or sideDir
+
+	local adjustedFront = normalizeOrNil(sideDir:Cross(upDir))
+	if adjustedFront then
+		if adjustedFront:Dot(frontDir) < 0 then
+			adjustedFront = -adjustedFront
+		end
+		frontDir = adjustedFront
 	end
 
 	local debugDraw = armorDebugCvar:GetBool()
@@ -906,16 +1112,27 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 	end
 
 	local front = 0
-	if IsValid(base) then
-		local f, s = ACE_CalcContraptionArmor(base)
-		front = f
-		Contraption.ACEArmorFront = f
-		Contraption.ACEArmorSide = s
+	local side = 0
+	local usedCache = false
+	local cached = Contraption.ACEArmorCachedData
+	if cached then
+		front = cached.Front or cached.front or 0
+		side = cached.Side or cached.side or 0
+		Contraption.ACEArmorFront = front
+		Contraption.ACEArmorSide = side
+		usedCache = true
+	else
+		if IsValid(base) then
+			local f, s = ACE_CalcContraptionArmor(base)
+			front = f
+			side = s
+			Contraption.ACEArmorFront = f
+			Contraption.ACEArmorSide = s
+		end
 	end
 
 	ACE_RebuildNonArmorPoints(Contraption, base)
 
-	local side = Contraption.ACEArmorSide or 0
 	-- Convert armor averages to points; side armor counts double to reflect exposure.
 	local newArmorPts = (front + side * 2) * 4
 	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
@@ -927,6 +1144,17 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 
 	local nonArmor = Contraption.ACEPointsNonArmor or 0
 	Contraption.ACEPoints = nonArmor + newArmorPts
+
+	local cacheKey = Contraption.ACEArmorCacheKey
+	if cacheKey and not usedCache then
+		ACE.DupeArmorCache = ACE.DupeArmorCache or {}
+		ACE.DupeArmorCache[cacheKey] = {
+			Front = front,
+			Side = side
+		}
+	end
+	Contraption.ACEArmorCacheKey = nil
+	Contraption.ACEArmorCachedData = nil
 
 	if armorDebugCvar:GetBool() then
 		print(string.format("[ACE ArmorDbg] Front=%.2f Side=%.2f Pts(x4)=%.2f", front or 0, side or 0, newArmorPts))

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -519,6 +519,25 @@ do
 	end)
 end
 
+
+local function ACE_NotifyContraptionModified(Contraption)
+	if not Contraption or not Contraption.ACEArmorCalculated then return end
+
+	Contraption.OTWarnings = Contraption.OTWarnings or {}
+	if Contraption.OTWarnings.WarnedModified then return end
+
+	local base = Contraption.GetACEBaseplate and Contraption:GetACEBaseplate()
+	local owner = IsValid(base) and base.CPPIGetOwner and base:CPPIGetOwner() or nil
+	local name = IsValid(owner) and owner:Nick() or "Unknown"
+	local msg = "[ACE] " .. name .. " modified a vehicle after cost initialization."
+	if Contraption.ACEArmorDirty then
+		msg = msg .. " Armor cost marked dirty."
+	end
+
+	chatMessageGlobal(msg, Color(255, 200, 0))
+	Contraption.OTWarnings.WarnedModified = true
+end
+
 function ACE_CheckLegalCont(Contraption)
 
 	-- Track one-time warning flags per contraption to avoid repeated spam.
@@ -1402,6 +1421,9 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 	Contraption.ACEArmorPoints = newArmorPts
 	Contraption.ACEArmorDirty = false
 	Contraption.ACEArmorCalculated = true
+	if Contraption.OTWarnings then
+		Contraption.OTWarnings.WarnedModified = false
+	end
 
 	local nonArmor = Contraption.ACEPointsNonArmor or 0
 	Contraption.ACEPoints = nonArmor + newArmorPts
@@ -1476,6 +1498,7 @@ do
 		if eclass == "Ignore" then return end
 		if eclass == "Armor" then
 			con.ACEArmorDirty = true
+			ACE_NotifyContraptionModified(con)
 			return
 		end
 
@@ -1483,6 +1506,7 @@ do
 		con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) + delta
 		con.ACEPointsPerType = con.ACEPointsPerType or {}
 		con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) + delta
+		ACE_NotifyContraptionModified(con)
 	end
 
 	local function ACE_InitPts(Class)
@@ -1545,6 +1569,7 @@ do
 					Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + delta
 					Class.ACEPointsPerType = Class.ACEPointsPerType or {}
 					Class.ACEPointsPerType[EClass] = (Class.ACEPointsPerType[EClass] or 0) + delta
+					ACE_NotifyContraptionModified(Class)
 				end
 			end
 
@@ -1562,6 +1587,7 @@ do
 
 		if EClass == "Armor" then
 			Class.ACEArmorDirty = true
+			ACE_NotifyContraptionModified(Class)
 		else
 			Class.ACEPoints = (Class.ACEPoints or 0) + newPts
 			Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) + newPts
@@ -1589,6 +1615,7 @@ do
 		if EClass == "Ignore" then return end
 		if EClass == "Armor" then
 			Class.ACEArmorDirty = true
+			ACE_NotifyContraptionModified(Class)
 			return
 		end
 
@@ -1598,6 +1625,7 @@ do
 		Class.ACEPointsNonArmor = (Class.ACEPointsNonArmor or 0) - AcePts
 
 		Class.ACEPointsPerType[EClass] = Class.ACEPointsPerType[EClass] - AcePts
+		ACE_NotifyContraptionModified(Class)
 	end
 
 	hook.Add("cfw.contraption.entityRemoved", "ACE_RemPoints", ACE_RemPts)

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -57,59 +57,9 @@ local function ACE_GetPtsType(ClassName)
 	return "Armor"
 end
 
--- Ammo scoring model.
--- Per-round cost scales with max penetration, caliber, and ammo type factor.
--- Total crate cost multiplies per-round cost by capacity and summed compatible ROF.
-local AmmoTypeFactors = {
-	AP = 0.5,
-	APHE = 0.6,
-	APDS = 0.9,
-	APFSDS = 1.2,
-	HVAP = 0.7,
-	HEAT = 0.75,
-	HEATFS = 0.9,
-	THEAT = 0.95,
-	THEATFS = 1.0,
-	HESH = 0.4,
-	HE = 0.5,
-	HEFS = 0.6,
-	HP = 0.1,
-	CAP = 0.6,
-	CHEAT = 0.8,
-	CHE = 0.25,
-	CHF = 0,
-	SM = 0,
-	FLR = 0,
-	FL = 0.3,
-	GLATGM = 0.75,
-	["GLATGM-HE"] = 0.25,
-	Refill = 0
-}
-
--- Normalization constants for the ammo formula; tune these to rebalance without
--- rewriting the math.
-local AmmoCostConfig = {
-	BaseRoundPts = 80, -- Base points per round before scaling.
-	RefPen = 600, -- Reference penetration (mm) for pen scaling.
-	RefCaliber = 120, -- Reference caliber (mm) for caliber scaling.
-	PenExp = 1.6, -- Penetration curve exponent.
-	RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
-	BlastExp = 1.1, -- Blast curve exponent.
-	BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
-	RpsRef = 1 / 7, -- Reference rounds per second for ROF scaling.
-	RpsExp = 0.5, -- ROF curve exponent.
-	ReadyRackBase = 2400, -- Ready rack baseline: base / caliber(mm).
-	ReadyRackMin = 10, -- Minimum ready rounds per gun group.
-	ReadyRackMax = 200, -- Maximum ready rounds per gun group.
-	ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
-	ReadyRackLowBoost = 0.5, -- Boost factor applied below pivot (0.5 = +50%).
-	StowFactor = 0.35, -- Cost multiplier for stowed rounds.
-	TailFactor = 0, -- Extra discount per round beyond tail start (0 disables).
-	TailStartMultiplier = 2 -- Tail start = readyCap * multiplier.
-}
-
-ACE.AmmoTypeFactors = AmmoTypeFactors
-ACE.AmmoCostConfig = AmmoCostConfig
+-- Ammo scoring config lives in acf_globals.lua for centralized tuning.
+local AmmoTypeFactors = ACE.AmmoTypeFactors
+local AmmoCostConfig = ACE.AmmoCostConfig
 
 ACE.DupeArmorCache = ACE.DupeArmorCache or {}
 ACE.DupeArmorCacheVersion = ACE.DupeArmorCacheVersion or 1
@@ -1188,6 +1138,16 @@ end
 function ACE_GetAmmoCratePointsForContraption(crate, Contraption, fallbackEnt)
 	if not IsValid(crate) then return 0 end
 
+	if Contraption and Contraption.ACEAmmoCache and not Contraption.ACENonArmorDirty then
+		local cache = Contraption.ACEAmmoCache
+		return ACE_CalcAmmoCratePoints(
+			crate,
+			cache.GunRpsById or {},
+			cache.Racks or {},
+			cache.ReadyAlloc
+		)
+	end
+
 	local ents = ACE_GetContraptionEntities(Contraption, fallbackEnt or crate)
 	local gunRpsById = {}
 	local racks = {}
@@ -1207,7 +1167,15 @@ function ACE_GetAmmoCratePointsForContraption(crate, Contraption, fallbackEnt)
 		end
 	end
 
-	return ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
+	local pts, detail = ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
+	if Contraption then
+		Contraption.ACEAmmoCache = {
+			GunRpsById = gunRpsById,
+			Racks = racks,
+			ReadyAlloc = readyAlloc
+		}
+	end
+	return pts, detail
 end
 
 function ACE_CalcNonArmorPoints(Contraption, baseEnt)
@@ -1286,6 +1254,11 @@ function ACE_CalcNonArmorPoints(Contraption, baseEnt)
 		end
 	end
 	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents)
+	local ammoCache = {
+		GunRpsById = gunRpsById,
+		Racks = racks,
+		ReadyAlloc = readyAlloc
+	}
 
 	for _, ent in ipairs(ents) do
 		if not IsValid(ent) then continue end
@@ -1366,13 +1339,13 @@ function ACE_CalcNonArmorPoints(Contraption, baseEnt)
 		end
 	end
 
-	return nonArmor, totals, { Items = trimmed, AmmoLines = ammoList }
+	return nonArmor, totals, { Items = trimmed, AmmoLines = ammoList }, ammoCache
 end
 
 local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
 	if not Contraption then return end
 
-	local nonArmor, totals, details = ACE_CalcNonArmorPoints(Contraption, baseEnt)
+	local nonArmor, totals, details, ammoCache = ACE_CalcNonArmorPoints(Contraption, baseEnt)
 
 	Contraption.ACEPointsNonArmor = nonArmor
 	Contraption.ACEPointsPerType = Contraption.ACEPointsPerType or {}
@@ -1380,6 +1353,8 @@ local function ACE_RebuildNonArmorPoints(Contraption, baseEnt)
 		Contraption.ACEPointsPerType[key] = value
 	end
 	Contraption.ACEPointsDetails = details
+	Contraption.ACEAmmoCache = ammoCache
+	Contraption.ACENonArmorDirty = false
 end
 
 -- Rebuild armor points when dirty and synchronize totals for the breakdown.
@@ -1415,7 +1390,9 @@ function ACE_EnsureArmor(Contraption, baseEnt, force)
 		end
 	end
 
-	ACE_RebuildNonArmorPoints(Contraption, base)
+	if Contraption.ACENonArmorDirty or not Contraption.ACEPointsPerType then
+		ACE_RebuildNonArmorPoints(Contraption, base)
+	end
 
 	-- Convert armor averages to points; side armor counts double to reflect exposure.
 	local newArmorPts = (front + side * 2) * 4
@@ -1514,6 +1491,8 @@ do
 		Class.ACEArmorPoints = 0
 		Class.ACEArmorDirty = true
 		Class.ACEArmorCalculated = false
+		Class.ACENonArmorDirty = true
+		Class.ACEAmmoCache = nil
 
 		Class.ACEPointsPerType = {}
 		Class.ACEPointsPerType.Armor = 0
@@ -1536,6 +1515,11 @@ do
 		if not IsValid(Ent) then return end
 
 		local conRef = Class
+		local className = Ent:GetClass()
+		if className == "acf_ammo" or className == "acf_gun" or className == "acf_rack" then
+			Class.ACENonArmorDirty = true
+			Class.ACEAmmoCache = nil
+		end
 		local EClass = ACE_GetPtsType(Ent:GetClass())
 		local newPts = ACE_GetEntPoints(Ent)
 		local oldPts = Ent._AcePts or 0
@@ -1595,6 +1579,11 @@ do
 		Ent._ACEPointsConKey = nil
 		Ent._ACEPointsConRef = nil
 
+		local className = Ent:GetClass()
+		if className == "acf_ammo" or className == "acf_gun" or className == "acf_rack" then
+			Class.ACENonArmorDirty = true
+			Class.ACEAmmoCache = nil
+		end
 		local EClass = ACE_GetPtsType(Ent:GetClass())
 
 		if EClass == "Ignore" then return end

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -284,6 +284,10 @@ do
 			v.acflastupdatemass = ACF.CurTime
 		end
 
+		obj.acfphystotal = obj.acfphystotal or PhysMass
+		obj.acftotal = obj.acftotal or Mass
+		obj.acflastupdatemass = ACF.CurTime
+
 		if pwr then
 			--Get mass Material composition here
 			for material, tablemass in pairs(Compositions) do
@@ -297,7 +301,12 @@ do
 				end
 
 				--Gets the actual material percent of the contraption
-				PercentMat[material] = ( MatSums[material] / obj.acftotal ) or 0
+				local totalMass = obj.acftotal or Mass
+				if totalMass <= 0 then
+					PercentMat[material] = 0
+				else
+					PercentMat[material] = MatSums[material] / totalMass
+				end
 
 			end
 		end

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -134,20 +134,74 @@ ACF.MaxWeight = 200000 --The max weight in Kg
 
 ACE.CannonPointMul = 0.85 --Multiplier for cannon point cost
 ACE.EnginePointMul = 0.69 --Multiplier for engine cost in points
-ACF.PointsPerTon   = 60  --Base cost per ton of armor. Multiplier used to balance out armor
 ACE.AmmoPerTon     = 100 --Point cost per ton of ammo
 
-ACE.MatCostTables = {
-	Alum			= 1.06 * (0.8325 / 0.334),	--A 20% increase in cost for 60% reduction in weight.
-	CHA				= 0.7 * (0.98 / 1.25),	--20% more heavy for a 30% reduction in cost.
-	Cer				= 0.95 * (2.05 / 1.2),	--70% more protection per kg for a 10% increase in cost. Takes a ton of damage and evaporates if penetrated.
-	ERA				= 0.7 * (3 / 2.0),
-	Rub				= 1.05 * (0.05 / 0.2),
-	Texto			= 0.9 * (0.5 / 0.35),
-	RHA 			= 1,
-	DU				= 1.2 * (3.9 / 2.43),	--A 20% increase in cost for 40% reduction in weight.
-	Ti				= 1.3 * (1.7 / 0.61)	--A 25% increase in cost for 64% reduction in weight.
+-- Deprecated: armor mass-based cost has been replaced by LOS armor scan.
+-- ACF.PointsPerTon   = 60  --Base cost per ton of armor. Multiplier used to balance out armor
+
+-- Ammo cost scoring config for the ACE legality system.
+ACE.AmmoTypeFactors = ACE.AmmoTypeFactors or {
+	AP = 0.5,
+	APHE = 0.6,
+	APDS = 0.9,
+	APFSDS = 1.2,
+	HVAP = 0.7,
+	HEAT = 0.75,
+	HEATFS = 0.9,
+	THEAT = 0.95,
+	THEATFS = 1.0,
+	HESH = 0.4,
+	HE = 0.5,
+	HEFS = 0.6,
+	HP = 0.1,
+	CAP = 0.6,
+	CHEAT = 0.8,
+	CHE = 0.25,
+	CHF = 0,
+	SM = 0,
+	FLR = 0,
+	FL = 0.3,
+	GLATGM = 0.75,
+	["GLATGM-HE"] = 0.25,
+	Refill = 0
 }
+
+ACE.AmmoCostConfig = ACE.AmmoCostConfig or {
+	BaseRoundPts = 80, -- Base points per round before scaling.
+	RefPen = 600, -- Reference penetration (mm) for pen scaling.
+	RefCaliber = 120, -- Reference caliber (mm) for caliber scaling.
+	PenExp = 1.6, -- Penetration curve exponent.
+	RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
+	BlastExp = 1.1, -- Blast curve exponent.
+	BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
+	RpsRef = 1 / 7, -- Reference rounds per second for ROF scaling.
+	RpsExp = 0.5, -- ROF curve exponent.
+	ReadyRackBase = 2400, -- Ready rack baseline: base / caliber(mm).
+	ReadyRackMin = 10, -- Minimum ready rounds per gun group.
+	ReadyRackMax = 200, -- Maximum ready rounds per gun group.
+	ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
+	ReadyRackLowBoost = 0.5, -- Boost factor applied below pivot (0.5 = +50%).
+	StowFactor = 0.35, -- Cost multiplier for stowed rounds.
+	TailFactor = 0, -- Extra discount per round beyond tail start (0 disables).
+	TailStartMultiplier = 2 -- Tail start = readyCap * multiplier.
+}
+
+-- Armor tool UX timing.
+ACE.ArmorPreviewTapWindow = ACE.ArmorPreviewTapWindow or 0.35 -- Seconds between reload taps to trigger preview.
+ACE.ArmorPreviewCooldown = ACE.ArmorPreviewCooldown or 5 -- Seconds between preview requests per player.
+
+-- Deprecated: material cost table from the old mass-based armor system.
+-- ACE.MatCostTables = {
+-- 	Alum			= 1.06 * (0.8325 / 0.334),	--A 20% increase in cost for 60% reduction in weight.
+-- 	CHA				= 0.7 * (0.98 / 1.25),	--20% more heavy for a 30% reduction in cost.
+-- 	Cer				= 0.95 * (2.05 / 1.2),	--70% more protection per kg for a 10% increase in cost. Takes a ton of damage and evaporates if penetrated.
+-- 	ERA				= 0.7 * (3 / 2.0),
+-- 	Rub				= 1.05 * (0.05 / 0.2),
+-- 	Texto			= 0.9 * (0.5 / 0.35),
+-- 	RHA 			= 1,
+-- 	DU				= 1.2 * (3.9 / 2.43),	--A 20% increase in cost for 40% reduction in weight.
+-- 	Ti				= 1.3 * (1.7 / 0.61)	--A 25% increase in cost for 64% reduction in weight.
+-- }
 
 ---------------------------------- Misc & other ----------------------------------
 

--- a/lua/effects/acf_smoke/init.lua
+++ b/lua/effects/acf_smoke/init.lua
@@ -73,7 +73,7 @@ function EFFECT:StartSmoke( _, SmokeColor, ShootVector, WPRadius, SRadius ) --GT
 	--velocity = Vector(0, 0, 0)
 	--gravity = Vector(0, 0, 0)
 
-	
+
 
 	for _ = 0,3 do
 

--- a/lua/entities/ace_scalability/cl_init.lua
+++ b/lua/entities/ace_scalability/cl_init.lua
@@ -68,9 +68,9 @@ local function BuildRealPhysics( entity, Scale )
 
 		local SafetyCatch = true --If the mesh would generate a crash bypass it. Only time will tell what this will unleash. Likely client only desync of the hitbox.
 
-		for k, tab in pairs( Mesh ) do
-			for c, v in pairs( tab ) do
-				if v != vector_origin then
+		for _, tab in pairs( Mesh ) do
+			for _, v in pairs( tab ) do
+				if v ~= vector_origin then
 					SafetyCatch = false
 				end
 			end

--- a/lua/entities/ace_scalability/init.lua
+++ b/lua/entities/ace_scalability/init.lua
@@ -185,11 +185,28 @@ do -- AdvDupe2 duped parented ammo workaround
 	end
 
 	hook.Add("AdvDupe_FinishPasting", "ACF Parented Scalable Ent Fix", function(DupeInfo)
+		if not istable(DupeInfo) then return end
 		local Dupe	= unpack(DupeInfo, 1, 1)
+		if not istable(Dupe) then return end
 		local Player	= Dupe.Player
 		local CanParent = not IsValid(Player) or tobool(Player:GetInfo("advdupe2_paste_parents"))
 
 		if not CanParent then return end
+		if not istable(Dupe.CreatedEntities) then return end
+		local flagName = "_ACEAdvDupeScaleFix"
+		local first
+		for _, Entity in pairs(Dupe.CreatedEntities) do
+			if IsValid(Entity) then
+				first = Entity
+				break
+			end
+		end
+		if not first or first[flagName] then return end
+		for _, Entity in pairs(Dupe.CreatedEntities) do
+			if IsValid(Entity) then
+				Entity[flagName] = true
+			end
+		end
 
 		for _, Entity in pairs(Dupe.CreatedEntities) do
 			if not Entity.IsScalable then continue end

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -639,7 +639,7 @@ do
 			debugoverlay.Text(self:GetPos() + Vector(0,0,10), "Total Ammo Mass: " .. self.AmmoMassMax .. "kgs", 20 )
 
 			if WeaponType ~= "missile" then
-				self.ACEPoints = math.ceil(self.AmmoMassMax / 1000 * ACE.AmmoPerTon)
+				self.ACEPoints = math.ceil(AmmoMaxMass / 1000 * ACE.AmmoPerTon)
 			else
 				local BulletData2 = ACFM_CompactBulletData(self)
 				local MissileCost = CalculateMissileCost(BulletData2)

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -233,7 +233,15 @@ function ENT:Update( ArgsTable )
 	self.SpecialDamage     = true
 	self.TorqueMult        = self.TorqueMult or 1
 	self.FuelTank          = 0
-	self.ACEPoints			= Lookup.acepoints or 404
+	local FuelCostMul = {
+		Petrol				= 1.0,
+		Diesel				= 1.2, --Due to generally higher torques
+		Multifuel			= 1.2, --Due to generally higher torques
+		Electric			= 0.8 --Due to odd power outputs
+	}
+	local PtsPerHP = 2.33 / 1.5 --Added 1.5 mul from torque boost antics for any engines without a defined hp cost.
+	local FallBackCost = (self.peakkw / 0.7457) * PtsPerHP * (FuelCostMul[self.FuelType] or 1)
+	self.ACEPoints			= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointMul)
 
 	self.TorqueScale		= ACF.TorqueScale[self.EngineType]
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -1295,7 +1295,8 @@ do
 	function CalculateMissileCost(BulletData) --Used for both the missiles on the rack and the ammo entities
 		local Pts = ACF_GetRackValue(BulletData, "pointcost") or ACF_GetGunValue(BulletData.Id, "pointcost") or 0.9
 		local Guid = BulletData.Data7 or "Dumb"
-		Pts = Pts * MissileGuidanceFactors[Guid] or 0
+		local factor = MissileGuidanceFactors[Guid] or MissileGuidanceFactors.Dumb or 1
+		Pts = Pts * factor
 		return Pts
 
 	end

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -531,16 +531,16 @@ if CLIENT then
 		table.Add(Tabletxt,TPoints)
 
 		local FractionalPts = "/" .. PointVal
+		local sideWeighted = SideArm * 2
+		local cost = (FrontArm + sideWeighted) * 4
+		table.Add(Tabletxt,{ Color4, "Armor scan: "})
+		table.Add(Tabletxt,{ Color3, string.format("front=%.2f  side=%.2f", FrontArm, SideArm) .. Sep})
 		table.Add(Tabletxt,{ Color4, "Armor: "})
 		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsArmor / PointVal * 100,0) .. "%) - " .. PtsArmor .. FractionalPts ..  Sep})
 		table.Add(Tabletxt,{ Color4, "Engines: "})
 		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsEngine / PointVal * 100,0) .. "%) - " .. PtsEngine .. FractionalPts ..  Sep})
 		table.Add(Tabletxt,{ Color4, "Firepower: "})
 		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsFirepower / PointVal * 100,0) .. "%) - " .. PtsFirepower .. FractionalPts ..  Sep})
-		local sideWeighted = SideArm * 2
-		local cost = (FrontArm + sideWeighted) * 4
-		table.Add(Tabletxt,{ Color4, "Armor scan ((front + side*2) x4): "})
-		table.Add(Tabletxt,{ Color3, string.format("front=%.2f  side=%.2f  side*2=%.2f  cost=%.2f", FrontArm, SideArm, sideWeighted, cost) .. Sep})
 		table.Add(Tabletxt,{ Color4, "Fuel: "})
 		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsFuel / PointVal * 100,0) .. "%) - " .. PtsFuel .. FractionalPts ..  Sep})
 		table.Add(Tabletxt,{ Color4, "Ammo: "})

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -18,12 +18,12 @@ if CLIENT then
 	}
 end
 
---Used by the panel. If i can to use the TOOL itself for this, i would be really appreciated
+-- Shared panel state used across panel rebuilds to keep UI controls stable.
 local ToolPanel = ToolPanel or {}
 
-CreateClientConVar( "acfarmorprop_area", 0, false, true ) -- we don't want this one to save
+CreateClientConVar( "acfarmorprop_area", 0, false, true ) -- Transient area cache; do not persist.
 
--- Calculates mass, armor, and health given prop area and desired ductility and thickness.
+-- Compute mass, armor, and health from prop area, ductility, thickness, and material.
 local function CalcArmor( Area, Ductility, Thickness, Mat )
 
 	Mat = Mat or "RHA"
@@ -40,7 +40,7 @@ local function CalcArmor( Area, Ductility, Thickness, Mat )
 end
 
 
--- Apply settings to prop and store dupe info
+-- Apply tool settings to a prop and store duplicator metadata.
 local function ApplySettings( _, ent, data )
 
 	if not SERVER then return end
@@ -60,7 +60,8 @@ local function ApplySettings( _, ent, data )
 
 	local con = ent:GetContraption()
 
-	if con then ACE_RemPts(con, ent) end --Stupid roundabout fix. But only executed when the mat is changed. Hey if it works.
+	-- Rebuild contraption points when material changes to keep totals consistent.
+	if con then ACE_RemPts(con, ent) end
 
 	if data.Material then
 		ent.ACF = ent.ACF or {}
@@ -75,7 +76,7 @@ end
 duplicator.RegisterEntityModifier( "acfsettings", ApplySettings )
 duplicator.RegisterEntityModifier( "mass", ApplySettings )
 
--- Apply settings to prop
+-- Left-click applies the current tool settings to the targeted prop.
 function TOOL:LeftClick( trace )
 
 	local ent = trace.Entity
@@ -94,14 +95,14 @@ function TOOL:LeftClick( trace )
 
 	ApplySettings( ply, ent, { Mass = mass , Ductility = ductility, Material = material} )
 
-	-- this invalidates the entity and forces a refresh of networked armor values
+	-- Clear cached target to force a fresh network update of armor values.
 	self.AimEntity = nil
 
 	return true
 
 end
 
--- Suck settings from prop
+-- Right-click copies the targeted prop settings into the tool.
 function TOOL:RightClick( trace )
 
 	local ent = trace.Entity
@@ -116,14 +117,15 @@ function TOOL:RightClick( trace )
 	ply:ConCommand( "acfarmorprop_thickness " .. ent.ACF.MaxArmour )
 	ply:ConCommand( "acfarmorprop_material " .. (ent.ACF.Material or "RHA") )
 
-	-- this invalidates the entity and forces a refresh of networked armor values
+	-- Clear cached target to force a fresh network update of armor values.
 	self.AimEntity = nil
 
 	return true
 
 end
 
-do -- Allowing everyone to read contraptions
+do
+	-- Allow read-only armor inspection even when CanTool would block edits.
 	ACE_OldHookCall = ACE_OldHookCall or hook.Call
 
 	function hook.Call(Name, Gamemode, Player, Entity, Tool, ...)
@@ -135,7 +137,7 @@ do -- Allowing everyone to read contraptions
 	end
 end
 
--- Total up mass of constrained ents
+-- Reload aggregates mass across constrained entities.
 function TOOL:Reload( trace )
 
 	local ent = trace.Entity
@@ -152,17 +154,17 @@ function TOOL:Reload( trace )
 
 	local power		= data.Power
 
-	local GeneralTb	= { data.MaterialMass, data.MaterialPercent }
+	local Contraption = ent:GetContraption() or nil
+	local details = Contraption and Contraption.ACEPointsDetails or nil
+
+	local GeneralTb	= { data.MaterialMass, data.MaterialPercent, details }
 	local ToJSON		= util.TableToJSON( GeneralTb )
 	local Compressed	= util.Compress(ToJSON)
-
-	local Contraption = ent:GetContraption() or nil
 	local PointVal		= 0
 
 	local PtsArmor = 0
 	local PtsEngine = 0
 	local PtsFirepower = 0
-	local PtsFuel = 0
 	local PtsAmmo = 0
 	local PtsCrew = 0
 	local PtsElectronics = 0
@@ -174,7 +176,6 @@ function TOOL:Reload( trace )
 		PtsArmor = Contraption.ACEPointsPerType.Armor
 		PtsEngine = Contraption.ACEPointsPerType.Engines
 		PtsFirepower = Contraption.ACEPointsPerType.Firepower
-		PtsFuel = Contraption.ACEPointsPerType.Fuel
 		PtsAmmo = Contraption.ACEPointsPerType.Ammo
 		PtsCrew = Contraption.ACEPointsPerType.Crew
 		PtsElectronics = Contraption.ACEPointsPerType.Electronics
@@ -188,7 +189,7 @@ function TOOL:Reload( trace )
 	if Contraption ~= nil and Contraption.ACEArmorCalculated then
 		frontArm = Contraption.ACEArmorFront or 0
 		sideArm = Contraption.ACEArmorSide or 0
-	elseif ACE_GetArmorScan then
+	elseif Contraption == nil and ACE_GetArmorScan then
 		frontArm, sideArm = ACE_GetArmorScan(ent)
 	end
 
@@ -202,7 +203,6 @@ function TOOL:Reload( trace )
 		net.WriteFloat(PtsArmor)
 		net.WriteFloat(PtsEngine)
 		net.WriteFloat(PtsFirepower)
-		net.WriteFloat(PtsFuel)
 		net.WriteFloat(PtsAmmo)
 		net.WriteFloat(PtsCrew)
 		net.WriteFloat(PtsElectronics)
@@ -211,7 +211,8 @@ function TOOL:Reload( trace )
 		net.WriteBool(ArmorDirty)
 		net.WriteBool(ArmorInitMissing)
 
-		net.WriteData(Compressed)
+		net.WriteUInt(#Compressed, 16)
+		net.WriteData(Compressed, #Compressed)
 
 	net.Send(self:GetOwner())
 
@@ -269,10 +270,10 @@ if CLIENT then
 
 	local getPhrase = language.GetPhrase
 
-	--Required in order to update material data inserted in client convars
+	-- Normalize legacy material values stored in client convars.
 	local function ACE_MaterialCheck( Material )
 
-		--Convert old numeric IDs to the new string IDs
+		-- Map legacy numeric ids to string ids.
 		local BackCompMat = {
 			"RHA",
 			"CHA",
@@ -283,23 +284,23 @@ if CLIENT then
 			"Texto"
 		}
 
-		--Refreshing the data, so we can replace non valid data with the callback.
+		-- If the convar holds a legacy id, replace it with the modern id.
 		if isnumber(tonumber(Material)) then
 
 			local Mat_ID = math.Clamp(Material + 1, 1,7)
 			Material = BackCompMat[Mat_ID]
 
-			--Updates the convar with the proper material
+			-- Write back the normalized material id.
 			RunConsoleCommand( "acfarmorprop_material", Material )
 		end
 	end
 
-	--Looks like client convars are not initialized very quickly, so we will wait a bit until they become valid.
+	-- Delay normalization to allow client convars to initialize.
 	timer.Simple(0.1, function()
 		ACE_MaterialCheck( GetConVar("acfarmorprop_material"):GetString() )
 	end )
 
-	--Replicated from PANEL:CPanelText(Name, Desc, Font). No idea why this doesnt work with this function out of this file
+	-- Helper to add centered help text; mirrors PANEL:CPanelText for this file.
 	local function ArmorPanelText( name, panel, desc, font )
 
 		if not PanelTxt then PanelTxt = {} end
@@ -321,7 +322,7 @@ if CLIENT then
 
 	end
 
-	-- Material ComboBox creation
+	-- Build or refresh the material combo box.
 	local function MaterialTable( panel )
 
 		local MaterialTypes = ACE.ArmorTypes
@@ -344,7 +345,7 @@ if CLIENT then
 			ToolPanel.ComboMat:Clear()
 		end
 
-		-- (Re)populate choices every time to avoid stale lists
+		-- Rebuild the list each time to avoid stale entries.
 		for _, Mat  in pairs(MaterialTypes) do
 			local year = Mat.year or 0
 			if (ACF.Year or 0) >= year then
@@ -364,14 +365,14 @@ if CLIENT then
 		ArmorPanelText( "ComboYear" , ToolPanel.panel, getPhrase("tool.acfarmorprop.year") .. ": " .. (MaterialData.year or "unknown") )
 
 		function ToolPanel.ComboMat:OnSelect(_, value, data)
-			-- data carries the real material id; fallback to value if missing
+			-- Use provided material id when available; fallback to display value.
 			local matId = tostring(data or value)
 			RunConsoleCommand("acfarmorprop_material", matId)
 			self:SetValue(value)
 		end
 	end
 
-	--Main menu building
+	-- Build the tool control panel.
 	function TOOL.BuildCPanel( panel )
 		local Presets = vgui.Create( "ControlPresets" )
 
@@ -392,13 +393,13 @@ if CLIENT then
 
 	end
 
-	-- clamp thickness if the change in ductility puts mass out of range
-	cvars.RemoveChangeCallback( "acfarmorprop_ductility", "acfarmorprop_ductility" ) -- Reload support
+	-- When ductility changes, adjust thickness to keep mass within bounds.
+	cvars.RemoveChangeCallback( "acfarmorprop_ductility", "acfarmorprop_ductility" ) -- Clear any prior callback so reloads do not stack.
 	cvars.AddChangeCallback( "acfarmorprop_ductility", function( _, _, value )
 
 		local area = GetConVar( "acfarmorprop_area" ):GetFloat()
 
-		-- don't bother recalculating if we don't have a valid ent
+		-- Skip if no valid area has been sampled.
 		if area == 0 then return end
 
 		local ductility = math.Clamp( ( tonumber( value ) or 0 ) / 100, -0.8, 0.8 )
@@ -420,13 +421,13 @@ if CLIENT then
 
 	end, "acfarmorprop_ductility")
 
-	-- clamp ductility if the change in thickness puts mass out of range
+	-- When thickness changes, adjust ductility to keep mass within bounds.
 	cvars.RemoveChangeCallback( "acfarmorprop_thickness", "acfarmorprop_thickness" )
 	cvars.AddChangeCallback( "acfarmorprop_thickness", function( _, _, value )
 
 		local area = GetConVar( "acfarmorprop_area" ):GetFloat()
 
-		-- don't bother recalculating if we don't have a valid ent
+		-- Skip if no valid area has been sampled.
 		if area == 0 then return end
 
 		local thickness = math.Clamp( tonumber( value ) or 0, 0.1, 5000 )
@@ -448,7 +449,7 @@ if CLIENT then
 
 	end, "acfarmorprop_thickness")
 
-	-- Refresh Armor material info on menu
+	-- Update material details when selection changes.
 	cvars.RemoveChangeCallback( "acfarmorprop_material", "acfarmorprop_material" )
 	cvars.AddChangeCallback( "acfarmorprop_material", function( _, _, value )
 
@@ -456,10 +457,10 @@ if CLIENT then
 
 				local MatData = ACE_GetMaterialData( value )
 
-				--Use RHA if the choosen material is invalid or doesnt exist
+				-- Fallback to RHA if the selected material is invalid.
 				if not MatData then RunConsoleCommand( "acfarmorprop_material", "RHA" ) return end
 
-				--Too redundant, ik, but looks like the unique way to have it working even when right clicking a prop
+				-- Ensure the combo box reflects updates triggered from props.
 				ToolPanel.ComboMat:SetText(MatData.sname)
 
 				ArmorPanelText( "ComboTitle", ToolPanel.panel, MatData.name , "DermaDefaultBold" )
@@ -485,7 +486,7 @@ if CLIENT then
 		local phystotal	= math.Round( net.ReadFloat(), 1 )
 		local parenttotal	= math.Round( net.ReadFloat(), 1 )
 		local physratio	= math.Round( net.ReadFloat(), 1 )
-		local power		= net.ReadFloat() -- Note: intentional
+		local power		= net.ReadFloat() -- Preserve precision for hp/ton calculation.
 
 
 		local hpton		= math.Round( power / (total / 1000), 1 )
@@ -494,7 +495,6 @@ if CLIENT then
 		local PtsArmor = math.Round( net.ReadFloat(), 1 )
 		local PtsEngine = math.Round( net.ReadFloat(), 1 )
 		local PtsFirepower = math.Round( net.ReadFloat(), 1 )
-		local PtsFuel = math.Round( net.ReadFloat(), 1 )
 		local PtsAmmo = math.Round( net.ReadFloat(), 1 )
 		local PtsCrew = math.Round( net.ReadFloat(), 1 )
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
@@ -503,25 +503,28 @@ if CLIENT then
 		local ArmorDirty = net.ReadBool()
 		local ArmorInitMissing = net.ReadBool()
 
-		local Compressed	= net.ReadData(640)
-		local Decompress	= util.Decompress(Compressed)
-		local FromJSON	= util.JSONToTable( Decompress )
+		local compressedLen = net.ReadUInt(16)
+		local Compressed = compressedLen > 0 and net.ReadData(compressedLen) or nil
+		local Decompress = Compressed and util.Decompress(Compressed) or nil
+		local FromJSON = Decompress and util.JSONToTable(Decompress) or nil
 
-		local Sep = "\n"
+	local Sep = "\n"
 
-		local Tabletxt	= {}
+	local Tabletxt	= {}
 
-		local PTBreakdownHeader		= { Color2, "<|",Color1, "|============|", Color2, "[- Cost Breakdown -]", Color1, "|============|",Color2, "|>" .. Sep }
+	local function pct(part, total)
+		if total <= 0 then return 0 end
+		return math.Round(part / total * 100, 0)
+	end
+
+	local PTBreakdownHeader		= { Color2, "<|",Color1, "|============|", Color2, "[- Cost Breakdown -]", Color1, "|============|",Color2, "|>" .. Sep }
 
 
 		local Title		= { Color2, "<|",Color1, "|============|", Color2, "[- Contraption Summary -]", Color1, "|============|",Color2, "|>" .. Sep }
-		--local ArmorComp1	= { Color4, "- Armor composition: " .. Sep }
 		local TMass2		= { Color4, "-Mass Ratio: ",Color3, "" .. phystotal .. "kg", Color4, " physical, ", Color3, "" .. parenttotal .. "kg", Color4, " parented / ", Color3, physratio .. "%", Color4, " physical )" .. Sep }
 
 		local Engine		= { Color4, "-Total Power: ", Color3, "" .. math.Round(power, 1), Color4," hp -> ",Color3, "" .. hpton, Color4, " hp/ton" .. Sep }
 
-
-		--PointVal
 
 		Tabletxt = table.Add(Tabletxt, PTBreakdownHeader)
 
@@ -540,26 +543,30 @@ if CLIENT then
 		end
 
 		local FractionalPts = "/" .. PointVal
-		table.Add(Tabletxt,{ Color4, "Armor scan: "})
-		table.Add(Tabletxt,{ Color3, string.format("front=%.2f  side=%.2f", FrontArm, SideArm) .. Sep})
-		table.Add(Tabletxt,{ Color4, "Armor: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsArmor / PointVal * 100,0) .. "%) - " .. PtsArmor .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Engines: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsEngine / PointVal * 100,0) .. "%) - " .. PtsEngine .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Firepower: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsFirepower / PointVal * 100,0) .. "%) - " .. PtsFirepower .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Fuel: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsFuel / PointVal * 100,0) .. "%) - " .. PtsFuel .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Ammo: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsAmmo / PointVal * 100,0) .. "%) - " .. PtsAmmo .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Crew: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsCrew / PointVal * 100,0) .. "%) - " .. PtsCrew .. FractionalPts ..  Sep})
-		table.Add(Tabletxt,{ Color4, "Electronics: "})
-		table.Add(Tabletxt,{ Color3, "(" .. math.Round(PtsElectronics / PointVal * 100,0) .. "%) - " .. PtsElectronics .. FractionalPts .. Sep})
+		table.Add(Tabletxt, { Color4, "Armor scan: ", Color3, string.format("front=%.2fmm  side=%.2fmm", FrontArm, SideArm) .. Sep })
+		table.Add(Tabletxt, { Color4, "Armor: ", Color3, "(" .. pct(PtsArmor, PointVal) .. "%) - " .. PtsArmor .. FractionalPts .. Sep })
+		table.Add(Tabletxt, { Color4, "Engines: ", Color3, "(" .. pct(PtsEngine, PointVal) .. "%) - " .. PtsEngine .. FractionalPts .. Sep })
+		if PtsFirepower > 0 then
+			table.Add(Tabletxt, { Color4, "Firepower: ", Color3, "(" .. pct(PtsFirepower, PointVal) .. "%) - " .. PtsFirepower .. FractionalPts .. Sep })
+		end
+		table.Add(Tabletxt, { Color4, "Ammo: ", Color3, "(" .. pct(PtsAmmo, PointVal) .. "%) - " .. PtsAmmo .. FractionalPts .. Sep })
+		table.Add(Tabletxt, { Color4, "Crew: ", Color3, "(" .. pct(PtsCrew, PointVal) .. "%) - " .. PtsCrew .. FractionalPts .. Sep })
+		table.Add(Tabletxt, { Color4, "Electronics: ", Color3, "(" .. pct(PtsElectronics, PointVal) .. "%) - " .. PtsElectronics .. FractionalPts .. Sep })
+
+		-- Optional server-provided breakdown of highest-cost items.
+		local Details = FromJSON and FromJSON[3]
+		if Details and Details.Items and #Details.Items > 0 then
+			table.Add(Tabletxt,{ Color4, "- Top Cost Items:" .. Sep})
+			for _, item in ipairs(Details.Items) do
+				local category = item.Category or item.category or "Item"
+				local label = item.Label or item.label or ""
+				local pts = item.Points or item.points or item.Pts or item.pts or 0
+				table.Add(Tabletxt, { Color4, category .. ": ", Color3, string.format("%s - %.1fpts", label, pts) .. Sep })
+			end
+		end
 
 		Tabletxt = table.Add(Tabletxt, Title)
 		Tabletxt = table.Add(Tabletxt,TMass2)
-		--Tabletxt = table.Add(Tabletxt,ArmorComp1)
 
 
 		local Count = 0
@@ -687,10 +694,10 @@ if CLIENT then
 			surface.DrawTexturedRect( 0, 0, 256, 256 )
 			surface.SetFont( "Torchfont" )
 
-			-- header
+			-- Screen title.
 			draw.SimpleTextOutlined( "#tool.acfarmorprop.armorinfo", "Torchfont", 128, 30, Color( 224, 224, 255, 255 ), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 4, color_black )
 
-			-- armor bar
+			-- Armor progress bar.
 			draw.RoundedBox( 6, 10, 83, 236, 64, Color( 200, 200, 200, 255 ) )
 			if Armour ~= 0 and MaxArmour ~= 0 then
 				draw.RoundedBox( 6, 15, 88, Armour / MaxArmour * 226, 54, Color( 0, 0, 200, 255 ) )
@@ -699,7 +706,7 @@ if CLIENT then
 			draw.SimpleTextOutlined( "#tool.acfarmorprop.armor", "Torchfont", 128, 100, Color( 224, 224, 255, 255 ), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 4, color_black )
 			draw.SimpleTextOutlined( ArmourTxt, "Torchfont", 128, 130, Color( 224, 224, 255, 255 ), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER, 4, color_black )
 
-			-- health bar
+			-- Health progress bar.
 			draw.RoundedBox( 6, 10, 183, 236, 64, Color( 200, 200, 200, 255 ) )
 			if Health ~= 0 and MaxHealth ~= 0 then
 				draw.RoundedBox( 6, 15, 188, Health / MaxHealth * 226, 54, Color( 200, 0, 0, 255 ) )

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -583,9 +583,9 @@ if CLIENT then
 		local ArmorInitMissing = net.ReadBool()
 		local HypoRequested = net.ReadBool()
 		local HypoUsed = net.ReadBool()
-		local HypoFront = math.Round( net.ReadFloat(), 2 )
-		local HypoSide = math.Round( net.ReadFloat(), 2 )
-		local HypoPts = math.Round( net.ReadFloat(), 1 )
+		net.ReadFloat()
+		net.ReadFloat()
+		net.ReadFloat()
 
 		local compressedLen = net.ReadUInt(16)
 		local Compressed = compressedLen > 0 and net.ReadData(compressedLen) or nil

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -148,7 +148,8 @@ function TOOL:Reload( trace )
 	local ply = self:GetOwner()
 	local now = CurTime()
 	local lastReload = ply.ACE_ArmorReloadLast or 0
-	local doubleTap = (now - lastReload) <= 0.35
+	local doubleTapWindow = ACE.ArmorPreviewTapWindow or 0.35
+	local doubleTap = (now - lastReload) <= doubleTapWindow
 	ply.ACE_ArmorReloadLast = now
 
 	local data		= ACF_CalcMassRatio(ent, true)
@@ -239,7 +240,8 @@ function TOOL:Reload( trace )
 				PtsElectronics = totals.Electronics or 0
 				details = hypoDetails
 			end
-			ply.ACE_ArmorHypoNext = now + 5
+			local cooldown = ACE.ArmorPreviewCooldown or 5
+			ply.ACE_ArmorHypoNext = now + cooldown
 		end
 	end
 

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -145,6 +145,12 @@ function TOOL:Reload( trace )
 	if not IsValid( ent ) or ent:IsPlayer() then return false end
 	if CLIENT then return true end
 
+	local ply = self:GetOwner()
+	local now = CurTime()
+	local lastReload = ply.ACE_ArmorReloadLast or 0
+	local doubleTap = (now - lastReload) <= 0.35
+	ply.ACE_ArmorReloadLast = now
+
 	local data		= ACF_CalcMassRatio(ent, true)
 
 	local total		= ent.acftotal
@@ -156,20 +162,25 @@ function TOOL:Reload( trace )
 
 	local Contraption = ent:GetContraption() or nil
 	local details = Contraption and Contraption.ACEPointsDetails or nil
-
-	local GeneralTb	= { data.MaterialMass, data.MaterialPercent, details }
-	local ToJSON		= util.TableToJSON( GeneralTb )
-	local Compressed	= util.Compress(ToJSON)
 	local PointVal		= 0
 
 	local PtsArmor = 0
 	local PtsEngine = 0
 	local PtsFirepower = 0
 	local PtsAmmo = 0
+	local PtsAmmoReady = 0
+	local PtsAmmoBackup = 0
+	local AmmoReadyRounds = 0
+	local AmmoBackupRounds = 0
 	local PtsCrew = 0
 	local PtsElectronics = 0
 	local ArmorDirty = false
 	local ArmorInitMissing = false
+	local HypoUsed = false
+	local HypoFront = 0
+	local HypoSide = 0
+	local HypoPts = 0
+	local HypoRequested = doubleTap
 
 		if Contraption ~= nil then
 		PointVal		= Contraption.ACEPoints or ACE_GetEntPoints(ent) or 0
@@ -177,6 +188,10 @@ function TOOL:Reload( trace )
 		PtsEngine = Contraption.ACEPointsPerType.Engines
 		PtsFirepower = Contraption.ACEPointsPerType.Firepower
 		PtsAmmo = Contraption.ACEPointsPerType.Ammo
+		PtsAmmoReady = Contraption.ACEPointsPerType.AmmoReady or 0
+		PtsAmmoBackup = Contraption.ACEPointsPerType.AmmoBackup or 0
+		AmmoReadyRounds = Contraption.ACEPointsPerType.AmmoReadyRounds or 0
+		AmmoBackupRounds = Contraption.ACEPointsPerType.AmmoBackupRounds or 0
 		PtsCrew = Contraption.ACEPointsPerType.Crew
 		PtsElectronics = Contraption.ACEPointsPerType.Electronics
 		ArmorDirty = Contraption.ACEArmorDirty and Contraption.ACEArmorCalculated
@@ -193,6 +208,50 @@ function TOOL:Reload( trace )
 		frontArm, sideArm = ACE_GetArmorScan(ent)
 	end
 
+	if doubleTap and ACE_GetArmorScan then
+		local nextAllowed = ply.ACE_ArmorHypoNext or 0
+		if now < nextAllowed then
+			local wait = math.max(0, nextAllowed - now)
+			ply:ChatPrint(string.format("[ACE] Armor preview is on cooldown (%.1fs).", wait))
+		else
+			local scanEnt = ent
+			if Contraption and Contraption.GetACEBaseplate then
+				local base = Contraption:GetACEBaseplate()
+				if IsValid(base) then
+					scanEnt = base
+				end
+			end
+			HypoFront, HypoSide = ACE_GetArmorScan(scanEnt)
+			HypoPts = (HypoFront + HypoSide * 2) * 4
+			HypoUsed = true
+			if ACE_CalcNonArmorPoints and Contraption then
+				local nonArmor, totals, hypoDetails = ACE_CalcNonArmorPoints(Contraption, scanEnt)
+				PointVal = nonArmor + HypoPts
+				PtsArmor = HypoPts
+				PtsEngine = totals.Engines or 0
+				PtsFirepower = totals.Firepower or 0
+				PtsAmmo = totals.Ammo or 0
+				PtsAmmoReady = totals.AmmoReady or 0
+				PtsAmmoBackup = totals.AmmoBackup or 0
+				AmmoReadyRounds = totals.AmmoReadyRounds or 0
+				AmmoBackupRounds = totals.AmmoBackupRounds or 0
+				PtsCrew = totals.Crew or 0
+				PtsElectronics = totals.Electronics or 0
+				details = hypoDetails
+			end
+			ply.ACE_ArmorHypoNext = now + 5
+		end
+	end
+
+	if HypoUsed then
+		frontArm = HypoFront
+		sideArm = HypoSide
+	end
+
+	local GeneralTb	= { data.MaterialMass, data.MaterialPercent, details }
+	local ToJSON		= util.TableToJSON( GeneralTb )
+	local Compressed	= util.Compress(ToJSON)
+
 	net.Start("ACE_ArmorSummary")
 		net.WriteFloat(total)
 		net.WriteFloat(phystotal)
@@ -204,12 +263,21 @@ function TOOL:Reload( trace )
 		net.WriteFloat(PtsEngine)
 		net.WriteFloat(PtsFirepower)
 		net.WriteFloat(PtsAmmo)
+		net.WriteFloat(PtsAmmoReady)
+		net.WriteFloat(PtsAmmoBackup)
+		net.WriteFloat(AmmoReadyRounds)
+		net.WriteFloat(AmmoBackupRounds)
 		net.WriteFloat(PtsCrew)
 		net.WriteFloat(PtsElectronics)
 		net.WriteFloat(frontArm)
 		net.WriteFloat(sideArm)
 		net.WriteBool(ArmorDirty)
 		net.WriteBool(ArmorInitMissing)
+		net.WriteBool(HypoRequested)
+		net.WriteBool(HypoUsed)
+		net.WriteFloat(HypoFront)
+		net.WriteFloat(HypoSide)
+		net.WriteFloat(HypoPts)
 
 		net.WriteUInt(#Compressed, 16)
 		net.WriteData(Compressed, #Compressed)
@@ -236,7 +304,14 @@ function TOOL:Think()
 
 		local Mat = ent.ACF.Material or "RHA"
 		local MatData =  ACE_GetMaterialData( Mat )
-		local AcePts = ACE_GetEntPoints(ent)
+		local AcePts = 0
+		local cls = ent:GetClass()
+		if cls == "acf_ammo" and ACE_GetAmmoCratePointsForContraption then
+			local con = ent:GetContraption()
+			AcePts = ACE_GetAmmoCratePointsForContraption(ent, con, ent) or 0
+		else
+			AcePts = ACE_GetEntPoints(ent)
+		end
 
 		if not MatData then return end
 
@@ -496,12 +571,21 @@ if CLIENT then
 		local PtsEngine = math.Round( net.ReadFloat(), 1 )
 		local PtsFirepower = math.Round( net.ReadFloat(), 1 )
 		local PtsAmmo = math.Round( net.ReadFloat(), 1 )
+		local PtsAmmoReady = math.Round( net.ReadFloat(), 1 )
+		local PtsAmmoBackup = math.Round( net.ReadFloat(), 1 )
+		local AmmoReadyRounds = math.Round( net.ReadFloat(), 0 )
+		local AmmoBackupRounds = math.Round( net.ReadFloat(), 0 )
 		local PtsCrew = math.Round( net.ReadFloat(), 1 )
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
 		local FrontArm = math.Round( net.ReadFloat(), 2 )
 		local SideArm = math.Round( net.ReadFloat(), 2 )
 		local ArmorDirty = net.ReadBool()
 		local ArmorInitMissing = net.ReadBool()
+		local HypoRequested = net.ReadBool()
+		local HypoUsed = net.ReadBool()
+		local HypoFront = math.Round( net.ReadFloat(), 2 )
+		local HypoSide = math.Round( net.ReadFloat(), 2 )
+		local HypoPts = math.Round( net.ReadFloat(), 1 )
 
 		local compressedLen = net.ReadUInt(16)
 		local Compressed = compressedLen > 0 and net.ReadData(compressedLen) or nil
@@ -511,6 +595,44 @@ if CLIENT then
 	local Sep = "\n"
 
 	local Tabletxt	= {}
+
+	local function formatAmmoLines(lines)
+		if not istable(lines) then return {} end
+
+		local entries = {}
+		for _, entry in ipairs(lines) do
+			local count = tonumber(entry.Count or entry.count or 0) or 0
+			if count > 0 then
+				entries[#entries + 1] = {
+					count = math.floor(count + 0.5),
+					caliber = tonumber(entry.Caliber or entry.caliber or 0) or 0,
+					atype = tostring(entry.Type or entry.type or "Ammo"),
+					state = tostring(entry.State or entry.state or "")
+				}
+			end
+		end
+
+		table.sort(entries, function(a, b)
+			if a.caliber == b.caliber then
+				if a.atype == b.atype then
+					if a.state == b.state then
+						return a.count > b.count
+					end
+					return a.state == "READY"
+				end
+				return a.atype < b.atype
+			end
+			return a.caliber > b.caliber
+		end)
+
+		local formatted = {}
+		for _, entry in ipairs(entries) do
+			local calText = entry.caliber > 0 and string.format("%dmm", entry.caliber) or "0mm"
+			formatted[#formatted + 1] = string.format("%dx%s %s %s", entry.count, calText, entry.atype, entry.state)
+		end
+
+		return formatted
+	end
 
 	local function pct(part, total)
 		if total <= 0 then return 0 end
@@ -523,47 +645,68 @@ if CLIENT then
 		local Title		= { Color2, "<|",Color1, "|============|", Color2, "[- Contraption Summary -]", Color1, "|============|",Color2, "|>" .. Sep }
 		local TMass2		= { Color4, "-Mass Ratio: ",Color3, "" .. phystotal .. "kg", Color4, " physical, ", Color3, "" .. parenttotal .. "kg", Color4, " parented / ", Color3, physratio .. "%", Color4, " physical )" .. Sep }
 
-		local Engine		= { Color4, "-Total Power: ", Color3, "" .. math.Round(power, 1), Color4," hp -> ",Color3, "" .. hpton, Color4, " hp/ton" .. Sep }
+	local Engine		= { Color4, "-Total Power: ", Color3, "" .. math.Round(power, 1), Color4," hp -> ",Color3, "" .. hpton, Color4, " hp/ton" .. Sep }
 
+		local Details = FromJSON and FromJSON[3] or nil
+		local ammoLines = formatAmmoLines(Details and Details.AmmoLines)
 
-		Tabletxt = table.Add(Tabletxt, PTBreakdownHeader)
-
-		local TPoints = {}
-		if PointVal > ACF.PointsLimit then
-			local OverPoints = PointVal - ACF.PointsLimit
-			TPoints		= { Color4, "Total Cost: ", Color1, "" .. PointVal .. "pts", Color2, "  -  ", Color1, OverPoints .. " pts over" .. Sep }
-		else
-			TPoints		= { Color4, "Total Cost: ", Color3, "" .. PointVal .. "pts" .. Sep }
-		end
-		table.Add(Tabletxt,TPoints)
-		if ArmorDirty then
-			table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
-		elseif ArmorInitMissing then
-			table.Add(Tabletxt, { Color2, "[!] Armor cost not initialized; unfreeze or enter vehicle." .. Sep })
-		end
-
-		local FractionalPts = "/" .. PointVal
-		table.Add(Tabletxt, { Color4, "Armor scan: ", Color3, string.format("front=%.2fmm  side=%.2fmm", FrontArm, SideArm) .. Sep })
-		table.Add(Tabletxt, { Color4, "Armor: ", Color3, "(" .. pct(PtsArmor, PointVal) .. "%) - " .. PtsArmor .. FractionalPts .. Sep })
-		table.Add(Tabletxt, { Color4, "Engines: ", Color3, "(" .. pct(PtsEngine, PointVal) .. "%) - " .. PtsEngine .. FractionalPts .. Sep })
-		if PtsFirepower > 0 then
-			table.Add(Tabletxt, { Color4, "Firepower: ", Color3, "(" .. pct(PtsFirepower, PointVal) .. "%) - " .. PtsFirepower .. FractionalPts .. Sep })
-		end
-		table.Add(Tabletxt, { Color4, "Ammo: ", Color3, "(" .. pct(PtsAmmo, PointVal) .. "%) - " .. PtsAmmo .. FractionalPts .. Sep })
-		table.Add(Tabletxt, { Color4, "Crew: ", Color3, "(" .. pct(PtsCrew, PointVal) .. "%) - " .. PtsCrew .. FractionalPts .. Sep })
-		table.Add(Tabletxt, { Color4, "Electronics: ", Color3, "(" .. pct(PtsElectronics, PointVal) .. "%) - " .. PtsElectronics .. FractionalPts .. Sep })
-
-		-- Optional server-provided breakdown of highest-cost items.
-		local Details = FromJSON and FromJSON[3]
-		if Details and Details.Items and #Details.Items > 0 then
-			table.Add(Tabletxt,{ Color4, "- Top Cost Items:" .. Sep})
-			for _, item in ipairs(Details.Items) do
-				local category = item.Category or item.category or "Item"
-				local label = item.Label or item.label or ""
-				local pts = item.Points or item.points or item.Pts or item.pts or 0
-				table.Add(Tabletxt, { Color4, category .. ": ", Color3, string.format("%s - %.1fpts", label, pts) .. Sep })
+		local showBreakdown = not (ArmorInitMissing and not HypoUsed)
+		if not showBreakdown then
+			if not HypoRequested then
+				table.Add(Tabletxt, {
+					Color1,
+					"[!] ARMOR COST NOT INITIALIZED. ",
+					Color2,
+					"Unfreeze or enter vehicle. Double-tap R to preview." .. Sep
+				})
 			end
+		else
+			Tabletxt = table.Add(Tabletxt, PTBreakdownHeader)
+			if HypoUsed then
+				table.Add(Tabletxt, { Color2, "[i] Preview mode (no points applied). Respawn to apply." .. Sep })
+			end
+
+			local TPoints = {}
+			local totalLabel = HypoUsed and "Total Cost (preview): " or "Total Cost: "
+			if PointVal > ACF.PointsLimit then
+				local OverPoints = PointVal - ACF.PointsLimit
+				TPoints		= { Color4, totalLabel, Color1, "" .. PointVal .. "pts", Color2, "  -  ", Color1, OverPoints .. " pts over" .. Sep }
+			else
+				TPoints		= { Color4, totalLabel, Color3, "" .. PointVal .. "pts" .. Sep }
+			end
+			table.Add(Tabletxt,TPoints)
+			if ArmorDirty then
+				table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
+			elseif ArmorInitMissing and not HypoUsed then
+				table.Add(Tabletxt, { Color1, "[!] ARMOR COST NOT INITIALIZED. ", Color2, "Unfreeze or enter vehicle." .. Sep })
+			end
+
+			local FractionalPts = "/" .. PointVal
+			table.Add(Tabletxt, { Color4, "Armor scan: ", Color3, string.format("front=%.2fmm  side=%.2fmm", FrontArm, SideArm) .. Sep })
+			table.Add(Tabletxt, { Color4, "Armor: ", Color3, "(" .. pct(PtsArmor, PointVal) .. "%) - " .. PtsArmor .. FractionalPts .. Sep })
+			table.Add(Tabletxt, { Color4, "Engines: ", Color3, "(" .. pct(PtsEngine, PointVal) .. "%) - " .. PtsEngine .. FractionalPts .. Sep })
+			if PtsFirepower > 0 then
+				table.Add(Tabletxt, { Color4, "Firepower: ", Color3, "(" .. pct(PtsFirepower, PointVal) .. "%) - " .. PtsFirepower .. FractionalPts .. Sep })
+			end
+			if PtsAmmo > 0 or #ammoLines > 0 or PtsAmmoReady > 0 or PtsAmmoBackup > 0 then
+				table.Add(Tabletxt, { Color4, "Ammo: ", Color3, "(" .. pct(PtsAmmo, PointVal) .. "%) - " .. PtsAmmo .. FractionalPts .. Sep })
+				if #ammoLines > 0 then
+					for _, line in ipairs(ammoLines) do
+						table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
+					end
+				else
+					if AmmoReadyRounds > 0 then
+						table.Add(Tabletxt, { Color3, "    " .. AmmoReadyRounds .. " rds READY" .. Sep })
+					end
+					if AmmoBackupRounds > 0 then
+						table.Add(Tabletxt, { Color3, "    " .. AmmoBackupRounds .. " rds BACKUP" .. Sep })
+					end
+				end
+			end
+			table.Add(Tabletxt, { Color4, "Crew: ", Color3, "(" .. pct(PtsCrew, PointVal) .. "%) - " .. PtsCrew .. FractionalPts .. Sep })
+			table.Add(Tabletxt, { Color4, "Electronics: ", Color3, "(" .. pct(PtsElectronics, PointVal) .. "%) - " .. PtsElectronics .. FractionalPts .. Sep })
 		end
+
 
 		Tabletxt = table.Add(Tabletxt, Title)
 		Tabletxt = table.Add(Tabletxt,TMass2)

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -166,15 +166,10 @@ function TOOL:Reload( trace )
 	local PtsAmmo = 0
 	local PtsCrew = 0
 	local PtsElectronics = 0
+	local ArmorDirty = false
+	local ArmorInitMissing = false
 
 		if Contraption ~= nil then
-			if ACE_EnsureArmor then
-				local base = ent
-				if Contraption.GetACEBaseplate then
-					base = Contraption:GetACEBaseplate() or ent
-				end
-				ACE_EnsureArmor(Contraption, base)
-			end
 		PointVal		= Contraption.ACEPoints or ACE_GetEntPoints(ent) or 0
 		PtsArmor = Contraption.ACEPointsPerType.Armor
 		PtsEngine = Contraption.ACEPointsPerType.Engines
@@ -183,12 +178,17 @@ function TOOL:Reload( trace )
 		PtsAmmo = Contraption.ACEPointsPerType.Ammo
 		PtsCrew = Contraption.ACEPointsPerType.Crew
 		PtsElectronics = Contraption.ACEPointsPerType.Electronics
+		ArmorDirty = Contraption.ACEArmorDirty and Contraption.ACEArmorCalculated
+		ArmorInitMissing = not Contraption.ACEArmorCalculated
 	else
 		PointVal = ACE_GetEntPoints(ent)
 	end
 
 	local frontArm, sideArm = 0, 0
-	if ACE_GetArmorScan then
+	if Contraption ~= nil and Contraption.ACEArmorCalculated then
+		frontArm = Contraption.ACEArmorFront or 0
+		sideArm = Contraption.ACEArmorSide or 0
+	elseif ACE_GetArmorScan then
 		frontArm, sideArm = ACE_GetArmorScan(ent)
 	end
 
@@ -208,6 +208,8 @@ function TOOL:Reload( trace )
 		net.WriteFloat(PtsElectronics)
 		net.WriteFloat(frontArm)
 		net.WriteFloat(sideArm)
+		net.WriteBool(ArmorDirty)
+		net.WriteBool(ArmorInitMissing)
 
 		net.WriteData(Compressed)
 
@@ -498,6 +500,8 @@ if CLIENT then
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
 		local FrontArm = math.Round( net.ReadFloat(), 2 )
 		local SideArm = math.Round( net.ReadFloat(), 2 )
+		local ArmorDirty = net.ReadBool()
+		local ArmorInitMissing = net.ReadBool()
 
 		local Compressed	= net.ReadData(640)
 		local Decompress	= util.Decompress(Compressed)
@@ -529,6 +533,11 @@ if CLIENT then
 			TPoints		= { Color4, "Total Cost: ", Color3, "" .. PointVal .. "pts" .. Sep }
 		end
 		table.Add(Tabletxt,TPoints)
+		if ArmorDirty then
+			table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
+		elseif ArmorInitMissing then
+			table.Add(Tabletxt, { Color2, "[!] Armor cost not initialized; unfreeze or enter vehicle." .. Sep })
+		end
 
 		local FractionalPts = "/" .. PointVal
 		local sideWeighted = SideArm * 2

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -363,7 +363,7 @@ if CLIENT then
 		ArmorPanelText( "ComboCHE"  , ToolPanel.panel, getPhrase("tool.acfarmorprop.chemprot") .. ": " .. (MaterialData.HEATeffectiveness or MaterialData.effectiveness) .. "x RHA" )
 		ArmorPanelText( "ComboYear" , ToolPanel.panel, getPhrase("tool.acfarmorprop.year") .. ": " .. (MaterialData.year or "unknown") )
 
-		function ToolPanel.ComboMat:OnSelect(self, index, value, data)
+		function ToolPanel.ComboMat:OnSelect(_, value, data)
 			-- data carries the real material id; fallback to value if missing
 			local matId = tostring(data or value)
 			RunConsoleCommand("acfarmorprop_material", matId)
@@ -540,8 +540,6 @@ if CLIENT then
 		end
 
 		local FractionalPts = "/" .. PointVal
-		local sideWeighted = SideArm * 2
-		local cost = (FrontArm + sideWeighted) * 4
 		table.Add(Tabletxt,{ Color4, "Armor scan: "})
 		table.Add(Tabletxt,{ Color3, string.format("front=%.2f  side=%.2f", FrontArm, SideArm) .. Sep})
 		table.Add(Tabletxt,{ Color4, "Armor: "})


### PR DESCRIPTION
I completely rehauled the armor cost calculation to now take average armor weighted by surface area, it's not perfect, but it should be a far more accurate descriptor of a tank's strength. Is completely functional with debug features, notabley needs the tank's biggest gun to be aiming forward along the correct axis, and there's some guesswork i can do to get around that but for now it should be good. it also gives builders a free armor readout for their tanks.

It multiplies the front+side by 4, so that if a tank has 750mm of avg front + side armor it would be the 3000 points allocated. this should be fine for modern tanks, but the values can obviously be tweaked.

**ace_armor_debugvis 1** will let you see the boxes.

im aware it isn't perfect but it's in a functional state for community testing.

<img width="2149" height="1326" alt="image" src="https://github.com/user-attachments/assets/8af18c26-0d6c-486e-8174-0d3c5e8a2883" />
