### PR TITLE
changing the recoil and ballistic parameters of SWEPs

### DIFF
--- a/lua/weapons/weapon_ace_ak47/shared.lua
+++ b/lua/weapons/weapon_ace_ak47/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 35
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -30,26 +30,27 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
 SWEP.HeatPerShot = 10 --Heat generated per shot
-SWEP.HeatMax = 80 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatMax = 71.25 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 30	--Amount of angular recoil
+SWEP.AngularRecoil = 53.44	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
 SWEP.RecoilSideBias = 0.15
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
-SWEP.CrouchRecoilBonus = 0.2 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
+SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.1 --First-shot random spread, in degrees
 SWEP.MaxSpread = 3 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 1.5 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.MovementSpread = 1 --Increase aimcone to this many degrees when sprinting at full speed
 SWEP.UnscopedSpread = 0.4 --Spread, in degrees, when unscoped with a scoped weapon
 
 
@@ -103,7 +104,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.1
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.5
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_amr/shared.lua
+++ b/lua/weapons/weapon_ace_amr/shared.lua
@@ -21,34 +21,38 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 0
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 20
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
 
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
 SWEP.HeatReductionDelay = 0.1
-SWEP.HeatPerShot = 0 --Heat generated per shot
-SWEP.HeatMax = 25 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 600 --Heat loss per second when not firing
+--SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
+SWEP.HeatPerShot = 1 --Heat generated per shot
+SWEP.HeatMax = 1 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
+
+SWEP.AngularRecoil = 1	--Amount of angular recoil
+			--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
 SWEP.RecoilSideBias = 0.1 --How much the recoil is biased to one side proportional to vertical recoil
 						--Positive numbers bias to the right, negative to the left
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 8 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.ViewPunchAmount = 30 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
 
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0 --First-shot random spread, in degrees
-SWEP.MaxSpread = 0 --Maximum added random spread from heat value, in degrees
+SWEP.MaxSpread = 1 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 0 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 0 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.MovementSpread = 4 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.UnscopedSpread = 0.9 --Spread, in degrees, when unscoped with a scoped weapon
 
 SWEP.CarrySpeedMul			= 0.7
 

--- a/lua/weapons/weapon_ace_at4/shared.lua
+++ b/lua/weapons/weapon_ace_at4/shared.lua
@@ -157,7 +157,7 @@ function SWEP:PrimaryAttack()
 				Owner = owner,
 				Launcher = owner,
 
-				Pos = owner:GetShootPos() + owner:GetAimVector() * 1100,
+				Pos = owner:GetShootPos() + owner:GetAimVector() * 1500,
 				Ang = owner:GetAimVector():Angle(),
 
 				Mdl = "models/munitions/round_100mm_mortar_shot.mdl",
@@ -175,7 +175,7 @@ function SWEP:PrimaryAttack()
 				BoostTime = 0,
 				BoostDelay = 0,
 
-				Drag = 0.001,
+				Drag = 0.003,
 				GuidanceName = "Dumb",
 				FuseName = "Contact",
 				HasInertial = false,
@@ -186,8 +186,8 @@ function SWEP:PrimaryAttack()
 				ArmorThickness = 8,
 
 				MotorSound = "acf_extra/airfx/rpg_fire.wav",
-				BoostEffect = "ACE_RocketBlackSmoke",
-				MotorEffect = "ACE_RocketBlackSmoke"
+				BoostEffect = "rocket_smoke",
+				MotorEffect = "rocket_smoke"
 			}
 			local BData = self.BulletData
 			BData.BulletData = nil

--- a/lua/weapons/weapon_ace_at4t/shared.lua
+++ b/lua/weapons/weapon_ace_at4t/shared.lua
@@ -170,7 +170,7 @@ function SWEP:PrimaryAttack()
 				Owner = owner,
 				Launcher = owner,
 
-				Pos = owner:GetShootPos() + owner:GetAimVector() * 800,
+				Pos = owner:GetShootPos() + owner:GetAimVector() * 850,
 				Ang = owner:GetAimVector():Angle(),
 
 				Mdl = "models/missiles/hvar.mdl",
@@ -188,7 +188,7 @@ function SWEP:PrimaryAttack()
 				BoostTime = 0,
 				BoostDelay = 0,
 
-				Drag = 0.001,
+				Drag = 0.003,
 				GuidanceName = "Dumb",
 				FuseName = "Contact",
 				HasInertial = false,

--- a/lua/weapons/weapon_ace_aug/shared.lua
+++ b/lua/weapons/weapon_ace_aug/shared.lua
@@ -24,34 +24,34 @@ SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you re
 
 SWEP.ZoomFOV = 20
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
-
+SWEP.ReticuleSize = 10
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
-SWEP.HeatReductionDelay = 0.15 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 5 --Heat generated per shot
-SWEP.HeatMax = 50 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatMax = 37.5 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 40	--Amount of angular recoil
+SWEP.AngularRecoil = 28.125	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
 SWEP.RecoilSideBias = 0.2
 
-SWEP.ZoomRecoilBonus = 0.2 --Reduce recoil by this amount when zoomed or scoped
+SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
-SWEP.BaseSpread = 0.05 --First-shot random spread, in degrees
-SWEP.MaxSpread = 3 --Maximum added random spread from heat value, in degrees
+SWEP.BaseSpread = 0 --First-shot random spread, in degrees
+SWEP.MaxSpread = 1 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 1.5 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.MovementSpread = 1 --Increase aimcone to this many degrees when sprinting at full speed
 SWEP.UnscopedSpread = 0.4 --Spread, in degrees, when unscoped with a scoped weapon
+
 
 
 --Model settings--
@@ -69,7 +69,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.556
-	self.BulletData.PropLength = 12.4 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 11.5 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.2
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_awp/shared.lua
+++ b/lua/weapons/weapon_ace_awp/shared.lua
@@ -24,7 +24,7 @@ SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you re
 
 SWEP.ZoomFOV = 10
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
-
+SWEP.ReticuleSize = 10
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
@@ -51,8 +51,8 @@ SWEP.ViewPunchAmount = 3 --Degrees to punch the view upwards each shot - does no
 SWEP.BaseSpread = 0 --First-shot random spread, in degrees
 SWEP.MaxSpread = 0 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 0 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 0 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.MovementSpread = 4 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.UnscopedSpread = 1 --Spread, in degrees, when unscoped with a scoped weapon
 
 SWEP.CarrySpeedMul			= 0.8
 

--- a/lua/weapons/weapon_ace_deagle/shared.lua
+++ b/lua/weapons/weapon_ace_deagle/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 15
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 40
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -29,14 +29,14 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 --SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
---SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatReductionRate = 1600 --Heat loss per second when not firing
-SWEP.HeatPerShot = 40 --Heat generated per shot
-SWEP.HeatMax = 40 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionDelay = 0 --Delay after firing before beginning to reduce heat
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
+SWEP.HeatPerShot = 80 --Heat generated per shot
+SWEP.HeatMax = 80 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 10	--Amount of angular recoil
+SWEP.AngularRecoil = 80	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -44,8 +44,8 @@ SWEP.RecoilSideBias = 0
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 1 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.05 --First-shot random spread, in degrees
@@ -70,8 +70,8 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 1.27
-	self.BulletData.PropLength = 4 --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.ProjLength = 2 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
+	self.BulletData.PropLength = 2.5 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
 	self.BulletData.Data7 = 0
@@ -87,13 +87,13 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.015 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.015 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.7
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_deagle/shared.lua
+++ b/lua/weapons/weapon_ace_deagle/shared.lua
@@ -88,7 +88,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.015 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_elite/shared.lua
+++ b/lua/weapons/weapon_ace_elite/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 15
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -31,12 +31,12 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
 SWEP.HeatReductionRate = 200 --Heat loss per second when not firing
-SWEP.HeatPerShot = 7 --Heat generated per shot
-SWEP.HeatMax = 15 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatPerShot = 15 --Heat generated per shot
+SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 20	--Amount of angular recoil
+SWEP.AngularRecoil = 30	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -44,8 +44,8 @@ SWEP.RecoilSideBias = 0
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.45 --First-shot random spread, in degrees
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.45
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.5
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_famas/shared.lua
+++ b/lua/weapons/weapon_ace_famas/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 40
+SWEP.ReticuleSize = 10
 
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
@@ -29,23 +29,22 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
---SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
---SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 12 --Heat generated per shot
-SWEP.HeatMax = 84 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
+SWEP.HeatPerShot = 6 --Heat generated per shot
+SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 20	--Amount of angular recoil
+SWEP.AngularRecoil = 22.5	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
-SWEP.RecoilSideBias = 0.1
+SWEP.RecoilSideBias = 0.15
 
-SWEP.ZoomRecoilBonus = 0.4 --Reduce recoil by this amount when zoomed or scoped
-SWEP.CrouchRecoilBonus = 0.4 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
+SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
+SWEP.ViewPunchAmount = 0.15 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.15 --First-shot random spread, in degrees
@@ -70,7 +69,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.556
-	self.BulletData.PropLength = 12 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 11 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -94,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.2
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_fiveseven/shared.lua
+++ b/lua/weapons/weapon_ace_fiveseven/shared.lua
@@ -44,8 +44,8 @@ SWEP.RecoilSideBias = 0
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.05 --First-shot random spread, in degrees
@@ -70,7 +70,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.57
-	self.BulletData.PropLength = 8 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 2 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 2.1 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.2
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.5
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_fiveseven/shared.lua
+++ b/lua/weapons/weapon_ace_fiveseven/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 20
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 

--- a/lua/weapons/weapon_ace_galil/shared.lua
+++ b/lua/weapons/weapon_ace_galil/shared.lua
@@ -21,21 +21,21 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 40
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
---SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
---SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 5 --Heat generated per shot
-SWEP.HeatMax = 35 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
+SWEP.HeatReductionDelay = 0.1 --Delay after firing before beginning to reduce heat
+SWEP.HeatPerShot = 10 --Heat generated per shot
+SWEP.HeatMax = 70 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 20	--Amount of angular recoil
+SWEP.AngularRecoil = 50	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,15 +43,15 @@ SWEP.RecoilSideBias = -0.2
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.15 --First-shot random spread, in degrees
 SWEP.MaxSpread = 1 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 5 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 2 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.MovementSpread = 1 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.UnscopedSpread = 0.4 --Spread, in degrees, when unscoped with a scoped weapon
 
 
 --Model settings--
@@ -92,7 +92,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.2
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.5
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_glock/shared.lua
+++ b/lua/weapons/weapon_ace_glock/shared.lua
@@ -22,7 +22,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -31,7 +31,7 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 3 --Heat generated per shot
+SWEP.HeatPerShot = 10 --Heat generated per shot
 SWEP.HeatMax = 20 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
@@ -44,8 +44,8 @@ SWEP.RecoilSideBias = 0
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 1--Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.15 --First-shot random spread, in degrees

--- a/lua/weapons/weapon_ace_grenade/shared.lua
+++ b/lua/weapons/weapon_ace_grenade/shared.lua
@@ -104,7 +104,7 @@ function SWEP:PrimaryAttack()
 
 	self:SendWeaponAnim(ACT_VM_PULLPIN)
 
-	self:ThrowNade(5000, -7)
+	self:ThrowNade(400, -7)  -- Was 5000, now 400 for 0.4kg grenade
 end
 
 
@@ -128,7 +128,7 @@ function SWEP:SecondaryAttack()
 	self:SendWeaponAnim( ACT_VM_PULLPIN  )
 	owner:SetAnimation( PLAYER_ATTACK1 )
 
-	self:ThrowNade(1000, -10)
+	self:ThrowNade(80, -10)  -- Was 1000, now 80 for underhand toss
 end
 
 function SWEP:Think()

--- a/lua/weapons/weapon_ace_m16/shared.lua
+++ b/lua/weapons/weapon_ace_m16/shared.lua
@@ -21,21 +21,21 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
---SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
-SWEP.HeatReductionDelay = 0.1 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 4 --Heat generated per shot
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
+SWEP.HeatReductionDelay = 0.15 --Delay after firing before beginning to reduce heat
+SWEP.HeatPerShot = 5 --Heat generated per shot
 SWEP.HeatMax = 35 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 15	--Amount of angular recoil
+SWEP.AngularRecoil = 20	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,8 +43,8 @@ SWEP.RecoilSideBias = -0.1
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0 --First-shot random spread, in degrees
@@ -69,7 +69,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.556
-	self.BulletData.PropLength = 12.5 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 9 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.2
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_m249saw/shared.lua
+++ b/lua/weapons/weapon_ace_m249saw/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 20
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 50
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -30,12 +30,12 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 SWEP.HeatReductionRate = 600 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 50 --Heat generated per shot
-SWEP.HeatMax = 50 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatPerShot = 20 --Heat generated per shot
+SWEP.HeatMax = 60 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 10	--Amount of angular recoil
+SWEP.AngularRecoil = 40	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -47,11 +47,11 @@ SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does no
 
 
 --Spread (aimcone) settings--
-SWEP.BaseSpread = 1.5 --First-shot random spread, in degrees
-SWEP.MaxSpread = 0 --Maximum added random spread from heat value, in degrees
+SWEP.BaseSpread = 0.2 --First-shot random spread, in degrees
+SWEP.MaxSpread = 1 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
 SWEP.MovementSpread = 2 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 1 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.UnscopedSpread = 0.5 --Spread, in degrees, when unscoped with a scoped weapon
 
 SWEP.CarrySpeedMul			= 0.6
 
@@ -70,7 +70,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.556
-	self.BulletData.PropLength = 12.6 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 11 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.5
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_m3super90/shared.lua
+++ b/lua/weapons/weapon_ace_m3super90/shared.lua
@@ -71,7 +71,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Id = "7.62mmMG"
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
-	self.BulletData.Caliber = 1.2
+	self.BulletData.Caliber = 0.725
 	self.BulletData.PropLength = 2.6 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 3.5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
@@ -90,8 +90,8 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--		self.BulletData.DragCoef  = 0 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
-	self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_m3super90/shared.lua
+++ b/lua/weapons/weapon_ace_m3super90/shared.lua
@@ -90,7 +90,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--		self.BulletData.DragCoef  = 0 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)

--- a/lua/weapons/weapon_ace_m3super90/shared.lua
+++ b/lua/weapons/weapon_ace_m3super90/shared.lua
@@ -24,7 +24,7 @@ SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you re
 
 SWEP.ZoomFOV = 50
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
-
+SWEP.ReticuleSize = 10
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards

--- a/lua/weapons/weapon_ace_mac10/shared.lua
+++ b/lua/weapons/weapon_ace_mac10/shared.lua
@@ -21,21 +21,21 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 120 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 3 --Heat generated per shot
-SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatPerShot = 10 --Heat generated per shot
+SWEP.HeatMax = 60 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 8	--Amount of angular recoil
+SWEP.AngularRecoil = 40	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,8 +43,8 @@ SWEP.RecoilSideBias = -0.4
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.5 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.3 --First-shot random spread, in degrees
@@ -92,7 +92,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.6
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.9
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_mp5/shared.lua
+++ b/lua/weapons/weapon_ace_mp5/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -31,11 +31,11 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 8 --Heat generated per shot
-SWEP.HeatMax = 55 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatMax = 18 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 6	--Amount of angular recoil
+SWEP.AngularRecoil = 18	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,8 +43,8 @@ SWEP.RecoilSideBias = -0.1
 
 SWEP.ZoomRecoilBonus = 0.65 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.15 --First-shot random spread, in degrees
@@ -91,7 +91,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.6
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.9
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_p228/shared.lua
+++ b/lua/weapons/weapon_ace_p228/shared.lua
@@ -24,28 +24,31 @@ SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you re
 
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
-
+SWEP.ReticuleSize = 10
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 --SWEP.HeatReductionRate = 100 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 4 --Heat generated per shot
-SWEP.HeatMax = 16 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatPerShot = 8 --Heat generated per shot
+SWEP.HeatMax = 8 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
+SWEP.AngularRecoil = 16	--Amount of angular recoil
+
+
 
 SWEP.RecoilSideBias = 0.25 --How much the recoil is biased to one side proportional to vertical recoil
 						--Positive numbers bias to the right, negative to the left
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.1 --First-shot random spread, in degrees
-SWEP.MaxSpread = 5 --Maximum added random spread from heat value, in degrees
+SWEP.MaxSpread = 1 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
 SWEP.MovementSpread = 1 --Increase aimcone to this many degrees when sprinting at full speed
 SWEP.UnscopedSpread = 0 --Spread, in degrees, when unscoped with a scoped weapon
@@ -66,8 +69,8 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.9
-	self.BulletData.PropLength = 1.35 --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.ProjLength = 1.6 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
+	self.BulletData.PropLength = 2.2 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.ProjLength = 2.25 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
 	self.BulletData.Data7 = 0
@@ -89,7 +92,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.5
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.8
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_p90/shared.lua
+++ b/lua/weapons/weapon_ace_p90/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 40
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
 
@@ -31,11 +31,11 @@ SWEP.HasScope = true --True if the weapon has a sniper-style scope
 SWEP.HeatReductionRate = 175 --Heat loss per second when not firing
 SWEP.HeatReductionDelay = 0.1 --Delay after firing before beginning to reduce heat
 SWEP.HeatPerShot = 5 --Heat generated per shot
-SWEP.HeatMax = 20 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatMax = 17 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 8	--Amount of angular recoil
+SWEP.AngularRecoil = 17	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,8 +43,8 @@ SWEP.RecoilSideBias = 0.1
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.3 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.15 --First-shot random spread, in degrees
@@ -91,7 +91,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_scout/shared.lua
+++ b/lua/weapons/weapon_ace_scout/shared.lua
@@ -24,7 +24,7 @@ SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you re
 
 SWEP.ZoomFOV = 20
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
-
+SWEP.ReticuleSize = 10
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
@@ -50,8 +50,8 @@ SWEP.ViewPunchAmount = 2 --Degrees to punch the view upwards each shot - does no
 SWEP.BaseSpread = 0 --First-shot random spread, in degrees
 SWEP.MaxSpread = 0 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
-SWEP.MovementSpread = 0 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 0 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.MovementSpread = 4 --Increase aimcone to this many degrees when sprinting at full speed
+SWEP.UnscopedSpread = 1 --Spread, in degrees, when unscoped with a scoped weapon
 
 
 --Model settings--

--- a/lua/weapons/weapon_ace_sg552/shared.lua
+++ b/lua/weapons/weapon_ace_sg552/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 25
 SWEP.HasScope = true --True if the weapon has a sniper-style scope
 
@@ -30,12 +30,12 @@ SWEP.HasScope = true --True if the weapon has a sniper-style scope
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 SWEP.HeatReductionRate = 200 --Heat loss per second when not firing
 SWEP.HeatReductionDelay = 0.125 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 8 --Heat generated per shot
+SWEP.HeatPerShot = 6 --Heat generated per shot
 SWEP.HeatMax = 30 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 7	--Amount of angular recoil
+SWEP.AngularRecoil = 20	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,15 +43,15 @@ SWEP.RecoilSideBias = 0.15
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 0.1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.05 --First-shot random spread, in degrees
 SWEP.MaxSpread = 0.5 --Maximum added random spread from heat value, in degrees
 					--If HeatMax is 0 this will be ignored and only BaseSpread will be taken into account (AT4 for example)
 SWEP.MovementSpread = 1 --Increase aimcone to this many degrees when sprinting at full speed
-SWEP.UnscopedSpread = 2 --Spread, in degrees, when unscoped with a scoped weapon
+SWEP.UnscopedSpread = 0.5 --Spread, in degrees, when unscoped with a scoped weapon
 
 
 --Model settings--
@@ -69,7 +69,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.556
-	self.BulletData.PropLength = 12 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.PropLength = 7 --Volume of the case as a cylinder * Powder density converted from g to kg
 	self.BulletData.ProjLength = 5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
@@ -93,7 +93,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 1.3
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 2
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_tmp/shared.lua
+++ b/lua/weapons/weapon_ace_tmp/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -29,13 +29,13 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 --SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
-SWEP.HeatReductionRate = 100 --Heat loss per second when not firing
+SWEP.HeatReductionRate = 300 --Heat loss per second when not firing
 SWEP.HeatPerShot = 4 --Heat generated per shot
 SWEP.HeatMax = 25 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 5	--Amount of angular recoil
+SWEP.AngularRecoil = 20	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left

--- a/lua/weapons/weapon_ace_ump45/shared.lua
+++ b/lua/weapons/weapon_ace_ump45/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 1 --Number of bullets to fire each shot, used for sho
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
@@ -30,12 +30,12 @@ SWEP.HasScope = false --True if the weapon has a sniper-style scope
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
 --SWEP.HeatReductionRate = 125 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 8 --Heat generated per shot
-SWEP.HeatMax = 40 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatPerShot = 5 --Heat generated per shot
+SWEP.HeatMax = 20 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 9	--Amount of angular recoil
+SWEP.AngularRecoil = 20	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left
@@ -43,7 +43,7 @@ SWEP.RecoilSideBias = -0.2
 
 SWEP.ZoomRecoilBonus = 0.7 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.ViewPunchAmount = 0.2 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
 
 
 --Spread (aimcone) settings--

--- a/lua/weapons/weapon_ace_ump45/shared.lua
+++ b/lua/weapons/weapon_ace_ump45/shared.lua
@@ -91,7 +91,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.5
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.7
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_usp/shared.lua
+++ b/lua/weapons/weapon_ace_usp/shared.lua
@@ -23,26 +23,31 @@ SWEP.Primary.Automatic = false
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload"
 
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 
 
 --Recoil (crosshair movement) settings--
 --"Heat" is a number that represents how long you've been firing, affecting how quickly your crosshair moves upwards
-SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
+--SWEP.HeatReductionRate = 75 --Heat loss per second when not firing
 --SWEP.HeatReductionDelay = 0.3 --Delay after firing before beginning to reduce heat
-SWEP.HeatPerShot = 4 --Heat generated per shot
-SWEP.HeatMax = 16 --Maximum heat - determines max rate at which recoil is applied to eye angles
+SWEP.HeatReductionRate = 1600 --Heat loss per second when not firing
+SWEP.HeatPerShot = 20 --Heat generated per shot
+SWEP.HeatMax = 40 --Maximum heat - determines max rate at which recoil is applied to eye angles
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.RecoilSideBias = -0.1 --How much the recoil is biased to one side proportional to vertical recoil
-						--Positive numbers bias to the right, negative to the left
+SWEP.AngularRecoil = 20	--Amount of angular recoil
+
+--How much the recoil is biased to one side proportional to vertical recoil
+--Positive numbers bias to the right, negative to the left
+SWEP.RecoilSideBias = 0
 
 SWEP.ZoomRecoilBonus = 0.5 --Reduce recoil by this amount when zoomed or scoped
 SWEP.CrouchRecoilBonus = 0.5 --Reduce recoil by this amount when crouching
-SWEP.ViewPunchAmount = 0 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
-
+SWEP.ViewPunchAmount = 1 --Degrees to punch the view upwards each shot - does not actually move crosshair, just a visual effect
+SWEP.AccurateCrosshair = true
 
 --Spread (aimcone) settings--
 SWEP.BaseSpread = 0.07 --First-shot random spread, in degrees
@@ -67,7 +72,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Id = 1
 	self.BulletData.Caliber = 0.9
 	self.BulletData.PropLength = 2.2 --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.ProjLength = 1.3 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
+	self.BulletData.ProjLength = 1.5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
 	self.BulletData.Data7 = 0
@@ -89,7 +94,7 @@ function SWEP:InitBulletData()
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2
 	self.BulletData.KETransfert = 0.3
-	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.6
+	self.BulletData.PenArea = self.BulletData.FrArea ^ ACF.PenAreaMod * 0.5
 	self.BulletData.Pos = Vector(0, 0, 0)
 	self.BulletData.LimitVel = 800
 	self.BulletData.Ricochet = 60

--- a/lua/weapons/weapon_ace_xm1014/shared.lua
+++ b/lua/weapons/weapon_ace_xm1014/shared.lua
@@ -69,9 +69,9 @@ function SWEP:InitBulletData()
 	self.BulletData.Id = "7.62mmMG"
 	self.BulletData.Type = "AP"
 	self.BulletData.Id = 1
-	self.BulletData.Caliber = 1.2
-	self.BulletData.PropLength = 2.5 --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.ProjLength = 3.5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
+	self.BulletData.Caliber = 0.5
+	self.BulletData.PropLength = 3.5 --Volume of the case as a cylinder * Powder density converted from g to kg
+	self.BulletData.ProjLength = 4.5 --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
 	self.BulletData.Data5 = 0 --He Filler or Flechette count
 	self.BulletData.Data6 = 0 --HEAT ConeAng or Flechette Spread
 	self.BulletData.Data7 = 0

--- a/lua/weapons/weapon_ace_xm1014/shared.lua
+++ b/lua/weapons/weapon_ace_xm1014/shared.lua
@@ -21,7 +21,7 @@ SWEP.Primary.BulletCount = 10 --Number of bullets to fire each shot, used for sh
 
 SWEP.ReloadSound = "Weapon_Pistol.Reload" --Sound other players hear when you reload - this is NOT your first-person sound
 										--Most models have a built-in first-person reload sound
-SWEP.ReticuleSize = 45
+SWEP.ReticuleSize = 10
 SWEP.ZoomFOV = 60
 SWEP.HasScope = false --True if the weapon has a sniper-style scope
 


### PR DESCRIPTION
- Added viewpunch with accurate crosshair to all weapons (more dynamic camera behavior and a better shooting experience; previously, there was no viewpunch or accurate crosshair)
- Changed the crosshair size to a more reasonable size (10)
- Reworked the recoil of all SWEPs (all SWEPs were either extremely strangely configured or not configured at all after the recoil system update)
- Bringing bullet velocity to real values ​​(for almost all weapons, the velocity was set based on the caliber, without taking into account the barrel length and other factors affecting the final bullet velocity)
- Decreased penetration and increased damage by +-1.5 (for all except Sniper rifles and special) (the reduction in penetration is justified by the standard bulletproof protection of 6-8mm steel, therefore, regular firearms should not penetrate it)
- Changed the caliber of shotguns from 12.7 to 7.25 mm (each pellet was 12 mm, now 7.25, which is the average buckshot size)
- Fixed AT4 exploding inside the player
- Changed the AT4 trail to a more accurate one (the original trail is slightly to the side) (only for the regular AT4, not the AT4T)
- Added spread on the move for the Anti-Material Rifle (there was no spread while moving, which could negatively impact the gameplay experience)
