### PR TITLE
Realistic anti-air warhead sizes and missile improvements

### DIFF
--- a/lua/acf/shared/fuses/c_radio.lua
+++ b/lua/acf/shared/fuses/c_radio.lua
@@ -21,7 +21,7 @@ this.Target = nil
 this.Distance = 2000
 
 
-this.desc = "This fuse tracks around the missile itself in a radius detonating as soon as a target enters the radius. This may lead to early detonations.\nDistance in inches." --This fuse tracks the guidance module's target and detonates when the distance becomes low enough.\nDistance in inches.
+this.desc = "This fuse tracks around the missile itself in a radius detonating as soon as a target enters the radius. This may lead to early detonations.\n Useful for countering flares at the cost of detonating further from the target.\nDistance in inches." --This fuse tracks the guidance module's target and detonates when the distance becomes low enough.\nDistance in inches.
 
 
 -- Configuration information for things like acfmenu.
@@ -87,6 +87,8 @@ do
 	--Question: Should radio fuze be limited to detect props in front of the missile only? Its weird it detonates by detecting something behind it.
 	function this:GetDetonate(missile)
 
+		local CPPIOwn = missile:CPPIGetOwner()
+
 		if not self:IsArmed() then return false end
 
 		local MissilePos = missile.CurPos
@@ -107,6 +109,8 @@ do
 		if tr.Hit then
 
 			local HitEnt = tr.Entity
+
+			if CPPIOwn == HitEnt:CPPIGetOwner() then return false end
 
 			if ACF_Check( HitEnt ) then
 

--- a/lua/acf/shared/fuses/f_overshoot.lua
+++ b/lua/acf/shared/fuses/f_overshoot.lua
@@ -20,8 +20,10 @@ this.Target = nil
 -- the fuse may trigger at some point under this range - unless it's travelling so fast that it steps right on through.
 this.Distance = 2000
 
+this.fuseArmed = false --Arms the fuse once it gets below the target distance. Allows missiles without memory to fuse after losing sight of the target.
 
-this.desc = "If the missile is in the set activation distance, detonates the missile when distance increases as it flys past the target.\nDistance in inches."
+
+this.desc = "Once the arming distance has been reached. Detonates when the missile loses the target which is assumed to be at the closest point.\n NOT reccomended for missiles without inertial guidance.\nDistance in inches."
 
 
 -- Configuration information for things like acfmenu.
@@ -49,16 +51,29 @@ do
 
 		if not self:IsArmed() then return false end
 
-		if (missile.IsDecoyed or false) then return false end
+		--if (missile.IsDecoyed or false) then return false end
 
 		local missilePos = missile:GetPos()
 		local missileTarget = missile.TargetPos
 
-		if not missileTarget then return false end
+		if not missileTarget then --Target Lost
+			
+			if not self.fuseArmed then
+				return false 
+			else --The fuse was armed but we lost sight of the target. Detonate.
+				return true 				
+			end
+		end
 
 		local CurDist = missileTarget:DistToSqr( missilePos )
 
-		if CurDist < self.Distance^2 and (missileTarget:DistToSqr( missilePos ) < missileTarget:DistToSqr( missilePos + missile.Flight )) then
+		if CurDist < self.Distance^2 then
+			self.fuseArmed = true
+			--print("isarmed")
+		end
+
+		if self.fuseArmed and (missileTarget:DistToSqr( missilePos ) < missileTarget:DistToSqr( missilePos + missile.Flight )) then
+			
 
 			return true
 

--- a/lua/acf/shared/guidances/d_infrared.lua
+++ b/lua/acf/shared/guidances/d_infrared.lua
@@ -56,6 +56,7 @@ function this:Configure(missile)
 	self.HeatAboveAmbient = self.HeatAboveAmbient / (ACF_GetGunValue(missile.BulletData, "seeksensitivity") or 1)
 	--self.SeekSensitivity	= ACF_GetGunValue(missile.BulletData, "seeksensitivity") or this.SeekSensitivity
 	self.HasIRCCM	= ACF_GetGunValue(missile.BulletData, "irccm") or this.HasIRCCM
+	self.seekReduction	= ACF_GetGunValue(missile.BulletData, "seekreduction") or 1
 
 	--print("CEent")
 	--for i, ent in ipairs(ACE.contraptionEnts) do
@@ -173,7 +174,7 @@ function this:GetWhitelistedContraptionsInCone(missile)
 		dist	= difpos:Length()
 
 		-- skip any ent outside of minimun distance
-		if dist < self.MinimumDistance then continue end
+		if dist < self.MinimumDistance and ACF.CurTime < (missile.ActivationTime or math.huge) + 0.5 then continue end --Disables the minimum distance check after a missile has existed for more than a second
 
 		-- skip any ent far than maximum distance
 		if dist > self.MaximumDistance then continue end
@@ -230,6 +231,12 @@ function this:AcquireLock(missile)
 	local testang	= Angle()
 
 	local DifSeek = vector_origin
+
+
+	local SeekMul = 3 --Seeker Cone multiplier. Used for Seeker Expanded Acquisition making the missile search in a larger area if it lacks a target.
+	if self.Target then
+		SeekMul =  self.seekReduction or 1
+	end
 
 	if missile.TargetPos then
 		--print("HasTpos")
@@ -299,7 +306,9 @@ function this:AcquireLock(missile)
 
 		absang	= Angle(math.abs(ang.p),math.abs(ang.y),0) --Since I like ABS so much
 
-		if absang.p < self.SeekCone and absang.y < self.SeekCone then --Entity is within missile cone
+
+		local SeekExpanded = self.SeekCone*SeekMul --Expanded Seeker Angle used for searching without a target.
+		if absang.p < SeekExpanded and absang.y < SeekExpanded then --Entity is within missile cone
 
 			testang = absang.p + absang.y --Could do pythagorean stuff but meh, works 98% of time
 

--- a/lua/acf/shared/guidances/f_radar.lua
+++ b/lua/acf/shared/guidances/f_radar.lua
@@ -52,6 +52,7 @@ function this:Configure(missile)
 	self.SeekCone = ACF_GetGunValue(missile.BulletData, "seekcone") or this.SeekCone
 	self.GCMultiplier	= ACF_GetGunValue(missile.BulletData, "groundclutterfactor") or this.GCMultiplier
 	self.HasIRCCM	= ACF_GetGunValue(missile.BulletData, "irccm") or this.HasIRCCM
+	self.seekReduction	= ACF_GetGunValue(missile.BulletData, "seekreduction") or 1
 end
 
 --TODO: still a bit messy, refactor this so we can check if a flare exits the viewcone too.
@@ -171,7 +172,8 @@ function this:GetWhitelistedEntsInCone(missile)
 		local dist = difpos:Length()
 
 		-- skip any ent outside of minimun distance
-		if dist < self.MinimumDistance then continue end
+		if dist < self.MinimumDistance and ACF.CurTime < (missile.ActivationTime or math.huge) + 0.5 then continue end --Disables the minimum distance check after a missile has existed for more than a second
+
 
 			local LOSdata = {}
 			LOSdata.start			= missilePos
@@ -232,6 +234,12 @@ function this:AcquireLock(missile)
 	local bestAng = math.huge
 	local bestent = nil
 
+
+	local SeekMul = 3 --Seeker Cone multiplier. Used for Seeker Expanded Acquisition making the missile search in a larger area if it lacks a target.
+	if self.Target then
+		SeekMul =  self.seekReduction or 1
+	end
+	
 	if missile.TargetPos then
 		--print("HasTpos")
 		DifSeek = missile.TargetPos - missilePos
@@ -269,7 +277,8 @@ function this:AcquireLock(missile)
 		--print(absang.p)
 		--print(absang.y)
 
-		if (absang.p < self.SeekCone and absang.y < self.SeekCone) then --Entity is within missile cone
+		local SeekExpanded = self.SeekCone*SeekMul --Expanded Seeker Angle used for searching without a target.
+		if absang.p < SeekExpanded and absang.y < SeekExpanded then --Entity is within missile cone
 
 			debugoverlay.Sphere(entpos, 100, 5, Color(255,100,0,255))
 

--- a/lua/acf/shared/guidances/h_antiradiation.lua
+++ b/lua/acf/shared/guidances/h_antiradiation.lua
@@ -144,7 +144,7 @@ function this:GetWhitelistedEntsInCone(missile)
 		local dist = difpos:Length()
 
 		-- skip any ent outside of minimun distance
-		if dist < self.MinimumDistance then continue end
+		if dist < self.MinimumDistance and ACF.CurTime < (missile.ActivationTime or math.huge) + 0.5 then continue end --Disables the minimum distance check after a missile has existed for more than a second
 
 			local LOSdata = {}
 			LOSdata.start			= missilePos

--- a/lua/acf/shared/guidances/m_acoustic_spiral.lua
+++ b/lua/acf/shared/guidances/m_acoustic_spiral.lua
@@ -242,8 +242,8 @@ function this:GetWhitelistedEntsInCone(missile)
 		local difpos = entpos - missilePos
 		local dist = difpos:Length()
 
-			-- skip any ent outside of minimun distance
-			if dist < self.MinimumDistance then continue end
+		-- skip any ent outside of minimun distance
+		if dist < self.MinimumDistance and ACF.CurTime < (missile.ActivationTime or math.huge) + 0.5 then continue end --Disables the minimum distance check after a missile has existed for more than a second
 
 			-- skip any ent outside of minimun distance
 			if dist > self.MaxDistance then continue end

--- a/lua/acf/shared/guidances/m_acoustic_straight.lua
+++ b/lua/acf/shared/guidances/m_acoustic_straight.lua
@@ -195,8 +195,8 @@ function this:GetWhitelistedEntsInCone(missile)
 		local difpos = entpos - missilePos
 		local dist = difpos:Length()
 
-			-- skip any ent outside of minimun distance
-			if dist < self.MinimumDistance then continue end
+		-- skip any ent outside of minimun distance
+		if dist < self.MinimumDistance and ACF.CurTime < (missile.ActivationTime or math.huge) + 0.5 then continue end --Disables the minimum distance check after a missile has existed for more than a second
 
 			-- skip any ent outside of minimun distance
 			if dist > self.MaxDistance then continue end

--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -39,8 +39,8 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 		reloaddelay			= 30.0,
 
 		--Formerly 302 and 1. Reduced blast from 381Mj to 136Mj. For reference a 100kg bomb has 117Kj.
-		maxlength			= 130,							-- Length of missile. Used for ammo properties.
-		propweight			= 4,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 37.3,							-- Length of missile. Used for ammo properties.
+		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 								--320
@@ -84,6 +84,7 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -113,8 +114,8 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 		reloaddelay			= 45.0,
 
 		--Formerly 370 and 1. Reduced blast from 1059Mj to 215Mj. For reference a 250kg bomb has 224Kj.
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 9,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 62,							-- Length of missile. Used for ammo properties.
+		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -157,6 +158,7 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= false,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -166,14 +168,14 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 --AIM-120 Sparrow. A medium-Range AAM missile, perfect for those who really need a decent boom in a single pass. Just remember that this is not an AIM-9 and is better to aim before.
 ACF_defineGun("AIM-120 AAM", {							-- id
 	name             = "AIM-120 AMRAAM",
-	desc             = "Faster than the AIM-9, but also a lot heavier. Burns hot and fast, with a good reach, but harder to lock with.  This long-range missile is sure to deliver one heck of a blast upon impact.Less agile than its smaller stablemate, so choose your shots carefully.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 289 m/s",
+	desc             = "Faster than the AIM-9, but also a lot heavier. Burns hot and fast, with a good reach, but harder to lock with.  This long-range missile is sure to deliver one heck of a blast upon impact.Less agile than its smaller stablemate, so choose your shots carefully.\n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: Yes\nTop Speed: 289 m/s",
 	model            = "models/missiles/aim120c.mdl",
 	effect           = "ACE_MissileMedium",
 	effectbooster    = "ACE_MissileMedium",
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 383,
-	caliber          = 18,
+	caliber          = 17.8,
 	weight           = 152,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1991,
 	modeldiameter    = 20.41,						-- in cm
@@ -187,8 +189,8 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 		reloaddelay			= 60.0,
 
 		--Formerly 370 and 1. Reduced blast from 1059Mj to 215Mj. For reference a 250kg bomb has 224Kj.
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 9,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 41,							-- Length of missile. Used for ammo properties.
+		propweight			= 3,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -231,6 +233,7 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.0003, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -241,13 +244,13 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 --with its seek cone and is suggested to AIM before launching.
 ACF_defineGun("AIM-54 AAM", {							-- id
 	name             = "AIM-54 Phoenix",
-	desc             = "Supersonic long-range air to air missile with early radar homing.Though relatively easy to dodge, this 300 kg beast will atomize any aircraft it hits. Getting hit is a traumatic experience. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 191 m/s",
+	desc             = "Supersonic long-range air to air missile with early radar homing.Though relatively easy to dodge, this 300 kg beast will atomize any aircraft it hits. Getting hit is a traumatic experience. \n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: Yes\nTop Speed: 191 m/s",
 	model            = "models/missiles/arend/aim54c.mdl",
 	effect           = "ACE_MissileLarge",
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 153 * 2.53, --Convert to ammocrate units
-	caliber          = 38.1,
+	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 463,								-- Don't scale down the weight though!
 	year             = 1974,
 	modeldiameter    = 30,--Already in ammocrate units
@@ -262,8 +265,8 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 
 
 		--Formerly 396 and 5. Reduced blast from 5509Mj to 1303Mj. For reference a 500kg bomb has 2702Kj.
-		maxlength			= 120,							-- Length of missile. Used for ammo properties.
-		propweight			= 45,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 93.7,							-- Length of missile. Used for ammo properties.
+		propweight			= 10,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 
@@ -303,7 +306,9 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 
-	irccm				= false,
+	irccm				= true,
+	seekreduction		= 0.5, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
+
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.5,								-- Required time (in seconds) for missile to start guiding at target once launched
 	ghosttime          = 0.05									-- Time where this missile will be unable to hit surfaces, in seconds
@@ -318,7 +323,7 @@ ACF_defineGun("SRAAM AAM", {								-- id
 	gunclass         = "AAM",
 	rack             = "2x SRAAM",							-- Which rack to spawn this missile on?
 	length           = 115 * 2.53, --Convert to ammocrate units
-	caliber          = 16.5,
+	caliber          = 10,		--Actual is 165. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead	
 	weight           = 70,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1984,
 	modeldiameter    = 8,--Already in ammocrate units
@@ -331,8 +336,8 @@ ACF_defineGun("SRAAM AAM", {								-- id
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
-		maxlength			= 40,							-- Length of missile. Used for ammo properties.
-		propweight			= 3,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 62,							-- Length of missile. Used for ammo properties.
+		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 								--320
@@ -373,6 +378,7 @@ ACF_defineGun("SRAAM AAM", {								-- id
 	seekcone           = 10,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
+	seekreduction		= 0.5, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -402,8 +408,8 @@ ACF_defineGun("Magic AAM", {								-- id
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 3,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 33.3,							-- Length of missile. Used for ammo properties.
+		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 								--320
@@ -447,6 +453,7 @@ ACF_defineGun("Magic AAM", {								-- id
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -456,7 +463,7 @@ ACF_defineGun("Magic AAM", {								-- id
 
 ACF_defineGun("MICA AAM", {								-- id
 	name             = "MICA Missile",
-	desc             = "Thrust vectoring short range air to air missile. Not quite as maneuverable as the R-73 but still remarkably agile. Capable of missile intercept. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 189 m/s",
+	desc             = "Thrust vectoring short range air to air missile. Not quite as maneuverable as the R-73 but still remarkably agile. Capable of missile intercept. \n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: Yes\nTop Speed: 189 m/s",
 	model            = "models/missiles/arend/mica_em.mdl",
 	effect           = "ACE_MissileSmall",
 	effectbooster    = "ACE_MissileSmall",
@@ -476,8 +483,8 @@ ACF_defineGun("MICA AAM", {								-- id
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
-		maxlength			= 80,							-- Length of missile. Used for ammo properties.
-		propweight			= 4,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 30.7,							-- Length of missile. Used for ammo properties.
+		propweight			= 1.5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -523,6 +530,7 @@ ACF_defineGun("MICA AAM", {								-- id
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.0003, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -531,7 +539,7 @@ ACF_defineGun("MICA AAM", {								-- id
 
 ACF_defineGun("Meteor AAM", {							-- id
 	name             = "Meteor Missile",
-	desc             = "Long range ramjet proppeled missile. Takes a bit longer to get up to speed but much longer range and harder to overshoot. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 236 m/s",
+	desc             = "Long range ramjet proppeled missile. Takes a bit longer to get up to speed but much longer range and harder to overshoot. \n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: Yes\nTop Speed: 236 m/s",
 	model            = "models/missiles/arend/meteor.mdl",
 	effect           = "ACE_RocketBlackSmoke",
 	effectbooster    = "ACE_MissileTiny",
@@ -552,8 +560,8 @@ ACF_defineGun("Meteor AAM", {							-- id
 		reloaddelay			= 60.0,
 
 		--Formerly 370 and 1. Reduced blast from 1059Mj to 215Mj. For reference a 250kg bomb has 224Kj.
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 9,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 50,							-- Length of missile. Used for ammo properties.
+		propweight			= 4,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -597,6 +605,7 @@ ACF_defineGun("Meteor AAM", {							-- id
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.0003, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -625,8 +634,8 @@ ACF_defineGun("R-60 AAM", {								-- id
 		reloadspeed			= 1.5,
 		reloaddelay			= 30.0,
 
-		maxlength			= 50,							-- Length of missile. Used for ammo properties.
-		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 19,							-- Length of missile. Used for ammo properties.
+		propweight			= 0.1,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 15,							-- Armour effectiveness of casing, in mm
 
@@ -669,6 +678,7 @@ ACF_defineGun("R-60 AAM", {								-- id
 	seekcone           = 10,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -678,14 +688,14 @@ ACF_defineGun("R-60 AAM", {								-- id
 
 ACF_defineGun("R-73 AAM", {								-- id
 	name             = "R-73 Archer",
-	desc             = "A monster in a dogfight. Compared to the Aim-9 this missile has a longer range and incredible offbore capability. But the IRCCM isn't as effective.\n\nInertial Guidance: Yes\nECCM: Narrow Seeker\nDatalink: No\nTop Speed: 188 m/s",
+	desc             = "A monster in a dogfight. Compared to the Aim-9 this missile has a longer range and incredible offbore capability. But the IRCCM isn't as effective.\n\nInertial Guidance: Yes\nECCM: Reduction\nDatalink: No\nTop Speed: 188 m/s",
 	model            = "models/missiles/arend/r73.mdl",
 	effect           = "ACE_MissileSmall",
 	effectbooster    = "ACE_MissileSmall",
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 116 * 2.53, --Convert to ammocrate units
-	caliber          = 16.5,
+	caliber          = 10,		--Actual is 165. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead	
 	weight           = 105,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1984,
 	modeldiameter    = 15,--Already in ammocrate units
@@ -698,8 +708,8 @@ ACF_defineGun("R-73 AAM", {								-- id
 		reloadspeed			= 1.5,
 		reloaddelay			= 45.0,
 
-		maxlength			= 80,							-- Length of missile. Used for ammo properties.
-		propweight			= 4,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 40.2,							-- Length of missile. Used for ammo properties.
+		propweight			= 1,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -741,9 +751,10 @@ ACF_defineGun("R-73 AAM", {								-- id
 
 
 	--Doesn't use the IRCCM system. Instead has a narrower seek cone that makes it better able to filter flares.
-	seekcone           = 3,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 4,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 48,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
 	SeekSensitivity    = 1,
+	seekreduction		= 0.0002, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -752,7 +763,7 @@ ACF_defineGun("R-73 AAM", {								-- id
 
 ACF_defineGun("R-77 AAM", {							-- id
 	name             = "R-77 Adder",
-	desc             = "Counterpart to the aim-120. Very similar in performance but heavier but burns hot and fast.  This long-range missile is sure to deliver its payload fast.Less agile than its smaller stablemate, so choose your shots carefully. \n\nInertial Guidance: Yes\nECCM: Narrow Seeker\nDatalink: Yes\nTop Speed: 330 m/s",
+	desc             = "Counterpart to the aim-120. Very similar in performance but heavier but burns hot and fast.  This long-range missile is sure to deliver its payload fast. Less agile than its smaller stablemate, so choose your shots carefully. \n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: Yes\nTop Speed: 330 m/s",
 	model            = "models/missiles/arend/r77.mdl",
 	effect           = "ACE_MissileMedium",
 	effectbooster    = "ACE_MissileMedium",
@@ -773,8 +784,8 @@ ACF_defineGun("R-77 AAM", {							-- id
 		reloaddelay			= 60.0,
 
 		--Formerly 370 and 1. Reduced blast from 1059Mj to 215Mj. For reference a 250kg bomb has 224Kj.
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 9,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 37,							-- Length of missile. Used for ammo properties.
+		propweight			= 2.7,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -817,6 +828,8 @@ ACF_defineGun("R-77 AAM", {							-- id
 	seekcone           = 2,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 27.5,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
+	seekreduction		= 0.0003, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
+	irccm				= true,
 
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -832,7 +845,7 @@ ACF_defineGun("R-27 AAM", {							-- id
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 180 * 2.53, --Convert to ammocrate units
-	caliber          = 20,
+	caliber          = 23,
 	weight           = 253,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1994,
 	modeldiameter    = 28,--Already in ammocrate units
@@ -846,8 +859,8 @@ ACF_defineGun("R-27 AAM", {							-- id
 		reloaddelay			= 45.0,
 
 		--Formerly 370 and 1. Reduced blast from 1059Mj to 215Mj. For reference a 250kg bomb has 224Kj.
-		maxlength			= 100,							-- Length of missile. Used for ammo properties.
-		propweight			= 9,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 48,							-- Length of missile. Used for ammo properties.
+		propweight			= 3,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -889,6 +902,7 @@ ACF_defineGun("R-27 AAM", {							-- id
 	seekcone           = 2,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 20
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.	--was 25
 	SeekSensitivity    = 1,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -897,13 +911,13 @@ ACF_defineGun("R-27 AAM", {							-- id
 
 ACF_defineGun("R-33 AAM", {							-- id
 	name             = "R-33 Amos",
-	desc             = "A supersonic long-range air to air missile. H E A V Y. Faster than its Aim-54 counterpart but with a weaker warhead. Will vaporize any aircraft it touches.\n\nInertial Guidance: Yes\nECCM: No\nDatalink: No\nTop Speed: 216 m/s",
+	desc             = "A supersonic long-range air to air missile. H E A V Y. Faster than its Aim-54 counterpart but with a weaker warhead. Will vaporize any aircraft it touches.\n\nInertial Guidance: Yes\nECCM: ADV Reduction\nDatalink: No\nTop Speed: 216 m/s",
 	model            = "models/missiles/arend/r33.mdl",
 	effect           = "ACE_MissileLarge",
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 163 * 2.53, --Convert to ammocrate units
-	caliber          = 38.0,
+	caliber          = 20,		--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 490,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 27,--Already in ammocrate units
@@ -917,8 +931,8 @@ ACF_defineGun("R-33 AAM", {							-- id
 		reloaddelay			= 60.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 72.3,							-- Length of missile. Used for ammo properties.
+		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320
@@ -958,6 +972,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 	seekcone           = 2,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)  --was 4
 	viewcone           = 110,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
+	seekreduction		= 0.0003, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	irccm				= true,
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3

--- a/lua/acf/shared/missiles/missile_mininaval.lua
+++ b/lua/acf/shared/missiles/missile_mininaval.lua
@@ -580,7 +580,7 @@ ACF_defineGun("Scaled 9M317ME SAM", {							-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 38.0,
+	caliber          = 20,								--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 1040,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 15,--Already in ammocrate units
@@ -594,8 +594,8 @@ ACF_defineGun("Scaled 9M317ME SAM", {							-- id
 		reloaddelay			= 45.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 111.8,							-- Length of missile. Used for ammo properties.
+		propweight			= 15,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320
@@ -655,7 +655,7 @@ ACF_defineGun("Scaled 5V55 SAM", {							-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 51.4,
+	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 1480,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 15,--Already in ammocrate units
@@ -669,8 +669,8 @@ ACF_defineGun("Scaled 5V55 SAM", {							-- id
 		reloaddelay			= 45.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 177.5,							-- Length of missile. Used for ammo properties.
+		propweight			= 20,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 

--- a/lua/acf/shared/missiles/missile_naval.lua
+++ b/lua/acf/shared/missiles/missile_naval.lua
@@ -662,7 +662,7 @@ ACF_defineGun("9M317ME SAM", {							-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 38.0,
+	caliber          = 20,								--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 1040,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units
@@ -676,8 +676,8 @@ ACF_defineGun("9M317ME SAM", {							-- id
 		reloaddelay			= 45.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 111.8,							-- Length of missile. Used for ammo properties.
+		propweight			= 15,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -17,51 +17,53 @@ ACF_defineGunClass("SAM", {
 -- The FIM-92, a lightweight, medium-speed short-range anti-air missile.
 ACF_defineGun("FIM-92 SAM", {								-- id
 	name             = "FIM-92 Missile",
-	desc             = "The FIM-92 Stinger is a lightweight and versatile close-range air defense missile.\nWith a seek cone of 15 degrees and a sharply limited range that makes it useless versus high-flying targets, it is best to aim before firing and choose shots carefully.\n\nInertial Guidance: No\nECCM: No\nDatalink: No\nTop Speed: 194 m/s",
+	desc             = "The FIM-92 Stinger is a lightweight and versatile close-range air defense missile.\nWith a seek cone of 15 degrees and a sharply limited range that makes it useless versus high-flying targets, it is best to aim before firing and choose shots carefully.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 226 m/s",
 	model            = "models/missiles/fim_92.mdl",
-	effect           = "ACE_MissileTiny",					--Tiny motor for tiny rocket
+	effect           = "ACE_RocketBlackSmoke",					--Tiny motor for tiny rocket
+	effectbooster    = "ACE_MissileSmall",
 	gunclass         = "SAM",
 	rack             = "1x FIM-92",							-- Which rack to spawn this missile on?
 	length           = 150,
-	caliber          = 11,
+	caliber          = 7,
 	weight           = 20,									-- 15.1,	-- Don't scale down the weight though!
 	modeldiameter    = 3,									-- in cm
 	year             = 1978,
 
 	round = {
-		rocketmdl				= "models/missiles/fim_92.mdl",
+		rocketmdl			= "models/missiles/fim_92.mdl",
 		rackmdl				= "models/missiles/fim_92_folded.mdl",
 		firedelay			= 2.0,
 		reloadspeed			= 8.0,
 		reloaddelay			= 20,
 
-		--Former 125 and 1.5. Reduced blast from 107Mj to 60Mj. For reference a 100kg bomb has 117Kj.
-		maxlength			= 22,							-- Length of missile. Used for ammo properties.
-		propweight			= 0.5,							-- Motor mass - motor casing. Used for ammo properties.
+
+		maxlength			= 30,							-- Length of missile. Used for ammo properties.
+		propweight			= 0.3,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 20,							-- Armour effectiveness of casing, in mm
 
 		turnrate			= 240,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.4,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 85,							-- Acceleration in m/s.
-		burntime			= 2.5,							-- time in seconds for rocket motor to burn at max proppelant.
+		thrust				= 5,							-- Acceleration in m/s.
+		burntime			= 20,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
 		launchkick			= 40,							-- Speed missile starts with on launch in m/s
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 0,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
-		boostertime			= 0,							-- Time in seconds for booster runtime
-		boostdelay			= 0.15,							-- Delay in seconds before booster activates.
+		boostacceleration	= 200,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostertime			= 0.9,							-- Time in seconds for booster runtime
+		boostdelay			= 0.25,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 		velmul				= 0.1,		--No
 
-		dragcoef			= 0.001,						-- percent speed loss per second
+		dragcoef			= 0.00015,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
-		predictiondelay		= 0.4,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
+		datalink			= true,
+		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		pointcost			= 83
 	},
 
@@ -75,10 +77,11 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 				["4x FIM-92"] = true
 			},
 
-	seekcone           = 15,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
+	seekcone           = 7,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.	--was 55
-	SeekSensitivity    = 1,
-	irccm				= false,
+	SeekSensitivity    = 1.5,
+	irccm				= true,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	armdelay	= 0.15,									-- minimum fuse arming delay		-was 0.3
 	guidelay           = 0,									-- Required time (in seconds) for missile to start guiding at target once launched
@@ -88,13 +91,14 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 -- The Mistral missile is a faster short range missile with greater range than fim92 but less agility
 ACF_defineGun("Mistral SAM", {								-- id
 	name             = "Mistral Missile",
-	desc             = "A very fast short range missile, faster and less agile than FIM-92. Mostly for Anti-Aircraft and Anti-Missile operations.\n\nInertial Guidance: No\nECCM: No\nDatalink: No\nTop Speed: 204 m/s",
+	desc             = "A very fast short range missile, faster and less agile than FIM-92. Mostly for Anti-Aircraft and Anti-Missile operations.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: No\nTop Speed: 292 m/s",
 	model            = "models/missiles/fim_92_folded.mdl",
-	effect           = "ACE_MissileTiny",					-- Tiny motor for tiny rocket
+	effect           = "ACE_RocketBlackSmoke",					--Tiny motor for tiny rocket
+	effectbooster    = "ACE_MissileTiny",
 	gunclass         = "SAM",
 	rack             = "2x FIM-92",							-- Which rack to spawn this missile on?
 	length           = 150,
-	caliber          = 11,
+	caliber          = 9,
 	weight           = 19.7,									-- 15.1,	-- Don't scale down the weight though!
 	modeldiameter    = 3,									-- in cm
 	year             = 1974,
@@ -102,36 +106,36 @@ ACF_defineGun("Mistral SAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/fim_92.mdl",
 		rackmdl				= "models/missiles/fim_92_folded.mdl",
-		firedelay			= 2.5,
+		firedelay			= 2.0,
 		reloadspeed			= 8.0,
-		reloaddelay			= 25.0,
+		reloaddelay			= 20,
 
-		--Formerly 130 and 1.5. Reduced blast from 112Mj to 72Mj. For reference a 100kg bomb has 117Kj.
-		maxlength			= 35,							-- Length of missile. Used for ammo properties.
-		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
+
+		maxlength			= 23,							-- Length of missile. Used for ammo properties.
+		propweight			= 0.5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 20,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 30,							--Turn rate of missile at max deflection per 100 m/s
+		turnrate			= 50,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.3,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 190,							-- Acceleration in m/s.
-		burntime			= 4,							-- time in seconds for rocket motor to burn at max proppelant.
+		thrust				= 5,							-- Acceleration in m/s.
+		burntime			= 20,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
-		launchkick			= 30,							-- Speed missile starts with on launch in m/s
+		launchkick			= 60,							-- Speed missile starts with on launch in m/s
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 0,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
-		boostertime			= 0,							-- Time in seconds for booster runtime
+		boostacceleration	= 130,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostertime			= 6,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 		velmul				= 0.1,		--No
 
-		dragcoef			= 0.005,						-- percent speed loss per second
-		inertialcapable		= false,						-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
+		dragcoef			= 0.0015,						-- percent speed loss per second
+		inertialcapable		= true,						-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		pointcost			= 83
 	},
@@ -141,25 +145,28 @@ ACF_defineGun("Mistral SAM", {								-- id
 	fuses      = {"Contact", "Overshoot", "Radio", "Optical", "Timed", "Altitude"},
 
 	racks	= {											-- a whitelist for racks that this missile can load into.
-					["2x FIM-92"] = true
+				["1x FIM-92"] = true,
+				["2x FIM-92"] = true,
+				["4x FIM-92"] = true
 				},
 
-	seekcone			= 15,										-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
+	seekcone			= 7,										-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 35
 	viewcone			= 70,										-- getting outside this cone will break the lock.  Divided by 2.	--was 55
-	SeekSensitivity		= 1,
-	irccm				= false,
+	SeekSensitivity		= 1.5,
+	irccm				= true,
+	seekreduction		= 0.3, --Low level seek reduction mainly meant to make it not incredibly easy to flare.
 
 	guidelay   = 0,										-- Required time (in seconds) for missile to start guiding at target once launched
 	ghosttime  = 0.5,									-- Time where this missile will be unable to hit surfaces, in seconds
-	armdelay   = 0.00										-- minimum fuse arming delay		-was 0.3
+	armdelay   = 0.15										-- minimum fuse arming delay		-was 0.3
 } )
 
 
 ACF_defineGun("TY-90 AAM", {								-- id
 	name             = "TY-90 Anti Air Missile",
-	desc             = "A relatively short range missile but extremele agile. With a decent warhead..\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: No\nTop Speed: 151 m/s",
+	desc             = "A short range missile with exceptional agility. Cruises at a moderate speed compared to the other short range SAMs.\n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: No\nTop Speed: 242 m/s",
 	model            = "models/missiles/ty90.mdl",
-	effect           = "ACE_MissileSmall",
+	effect           = "ACE_RocketBlackSmoke",					--Tiny motor for tiny rocket
 	effectbooster    = "ACE_MissileSmall",
 	gunclass         = "SAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
@@ -173,12 +180,12 @@ ACF_defineGun("TY-90 AAM", {								-- id
 	round = {
 		rocketmdl			= "models/missiles/ty90.mdl",
 		rackmdl				= "models/missiles/ty90.mdl",
-		firedelay			= 1.5,
-		reloadspeed			= 1.5,
-		reloaddelay			= 45.0,
+		firedelay			= 2.0,
+		reloadspeed			= 8.0,
+		reloaddelay			= 20,
 
-		maxlength			= 85,							-- Length of missile. Used for ammo properties.
-		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 23,							-- Length of missile. Used for ammo properties.
+		propweight			= 0.5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
@@ -186,22 +193,22 @@ ACF_defineGun("TY-90 AAM", {								-- id
 		finefficiency		= 0.8,							--Fraction of speed redirected every second at max deflection
 		thrusterturnrate	= 0,							--Max turnrate from thrusters regardless of speed. Active only if the missile motor is active.
 
-		thrust				= 150,							-- Acceleration in m/s.
-		burntime			= 1.0,							-- time in seconds for rocket motor to burn at max proppelant.
+		thrust				= 5,							-- Acceleration in m/s.
+		burntime			= 20.0,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
-		launchkick			= 0,							-- Speed missile starts with on launch in m/s
+		launchkick			= 40,							-- Speed missile starts with on launch in m/s
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
-		boostacceleration	= 200,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
-		boostertime			= 0.3,							-- Time in seconds for booster runtime
+		boostacceleration	= 120,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostertime			= 6.0,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 		velmul				= 0.1,		--No
 
-		dragcoef			= 0.00075,						-- percent speed loss per second
+		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		pointcost			= 415
@@ -220,10 +227,11 @@ ACF_defineGun("TY-90 AAM", {								-- id
 				["4x FIM-92"] = true
 			},
 
-	seekcone           = 3,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
+	seekcone           = 7,								-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)	--was 25
 	viewcone           = 65,								-- getting outside this cone will break the lock.  Divided by 2.		--was 30
-	SeekSensitivity    = 1,
+	SeekSensitivity    = 1.5,
 	irccm				= true,
+	seekreduction		= 0.2,
 
 	armdelay           = 0.15,								-- minimum fuse arming delay		--was 0.4
 	guidelay           = 0.25,								-- Required time (in seconds) for missile to start guiding at target once launched
@@ -233,9 +241,9 @@ ACF_defineGun("TY-90 AAM", {								-- id
 -- The 9M31 Strela-1, a bulky, slow medium-range anti-air missile.
 ACF_defineGun("Strela-1 SAM", {								-- id
 	name             = "9M31 Strela-1",
-	desc             = "The 9M31 Strela-1 is a medium-range homing SAM with a much bigger payload than the FIM-92. Bulky. It is best suited to ground vehicles or stationary units. The strela is fast-reacting, while its missiles are surprisingly deadly and able to defend an acceptable area.\n\nInertial Guidance: No\nECCM: No\nDatalink: No\nTop Speed: 180 m/s",
+	desc             = "The 9M31 Strela-1 is a medium-range homing SAM with a much bigger payload than the FIM-92. Bulky. It is best suited to ground vehicles or stationary units. Beware the narrow seeker. This helps with flares but makes acquisition harder.\n\nInertial Guidance: No\nECCM: Reduction\nDatalink: No\nTop Speed: 179 m/s",
 	model            = "models/missiles/9m31.mdl",
-	effect           = "ACE_MissileSmall",
+	effect           = "ACE_MissileMedium",
 	gunclass         = "SAM",
 	rack             = "1x Strela-1",							-- Which rack to spawn this missile on?
 	length           = 219,
@@ -249,19 +257,18 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 		rocketmdl			= "models/missiles/9m31.mdl",
 		rackmdl				= "models/missiles/9m31f.mdl",
 		firedelay			= 1.25,
-		reloadspeed			= 5.0,
-		reloaddelay			= 30.0,
+		reloadspeed			= 8.0,
+		reloaddelay			= 20,
 
-		--Formerly 190 and 1. Reduced blast from 213j to 120Mj. For reference a 100kg bomb has 117Kj.
-		maxlength			= 145,							-- Length of missile. Used for ammo properties.
-		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 22,							-- Length of missile. Used for ammo properties.
+		propweight			= 0.5,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
 		turnrate			= 60,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.25,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 62,							-- Acceleration in m/s.
+		thrust				= 60,							-- Acceleration in m/s.
 		--120 seconds? Does it really have a 120 second burntime??? Not setting higher so people can't minimize proppelant
 		burntime			= 10,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
@@ -275,11 +282,11 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
-		velmul				= 0.1,		--No
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
+
 		pointcost			= 250
 	},
 
@@ -293,9 +300,11 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 						["4x Strela-1"] = true
 					},
 
-	seekcone           = 8,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
+	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
-	SeekSensitivity    = 0.8,
+	SeekSensitivity    = 1.5,
+	irccm				= false,
+	seekreduction		= 0.0002,
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
 	guidelay           = 0.75,									-- Required time (in seconds) for missile to start guiding at target once launched
@@ -304,14 +313,14 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 
 ACF_defineGun("VT-1 SAM", {										-- id
 	name             = "VT-1 Missile",
-	desc             = "Powerful command guided SAM. Great range, good agility, and a powerful warhead. \n\nInertial Guidance: False\nECCM: No\nDatalink: Yes\nTop Speed: 178 m/s",
+	desc             = "Powerful command guided SAM. Great range, good agility, and a powerful warhead. \n\nInertial Guidance: False\nECCM: Reduction\nDatalink: Yes\nTop Speed: 183 m/s",
 	model            = "models/missiles/arend/vt1.mdl",
 	effect           = "ACE_MissileSmall",
 	effectbooster	= "ACE_MissileSmall",
 	gunclass         = "SAM",
 	rack             = "1x VT-1",								-- Which rack to spawn this missile on?
 	length           = 92 * 2.53, --Convert to ammocrate units
-	caliber          = 12,
+	caliber          = 16.5,
 	weight           = 73,										-- Don't scale down the weight though!
 	year             = 1960,
 	modeldiameter    = 8,--Already in ammocrate units
@@ -323,13 +332,12 @@ ACF_defineGun("VT-1 SAM", {										-- id
 		reloadspeed			= 5.0,
 		reloaddelay			= 30.0,
 
-		--Formerly 190 and 1. Reduced blast from 213j to 120Mj. For reference a 100kg bomb has 117Kj.
-		maxlength			= 145,							-- Length of missile. Used for ammo properties.
-		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 38,							-- Length of missile. Used for ammo properties.
+		propweight			= 3,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 30,							-- Armour effectiveness of casing, in mm
 
-		turnrate			= 70,							--Turn rate of missile at max deflection per 100 m/s
+		turnrate			= 65,							--Turn rate of missile at max deflection per 100 m/s
 		finefficiency		= 0.3,							--Fraction of speed redirected every second at max deflection
 
 		thrust				= 60,							-- Acceleration in m/s.
@@ -345,7 +353,6 @@ ACF_defineGun("VT-1 SAM", {										-- id
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
-		velmul				= 0.1,		--No
 
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
@@ -368,6 +375,8 @@ ACF_defineGun("VT-1 SAM", {										-- id
 
 	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
+	irccm				= false,
+	seekreduction		= 0.25,
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
 	guidelay           = 0,									-- Required time (in seconds) for missile to start guiding at target once launched
@@ -378,14 +387,14 @@ ACF_defineGun("VT-1 SAM", {										-- id
 --Tunguska Missile
 ACF_defineGun("9M311 SAM", {										-- id
 	name             = "9M311 Tunguska",
-	desc             = "The 9M311 missile is a supersonic Anti Air missile that while is not agile enough to hit maneuvering planes, excels against helicopters. \n\nInertial Guidance: No\nECCM: No\nDatalink: Yes\nTop Speed: 233 m/s",
+	desc             = "The 9M311 missile is SAM meant to minimize traveltime. While lacking the agility and energy retention to hit maneuvering planes, this missile excels against helicopters due to the short traveltime. \n\nInertial Guidance: No\nECCM: Reduction\nDatalink: Yes\nTop Speed: 365 m/s",
 	model            = "models/missiles/arend/9m311_unfolded.mdl",
-	effect           = "ACE_MissileSmall",
-	effectbooster	= "ACE_MissileSmall",
+	effect           = "ACE_RocketBlackSmoke",
+	effectbooster	= "ACE_MotorSmall",
 	gunclass         = "SAM",
 	rack             = "1x 9m311",								-- Which rack to spawn this missile on?
 	length           = 100 * 2.53, --Convert to ammocrate units
-	caliber          = 12,
+	caliber          = 7.6,
 	weight           = 71,										-- Don't scale down the weight though!
 	year             = 1982,
 	modeldiameter    = 7,--Already in ammocrate units
@@ -399,33 +408,33 @@ ACF_defineGun("9M311 SAM", {										-- id
 
 		--Formerly 190 and 1. Reduced blast from 283j to 116Mj. For reference a 100kg bomb has 117Kj.
 
-		maxlength			= 140,							-- Length of missile. Used for ammo properties.
-		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 78,							-- Length of missile. Used for ammo properties.
+		propweight			= 2,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 25,							-- Armour effectiveness of casing, in mm
-		turnrate			= 15,							--Turn rate of missile at max deflection per 100 m/s
-		finefficiency		= 0.4,							--Fraction of speed redirected every second at max deflection
+		turnrate			= 13,							--Turn rate of missile at max deflection per 100 m/s
+		finefficiency		= 0.3,							--Fraction of speed redirected every second at max deflection
 
-		thrust				= 100,							-- Acceleration in m/s.
-		burntime			= 1,							-- time in seconds for rocket motor to burn at max proppelant.
+		thrust				= 5,							-- Acceleration in m/s.
+		burntime			= 20,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
-		launchkick			= 30,							-- Speed missile starts with on launch in m/s
+		launchkick			= 60,							-- Speed missile starts with on launch in m/s
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
 		--Should be around 1.5s. Set to 1/4th boost time.
-		boostacceleration	= 300,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
+		boostacceleration	= 800,							-- Acceleration in m/s of boost motor. Main Engine is not burning at this time.
 		boostertime			= 0.35,							-- Time in seconds for booster runtime
 		boostdelay			= 0,							-- Delay in seconds before booster activates.
 
 		fusetime			= 19,							--Time in seconds after launch/booster stop before missile scuttles
 		velmul				= 0.1,		--No
 
-		dragcoef			= 0.00035,						-- percent speed loss per second
+		dragcoef			= 0.0001,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
-		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
+		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		pointcost			= 235
 	},
 
@@ -443,6 +452,8 @@ ACF_defineGun("9M311 SAM", {										-- id
 
 	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 70,									-- getting outside this cone will break the lock.  Divided by 2.
+	irccm				= false,
+	seekreduction		= 0.25,
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
 	guidelay           = 0,									-- Required time (in seconds) for missile to start guiding at target once launched
@@ -454,14 +465,14 @@ ACF_defineGun("9M311 SAM", {										-- id
 --TOR Missile. This is going to be fun.
 ACF_defineGun("9M331 SAM", {								-- id
 	name             = "9M331 TOR",
-	desc             = "The TOR Missile. Medium range SAM. This vertically Launched medium range missile is fast reacting making it good for missile intercepts, agile, and deadly. The missile is first kicked out of the tube, spun towards the target, then launched. \n\nInertial Guidance: Yes\nECCM: No\nDatalink: Yes\nTop Speed: 241 m/s",
+	desc             = "The TOR Missile. Medium range SAM. This vertically Launched medium range missile is fast reacting making it good for missile intercepts, agile, and deadly. The missile is first kicked out of the tube, spun towards the target, then launched. \n\nInertial Guidance: Yes\nECCM: Reduction\nDatalink: Yes\nTop Speed: 251 m/s",
 	model            = "models/missiles/arend/9m331_unfolded.mdl",
 	effect           = "ACE_MissileMedium",
 	effectbooster	 = "Rocket_Smoke_Trail",
 	gunclass         = "SAM",
 	rack             = "1x9M331 Pod",							-- Which rack to spawn this missile on?
 	length           = 118 * 2.53, --Convert to ammocrate units
-	caliber          = 23.9,
+	caliber          = 15, --Had to artificially reduce the caliber from 23.5 to get the warhead area to reduce
 	weight           = 167,									-- 15.1,	-- Don't scale down the weight though!
 	year             = 1986,
 	modeldiameter    = 10,
@@ -474,8 +485,8 @@ ACF_defineGun("9M331 SAM", {								-- id
 		reloadspeed			= 5.0,
 		reloaddelay			= 40,
 
-		maxlength			= 55,							-- Length of missile. Used for ammo properties.
-		propweight			= 5,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 40,							-- Length of missile. Used for ammo properties.
+		propweight			= 1.0,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 35,							-- Armour effectiveness of casing, in mm
 								--320
@@ -483,11 +494,11 @@ ACF_defineGun("9M331 SAM", {								-- id
 		finefficiency		= 0.5,							--Fraction of speed redirected every second at max deflection
 		thrusterturnrate	= 120,							--Max turnrate from thrusters regardless of speed. Active only if the missile motor is active.
 
-		thrust				= 110,							-- Acceleration in m/s.
+		thrust				= 120,							-- Acceleration in m/s.
 		burntime			= 10,							-- time in seconds for rocket motor to burn at max proppelant.
 		startdelay			= 0,
 
-		launchkick			= 15,							-- Speed missile starts with on launch in m/s
+		launchkick			= 30,							-- Speed missile starts with on launch in m/s
 
 		--Technically if you were crazy you could use boost instead of your rocket motor to get thrust independent of burn. Maybe on torpedoes.
 
@@ -501,7 +512,7 @@ ACF_defineGun("9M331 SAM", {								-- id
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
-		predictiondelay		= 2,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
+		predictiondelay		= 1.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		pointcost			= 353
 	},
 
@@ -519,25 +530,26 @@ ACF_defineGun("9M331 SAM", {								-- id
 
 	seekcone           = 6,									-- getting inside this cone will get you locked.  Divided by 2 ('seekcone = 40' means 80 degrees total.)
 	viewcone           = 60,									-- getting outside this cone will break the lock.  Divided by 2.
-	SeekSensitivity    = 1,
+	irccm				= false,
+	seekreduction		= 0.25,
 
 	armdelay	= 0.15,									-- minimum fuse arming delay
-	guidelay           = 0.75,									-- Required time (in seconds) for missile to start guiding at target once launched
-	ghosttime          = 0.5									-- Time where this missile will be unable to hit surfaces, in seconds
+	guidelay           = 0,									-- Required time (in seconds) for missile to start guiding at target once launched
+	ghosttime          = 0									-- Time where this missile will be unable to hit surfaces, in seconds
 } )
 
 --AIM-54 phoenix. Being faster and bigger than AIM-120, can deliver a single big blast against the target, however, this 300kgs piece of aerial destruction has a serious trouble
 --with its seek cone and is suggested to AIM before launching.
 ACF_defineGun("9M38M1 SAM", {							-- id
 	name             = "9M38M1 BUK",
-	desc             = "Absolute monster of a missile. Long range yet still appreciably maneuverable. Takes a bit to get up to speed but it is a monster. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 273 m/s",
+	desc             = "Diabolically sized missile meant to bring about the end of aviation. Has a nasty amount of ECCM, an absurd warhead, and enough range to travel across some countries. Takes a bit to get up to speed but is remarkably difficult to defeat. \n\nInertial Guidance: Yes\nECCM: Yes\nDatalink: Yes\nTop Speed: 273 m/s",
 	model            = "models/macc/9m38m1.mdl",
 	effect           = "ACE_MissileLarge",
 	effectbooster	 = "ACE_MissileLarge",
 	gunclass         = "SAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 220 * 2.53, --Convert to ammocrate units
-	caliber          = 40.0,
+	caliber          = 20,								--Actual is 330. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 710,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units
@@ -551,8 +563,8 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 		reloaddelay			= 45.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 111.8,							-- Length of missile. Used for ammo properties.
+		propweight			= 15,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 								--320
@@ -594,6 +606,7 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.0002,
 
 	agility            = 3,									-- multiplier for missile turn-rate.  --was 0.7
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3
@@ -611,7 +624,7 @@ ACF_defineGun("5V55 SAM", {							-- id
 	gunclass         = "SAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 51.4,
+	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
 	weight           = 1480,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units
@@ -625,8 +638,8 @@ ACF_defineGun("5V55 SAM", {							-- id
 		reloaddelay			= 45.0,
 
 
-		maxlength			= 110,							-- Length of missile. Used for ammo properties.
-		propweight			= 40,							-- Motor mass - motor casing. Used for ammo properties.
+		maxlength			= 177.5,							-- Length of missile. Used for ammo properties.
+		propweight			= 20,							-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 40,							-- Armour effectiveness of casing, in mm
 
@@ -669,6 +682,7 @@ ACF_defineGun("5V55 SAM", {							-- id
 	viewcone           = 60,								-- getting outside this cone will break the lock.  Divided by 2.
 	SeekSensitivity    = 1,
 	irccm				= true,
+	seekreduction		= 0.25,
 
 	agility            = 3,									-- multiplier for missile turn-rate.  --was 0.7
 	armdelay           = 0.15,								-- minimum fuse arming delay --was 0.3

--- a/lua/acf/shared/missiles/pod.lua
+++ b/lua/acf/shared/missiles/pod.lua
@@ -19,7 +19,7 @@ ACF_DefineRackClass("POD", {
 
 
 
--- MAKE SURE THE CALIBER MATCHES THE ROCKETS YOU WANT TO LOAD!
+
 ACF_DefineRack("40mm7xPOD", {
 	name		= "7x 40mm FFAR Pod",
 	desc		= "A lightweight pod for small rockets which is vulnerable to shots and explosions.",
@@ -28,7 +28,6 @@ ACF_DefineRack("40mm7xPOD", {
 	weight	= 20,
 	year		= 1940,
 	magsize	= 7,
-	caliber	= 4,
 
 	reloadmul	= 150,
 
@@ -50,7 +49,6 @@ ACF_DefineRack("40mm7xPOD", {
 
 
 
--- MAKE SURE THE CALIBER MATCHES THE ROCKETS YOU WANT TO LOAD!
 ACF_DefineRack("70mm7xPOD", {
 	name		= "7x 70mm FFAR Pod",
 	desc		= "A lightweight pod for rockets which is vulnerable to shots and explosions.",
@@ -59,7 +57,6 @@ ACF_DefineRack("70mm7xPOD", {
 	weight	= 40,
 	year		= 1940,
 	magsize	= 7,
-	caliber	= 7,
 
 	reloadmul	= 150,
 
@@ -81,7 +78,7 @@ ACF_DefineRack("70mm7xPOD", {
 
 
 
--- MAKE SURE THE CALIBER MATCHES THE ROCKETS YOU WANT TO LOAD!
+
 ACF_DefineRack("1x BGM-71E", {
 	name = "BGM-71E Single Tube",
 	desc = "A single BGM-71E round.",
@@ -90,7 +87,6 @@ ACF_DefineRack("1x BGM-71E", {
 	weight = 10,
 	year = 1970,
 	magsize = 1,
-	caliber = 13,
 
 	whitelistonly	= true,
 	protectmissile  = true,
@@ -104,7 +100,6 @@ ACF_DefineRack("1x BGM-71E", {
 
 
 
--- MAKE SURE THE CALIBER MATCHES THE ROCKETS YOU WANT TO LOAD!
 ACF_DefineRack("2x BGM-71E", {
 	name = "BGM-71E 2x Rack",
 	desc = "A BGM-71E rack designed to carry 2 rounds.",
@@ -113,7 +108,7 @@ ACF_DefineRack("2x BGM-71E", {
 	weight = 60,
 	year = 1970,
 	magsize = 2,
-	caliber = 13,
+	--caliber = 13, --Obsolete. Left here to have an example. If the missile caliber does not match this tube size precisely it won't be able to be loaded into the launcher.
 
 	whitelistonly	= true,
 	protectmissile  = true,
@@ -128,7 +123,7 @@ ACF_DefineRack("2x BGM-71E", {
 
 
 
--- MAKE SURE THE CALIBER MATCHES THE ROCKETS YOU WANT TO LOAD!
+
 ACF_DefineRack("4x BGM-71E", {
 	name = "BGM-71E 4x Rack",
 	desc = "A BGM-71E rack designed to carry 4 rounds.",
@@ -137,7 +132,6 @@ ACF_DefineRack("4x BGM-71E", {
 	weight = 100,
 	year = 1970,
 	magsize = 4,
-	caliber = 13,
 
 	whitelistonly	= true,
 	protectmissile  = true,
@@ -152,7 +146,7 @@ ACF_DefineRack("4x BGM-71E", {
 	}
 } )
 
--- MAKE SURE THE CALIBER MATCHES THE yeah yeah I know I can read the code mate whitelist only mmkay?
+
 ACF_DefineRack("380mmRW61", {
 	name		= "380mm rocket asisted mortar",
 	desc		= "A lightweight pod for rocket-asisted mortars which is vulnerable to shots and explosions.",
@@ -161,7 +155,6 @@ ACF_DefineRack("380mmRW61", {
 	weight	= 600,
 	year		= 1945,
 	magsize	= 1,
-	caliber	= 38,
 
 	hidemissile	= false,
 	whitelistonly	= true,
@@ -236,7 +229,6 @@ ACF_DefineRack("1x FIM-92", {
 	weight = 10,
 	year = 1984,
 	magsize = 1,
-	caliber = 11,
 	protectmissile  = true,
 	hidemissile	= false,
 	whitelistonly	= true,
@@ -255,7 +247,6 @@ ACF_DefineRack("2x FIM-92", {
 	weight = 30,
 	year = 1984,
 	magsize = 2,
-	caliber = 11,
 	rofmod = 3,
 
 	protectmissile  = true,
@@ -300,7 +291,6 @@ ACF_DefineRack("1x Strela-1", {
 	weight = 10,
 	year = 1968,
 	magsize = 1,
-	caliber = 12,
 
 	protectmissile  = true,
 	hidemissile	= false,
@@ -320,8 +310,6 @@ ACF_DefineRack("2x Strela-1", {
 	weight = 30,
 	year = 1968,
 	magsize = 2,
-	caliber = 12,
-
 	protectmissile  = true,
 	hidemissile	= false,
 	whitelistonly	= true,
@@ -342,7 +330,6 @@ ACF_DefineRack("4x Strela-1", {
 	weight = 50,
 	year = 1968,
 	magsize = 4,
-	caliber = 12,
 
 	protectmissile  = true,
 	hidemissile	= false,
@@ -366,7 +353,6 @@ ACF_DefineRack("1x Ataka", {
 	weight = 10,
 	year = 1968,
 	magsize = 1,
-	caliber = 13,
 
 	protectmissile  = true,
 	hidemissile	= true,
@@ -387,7 +373,6 @@ ACF_DefineRack("1x SPG9", {
 	weight = 90,
 	year = 1968,
 	magsize = 1,
-	caliber = 7.3,
 	spread = 0.1,
 
 	protectmissile  = true,
@@ -409,7 +394,6 @@ ACF_DefineRack("1x Kornet", {
 	weight     = 30,
 	year       = 1994,
 	magsize    = 1,
-	caliber    = 15.2,
 
 	protectmissile   = true,
 	hidemissile      = true,
@@ -430,7 +414,6 @@ ACF_DefineRack("2x Kornet", {
 	weight     = 60,
 	year       = 1994,
 	magsize    = 2,
-	caliber    = 15.2,
 
 	protectmissile   = true,
 	hidemissile      = true,
@@ -452,7 +435,6 @@ ACF_DefineRack("4x Kornet", {
 	weight     = 120,
 	year       = 1994,
 	magsize    = 4,
-	caliber    = 15.2,
 
 	protectmissile   = true,
 	hidemissile      = true,
@@ -477,7 +459,6 @@ ACF_DefineRack("127mm4xPOD", {
 	weight = 100,
 	year = 1957,
 	magsize = 4,
-	caliber = 12.7,
 
 	protectmissile  = true,
 	hidemissile	= false,
@@ -502,7 +483,6 @@ ACF_DefineRack("1x 9m311", {
 	year = 1982,
 	magsize = 1,
 	armour  = 18,
-	caliber = 12,
 
 	whitelistonly   = true,
 	protectmissile  = true,
@@ -523,7 +503,6 @@ ACF_DefineRack("1x Javelin", {
 	weight = 6.4,
 	year = 1989,
 	magsize = 1,
-	caliber = 12.7,
 
 	protectmissile  = true,
 	hidemissile	= true,
@@ -544,7 +523,6 @@ ACF_DefineRack("20x S8KO", {
 	year = 1970,
 	magsize = 20,
 	armour  = 20,
-	caliber = 8,
 	whitelistonly   = true,
 	protectmissile  = true,
 	hidemissile     = false,
@@ -583,7 +561,6 @@ ACF_DefineRack("2x SRAAM", {
 	year = 1970,
 	magsize = 2,
 	armour  = 20,
-	caliber = 16.5,
 
 	mountpoints =
 	{
@@ -641,7 +618,6 @@ ACF_DefineRack("6x 9K121", {
 	year = 1984,
 	magsize = 6,
 	armour  = 20,
-	caliber = 13,
 
 	mountpoints =
 	{
@@ -663,7 +639,6 @@ ACF_DefineRack("1x 9M113", {
 	year = 1970,
 	magsize = 1,
 	armour  = 18,
-	caliber = 13.5,
 
 	whitelistonly   = true,
 	protectmissile  = true,

--- a/lua/acf/shared/missiles/rack.lua
+++ b/lua/acf/shared/missiles/rack.lua
@@ -93,7 +93,6 @@ ACF_DefineRack("2x AGM-114", {
 	gunclass = "RK",
 	weight = 50,
 	year = 1984,
-	caliber = 16,
 
 	mountpoints =
 	{
@@ -109,7 +108,6 @@ ACF_DefineRack("4x AGM-114", {
 	gunclass = "RK",
 	weight = 100,
 	year = 1984,
-	caliber = 16,
 
 	mountpoints =
 	{
@@ -159,7 +157,6 @@ ACF_DefineRack("1x9M331 Pod", {
 	weight = 100,
 	year = 1986,
 	magsize = 1,
-	caliber = 23.9,
 	whitelistonly   = true,
 	protectmissile  = false,
 	hidemissile     = false,

--- a/lua/acf/shared/rounds/roundhe.lua
+++ b/lua/acf/shared/rounds/roundhe.lua
@@ -242,7 +242,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.PropMass, 1)) .. " kg" )  --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:CPanelText("BlastPenDisplay", "Max Blast Penetration: " .. math.floor(Data.FillerMass * ACF.HEPower / ACF.HEBlastPenetration,1) .. " mm")
-	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
+	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.FillerMass, 1)) .. " kg")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
 	ACE_Checkboxes( Data )
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -55,7 +55,7 @@ ACF.TankVolumeMul       = 1						-- multiplier for fuel tank capacity, 1.0 is ap
 
 ---------------------------------- Ammo Crate config ----------------------------------
 
-ACF.CrateMaximumSize    = 250
+ACF.CrateMaximumSize    = 600
 ACF.CrateMinimumSize    = 5
 
 ACF.RefillDistance      = 400					-- Distance in which ammo crate starts refilling.

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -468,6 +468,14 @@ function ENT:Think()
 			self.CanDetonate = true
 		end
 
+		--Detonation by launcher scuttle command
+		if self.Launcher.ScuttleMissiles then
+			self.CanDetonate = true
+			self:Detonate()
+			return
+		end
+
+
 		--Detonation by fuse, if available
 
 		if self.CanDetonate == true then


### PR DESCRIPTION
Changes:

-Improved the logic of missiles increasing their lethality. Due to this, along with the missile update itself, the warheads of all Surface To Air and Air To Air missiles can now be reduced so they don't double as dual purpose anti tank artillery missiles.

-Added an input to launchers to detonate any currently launched missiles

-Added an output to launchers to display the position of the last fired missile. This is meant to help make creating custom guidance more accessible.

-Added reduction ECCM for missiles. Once a missile has acquired a target it will reduce the size of the area it seeks making the missile less prone to being flared.

-Added SEAM(Seeker Expanded Acquisition Mode) to missiles. Missiles will expand their seek radius to 3x of the base seek cone when they don't have a target. This is to emulate using the gimbal to search for a target expanding the search area.
Technically this search area would only be 2x without any gaps in coverage (double the radius of the seek angle) but this area could be larger if one tolerates gaps.

-Overshoot guidance will now detonate after arming if it loses sight of the target. This should allow command guide missiles to detonate on passing an aimpoint or help missiles without memory detonate after overshooting a target.

-Anti missile guidance now filters out your own missiles

-Added basic logic to allow anti missile guidance to spread out its targeting and target missiles not engaged by other missiles.

-Made it so the minimum distance requirement for seekers is disabled after 0.5 seconds of launch. This should allow missiles to continue to seek even when close to the target.

-Removed the caliber requirement from missile tubes.  Though I left the logic there, it just needlessly complicated adding missiles to a rack since you already have to specify allowed racks


***Missile Stat Changelog:***
Surface To Air missiles and Air To Air missiles were given their realistic warhead sizes
This will hopefully reduce their usage as dual purpose anti-tank artillery missiles

IR Sams were also given additional sensitivity to better help with engaging helicopters increasing the effective range of their seekers

*Fim-92*
-Changed caliber to 70mm
-Changed warhead size to 3.1kg
-Added IRCCM
-Added a datalink as this is the mounted version meant to be added to vehicles
-Added booster to improve reliability while launched and accelerating towards maneuvering targets
-Increased range slightly by considerably reducing drag
Should overall give the stinger more reliability up close and pushing the standoff distance slightly.
Still rather easy to avoid at distance with maneuvers or popping a few countermeasures.

*Mistral*
-Changed caliber to 90mm
-Changed warhead size to 3.3kg
-Added IRCCM
-Reduced drag
-Increased burntime considerably
The missile is not as agile as the stinger but the long burntime should make it quite good at hitting distant targets

*TY-90*
-Reduced warhead side to 3.4kg
-Increased burntime of missile

*Strela*
-Reduced warhead to 5.4kg
-Added seeker reduction IRCCM making it harder to flare

*VT-1*
-Reduced warhead to 15.4kg
-Changed caliber to 165mm

*9M311 Tunguska*
-Warhead weight reduced to 9.5kg
-Missile caliber changed to 76mm
-Significantly increased speed
Should significantly reduce the travel time to reach heli targets at the cost of reducing the total maneuvering the missile can make

*9M331 Tor*
-Warhead weight reduced to 15.5kg
-Missile Caliber Changed to 235mm
-Increased boost speed to reduce likelihood of missile dropping into ground after launch

*9M38M1 Buk*
-Warhead weight reduced to 70.6 kg
-Missile caliber changed to 200mm, actual is 330mm but because of shell customization caliber/length ratios could not get a warhead less than 50cm long
-Added Seeker Reduction IRCCM

**5V55 S-300*
-Warhead weight reduced to 130kg
-Missile caliber changed to 200mm, actual is 514mm but because of shell customization caliber/length ratios could not get a warhead less than 50cm long

*Aim-9*
-Warhead weight reduced to 9.4kg

*Aim-7*
-Warhead weight reduced to 40.5kg

*Aim-120*
-Caliber changed to 178mm
-Warhead weight reduced to 20kg
-Added advanced reduction seeker ECCM

*Aim-54*
-Missile caliber changed to 200mm, actual is 380mm but because of shell customization caliber/length ratios could not get a warhead less than 50cm long
-Warhead weight reduced to 60.4kg
-Added IRCM that should've been enabled

*SRAAM*
-Missile caliber changed to 100mm, actual is 165mm but because of shell customization caliber/length ratios could not get a warhead less than 50cm long
-Warhead weight reduced to 11.8kg, 4.4kg / 3.1kg TNT

*Mica*
-Warhead weight reduced to 12.5kg
-Added advanced reduction seeker ECCM

*Meteor*
-Warhead weight reduced to 24.5kg
-Added advanced reduction seeker ECCM

*R-60*
-Warhead weight reduced to 4.9kg,

*R-73*
-Warhead weight reduced to 7.4kg
-Added reduction seeker IRCCM

*R-27*
-Warhead weight reduced to 39.7kg
-Added shutoff ECCM

*R-77*
-Warhead weight reduced to 22.6kg
-Added ADV reduction seeker ECCM

*R-33*
-Warhead weight reduced to 47.5kg
-Added ADV reduction seeker ECCM