### PR TITLE
Fix legacy crewseat dupes and refactor dupe pose handling

### DIFF
--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -6,7 +6,101 @@
 
 include("acf/shared/sh_crewseat_base.lua")
 
+-- Resolve a crewseat model type from dupe data or the current model path.
+function ACE_CrewseatResolveModelType(ent, info)
+	if not IsValid(ent) then return nil end
+
+	local modelPath = (info and info.Model) or ent:GetModel()
+	if not modelPath then return nil end
+
+	local modelType = ACE.CrewseatModelLookup and ACE.CrewseatModelLookup[modelPath]
+	if not modelType or not (ACE.CrewseatModels and ACE.CrewseatModels[modelType]) then
+		return nil
+	end
+
+	if ent.ModelType ~= modelType then
+		ent.ModelType = modelType
+	end
+
+	local model = ACE.CrewseatModels[modelType]
+	if model and ent.Model ~= model then
+		ent:SetModel(model)
+		ent.Model = model
+	end
+
+	return modelType
+end
+
+-- Apply dupe model data with a fallback model type and optional legacy override.
+function ACE_CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitting)
+	local modelType = info.ModelType
+	local legacyLocked = false
+
+	if legacyForceSitting and info.ModelType == nil and info.Model == nil then
+		modelType = "Sitting"
+		legacyLocked = true
+	end
+
+	if not modelType or not ACE.CrewseatModels[modelType] then
+		local modelPath = info.Model or ent:GetModel()
+		modelType = (modelPath and ACE.CrewseatModelLookup[modelPath]) or modelType
+	end
+
+	if not modelType or not ACE.CrewseatModels[modelType] then
+		modelType = defaultModelType or "Sitting"
+	end
+
+	ent.ModelType = modelType
+	ent.ACE_LegacyCrewseatModelLocked = legacyLocked or nil
+
+	local model = ACE.CrewseatModels[modelType]
+	if model then
+		ent:SetModel(model)
+		ent.Model = model
+	end
+
+	return modelType, legacyLocked
+end
+
+-- Defer model sync so the duplicator can finish applying model data.
+function ACE_CrewseatDeferredModelSync(ent, info)
+	timer.Simple(0, function()
+		if not IsValid(ent) then return end
+		if ent.ACE_LegacyCrewseatModelLocked then return end
+		ACE_CrewseatResolveModelType(ent, info)
+	end)
+end
+
 ACE = ACE or {}
+
+-- Dump crewseat state for debugging from console.
+concommand.Add("ace_crewseat_dump", function(_, _, args)
+	local target = tonumber(args[1] or "")
+
+	local function dumpSeat(ent)
+		if not IsValid(ent) then return end
+
+		local owner = ent.CPPIGetOwner and ent:CPPIGetOwner()
+		local ownerName = IsValid(owner) and owner:Nick() or "Unknown"
+		local model = ent:GetModel() or "nil"
+		local modelType = ent.ModelType or "nil"
+		local weight = tonumber(ent.Weight) or 0
+		local legal = ent.Legal and "true" or "false"
+		local issues = ent.LegalIssues or ""
+
+		print(string.format("[ACE Crewseat] %s(%d) owner=%s model=%s modelType=%s weight=%.2f legal=%s issues=%s",
+			ent:GetClass(), ent:EntIndex(), ownerName, model, modelType, weight, legal, issues))
+	end
+
+	if target then
+		dumpSeat(Entity(target))
+		return
+	end
+
+	for _, seat in pairs(ACE.Crewseats or {}) do
+		dumpSeat(seat)
+	end
+end)
 
 -- Rare crew names (easter eggs)
 local rareNames = {
@@ -153,8 +247,11 @@ function ACE_InitializeCrewseat(ent, modelType)
 	ent:SetSolid(SOLID_VPHYSICS)
 
 	local phys = ent:GetPhysicsObject()
+	local crewData = ent.CrewseatData
+	local weight = (crewData and crewData.weight) or ent.Weight or 85
+
 	if IsValid(phys) then
-		phys:SetMass(85) -- requested seat weight
+		phys:SetMass(weight) -- requested seat weight
 	end
 
 	ent.Master = {}
@@ -164,7 +261,7 @@ function ACE_InitializeCrewseat(ent, modelType)
 	ent.ACF.Armour = ent.ACF.Armour or 1
 
 	ent.Name = ent.Name or ACE_GenerateCrewName()
-	ent.Weight = 85
+	ent.Weight = weight
 	ent.AnglePenalty = 0
 	ent.GForcePenalty = 0
 
@@ -219,10 +316,14 @@ end
 -- Crewseat-specific legal check (includes model validation)
 function ACE_CrewseatLegalCheck(ent)
 	if ACF.CurTime > ent.NextLegalCheck then
+		local currentModel = ent:GetModel()
+		if ent.Model ~= currentModel then
+			ent.Model = currentModel
+		end
+
 		ent.Legal, ent.LegalIssues = ACF_CheckLegal(ent, ent.Model, math.Round(ent.Weight, 2), nil, true, true)
 
 		if ent.Legal then
-			local currentModel = ent:GetModel()
 			if not (ACE_IsValidCrewseatModel and ACE_IsValidCrewseatModel(currentModel)) then
 				ent.Legal = false
 				ent.LegalIssues = "Invalid crewseat model"

--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -6,6 +6,8 @@
 
 include("acf/shared/sh_crewseat_base.lua")
 
+local crewseatDebug = CreateConVar("ace_debug_crewseat_models", "0", FCVAR_ARCHIVE, "Log crewseat model/type changes during dupe paste")
+
 -- Resolve a crewseat model type from dupe data or the current model path.
 function ACE_CrewseatResolveModelType(ent, info)
 	if not IsValid(ent) then return nil end
@@ -31,27 +33,63 @@ function ACE_CrewseatResolveModelType(ent, info)
 	return modelType
 end
 
+-- Check whether crewseat model debugging is enabled.
+function ACE_CrewseatDebugEnabled()
+	return crewseatDebug:GetBool()
+end
+
+-- Print a crewseat debug line when enabled.
+function ACE_CrewseatDebugLog(ent, stage, info, extra)
+	if not ACE_CrewseatDebugEnabled() then return end
+
+	local owner = "Unknown"
+	if ent.CPPIGetOwner then
+		local ply = ent:CPPIGetOwner()
+		if IsValid(ply) then owner = ply:Nick() end
+	end
+
+	local infoModel = info and info.Model or "nil"
+	local infoModelType = info and info.ModelType or "nil"
+	local entClass = IsValid(ent) and ent:GetClass() or "unknown"
+	local entIndex = IsValid(ent) and ent:EntIndex() or 0
+	local model = IsValid(ent) and ent:GetModel() or "nil"
+	local modelType = IsValid(ent) and (ent.ModelType or "nil") or "nil"
+
+	print(string.format("[ACE Crewseat] %s(%d) owner=%s stage=%s infoModel=%s infoModelType=%s model=%s modelType=%s extra=%s",
+		entClass, entIndex, owner, stage, infoModel, infoModelType, model, modelType, extra or "none"))
+end
+
 -- Apply dupe model data with a fallback model type and optional legacy override.
 function ACE_CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitting)
 	local modelType = info.ModelType
 	local legacyLocked = false
+	local reason = "preserved"
+
+	ent.ACE_DupeInfoModel = info.Model
+	ent.ACE_DupeInfoModelType = info.ModelType
 
 	if legacyForceSitting and info.ModelType == nil and info.Model == nil then
 		modelType = "Sitting"
 		legacyLocked = true
+		reason = "legacy forced sitting"
 	end
 
 	if not modelType or not ACE.CrewseatModels[modelType] then
 		local modelPath = info.Model or ent:GetModel()
 		modelType = (modelPath and ACE.CrewseatModelLookup[modelPath]) or modelType
+		if modelType and ACE.CrewseatModels[modelType] then
+			reason = "restored from model path"
+		end
 	end
 
 	if not modelType or not ACE.CrewseatModels[modelType] then
 		modelType = defaultModelType or "Sitting"
+		reason = "class default fallback"
 	end
 
 	ent.ModelType = modelType
 	ent.ACE_LegacyCrewseatModelLocked = legacyLocked or nil
+	ent.ACE_DupeResolveReason = reason
 
 	local model = ACE.CrewseatModels[modelType]
 	if model then
@@ -59,7 +97,7 @@ function ACE_CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitt
 		ent.Model = model
 	end
 
-	return modelType, legacyLocked
+	return modelType, legacyLocked, reason
 end
 
 -- Defer model sync so the duplicator can finish applying model data.
@@ -67,7 +105,15 @@ function ACE_CrewseatDeferredModelSync(ent, info)
 	timer.Simple(0, function()
 		if not IsValid(ent) then return end
 		if ent.ACE_LegacyCrewseatModelLocked then return end
-		ACE_CrewseatResolveModelType(ent, info)
+		local beforeModel = ent:GetModel()
+		local beforeType = ent.ModelType
+		local modelType = ACE_CrewseatResolveModelType(ent, info)
+		if modelType and (beforeModel ~= ent:GetModel() or beforeType ~= ent.ModelType) then
+			ent.ACE_DupeDeferredModel = ent:GetModel()
+			ent.ACE_DupeDeferredModelType = ent.ModelType
+			ent.ACE_DupeDeferredResolved = modelType
+			ACE_CrewseatDebugLog(ent, "DeferredSync", info, "resolved=" .. tostring(modelType))
+		end
 	end)
 end
 
@@ -84,12 +130,28 @@ concommand.Add("ace_crewseat_dump", function(_, _, args)
 		local ownerName = IsValid(owner) and owner:Nick() or "Unknown"
 		local model = ent:GetModel() or "nil"
 		local modelType = ent.ModelType or "nil"
+		local infoModel = ent.ACE_DupeInfoModel or "nil"
+		local infoModelType = ent.ACE_DupeInfoModelType or "nil"
+		local resolveReason = ent.ACE_DupeResolveReason or "nil"
+		local spawnModel = ent.ACE_DupeSpawnModel or "nil"
+		local spawnModelType = ent.ACE_DupeSpawnModelType or "nil"
+	local spawnLegacy = ent.ACE_DupeSpawnLegacy and "true" or "false"
+		local initModel = ent.ACE_InitModel or "nil"
+		local initModelType = ent.ACE_InitModelType or "nil"
+		local deferredModel = ent.ACE_DupeDeferredModel or "nil"
+		local deferredType = ent.ACE_DupeDeferredModelType or "nil"
+		local deferredResolved = ent.ACE_DupeDeferredResolved or "nil"
 		local weight = tonumber(ent.Weight) or 0
 		local legal = ent.Legal and "true" or "false"
 		local issues = ent.LegalIssues or ""
 
 		print(string.format("[ACE Crewseat] %s(%d) owner=%s model=%s modelType=%s weight=%.2f legal=%s issues=%s",
 			ent:GetClass(), ent:EntIndex(), ownerName, model, modelType, weight, legal, issues))
+		print(string.format("[ACE Crewseat] dupe infoModel=%s infoModelType=%s resolveReason=%s deferredModel=%s deferredModelType=%s deferredResolved=%s",
+			infoModel, infoModelType, resolveReason, deferredModel, deferredType, deferredResolved))
+		print(string.format("[ACE Crewseat] dupe spawnModel=%s spawnModelType=%s initModel=%s initModelType=%s",
+			spawnModel, spawnModelType, initModel, initModelType))
+		print(string.format("[ACE Crewseat] dupe spawnLegacy=%s", spawnLegacy))
 	end
 
 	if target then
@@ -267,6 +329,9 @@ function ACE_InitializeCrewseat(ent, modelType)
 
 	ent.ModelType = modelType
 	ent.Model = model
+
+	ent.ACE_InitModelType = modelType
+	ent.ACE_InitModel = model
 
 	ent.Sound = ent.Sound or ("npc/combine_soldier/die" .. tostring(math.random(1, 3)) .. ".wav")
 	ent.SoundPitch = ent.SoundPitch or 100

--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -323,11 +323,9 @@ function ACE_CrewseatLegalCheck(ent)
 
 		ent.Legal, ent.LegalIssues = ACF_CheckLegal(ent, ent.Model, math.Round(ent.Weight, 2), nil, true, true)
 
-		if ent.Legal then
-			if not (ACE_IsValidCrewseatModel and ACE_IsValidCrewseatModel(currentModel)) then
-				ent.Legal = false
-				ent.LegalIssues = "Invalid crewseat model"
-			end
+		if ent.Legal and not (ACE_IsValidCrewseatModel and ACE_IsValidCrewseatModel(currentModel)) then
+			ent.Legal = false
+			ent.LegalIssues = "Invalid crewseat model"
 		end
 
 		ent.NextLegalCheck = ACF.Legal.NextCheck(ent.Legal)

--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -45,6 +45,8 @@ function MakeACE_Crewseat_Driver(Owner, Pos, Angle, Id, EntityData)
 		modelType = entData.defaultModel or "Sitting"
 	end
 	ent.ModelType = modelType
+	ent.ACE_DupeSpawnModelType = modelType
+	ent.ACE_DupeSpawnModel = ACE.CrewseatModels and ACE.CrewseatModels[modelType] or nil
 
 	ent:Spawn()
 	ent:CPPISetOwner(Owner)
@@ -129,7 +131,9 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
 	ACE_CrewseatDeferredModelSync(self, info)
 end
 

--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -38,6 +38,8 @@ function MakeACE_Crewseat_Driver(Owner, Pos, Angle, Id, EntityData)
 	ent:SetAngles(Angle)
 	ent:SetPos(Pos)
 
+	ent.CrewseatData = entData
+
 	local modelType = EntityData
 	if not modelType or modelType == "" then
 		modelType = entData.defaultModel or "Sitting"
@@ -112,6 +114,23 @@ function ENT:UpdateOverlayText()
 	end
 
 	self:SetOverlayText(str)
+end
+
+function ENT:BuildDupeInfo()
+	local info = self.BaseClass.BuildDupeInfo(self) or {}
+	info.ModelType = self.ModelType
+	info.Model = self.Model
+	return info
+end
+
+function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
+	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
+
+	local class = self:GetClass()
+	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
+
+	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDeferredModelSync(self, info)
 end
 
 function ENT:ACF_OnDamage(Entity, Energy, FrArea, _, Inflictor, _, _)

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -46,6 +46,8 @@ function MakeACE_Crewseat_Gunner(Owner, Pos, Angle, Id, EntityData)
 		modelType = entData.defaultModel or "Sitting"
 	end
 	ent.ModelType = modelType
+	ent.ACE_DupeSpawnModelType = modelType
+	ent.ACE_DupeSpawnModel = ACE.CrewseatModels and ACE.CrewseatModels[modelType] or nil
 
 	ent:Spawn()
 	ent:CPPISetOwner(Owner)
@@ -223,6 +225,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
 	ACE_CrewseatDeferredModelSync(self, info)
 end

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -39,6 +39,8 @@ function MakeACE_Crewseat_Gunner(Owner, Pos, Angle, Id, EntityData)
 	ent:SetAngles(Angle)
 	ent:SetPos(Pos)
 
+	ent.CrewseatData = entData
+
 	local modelType = EntityData
 	if not modelType or modelType == "" then
 		modelType = entData.defaultModel or "Sitting"
@@ -211,23 +213,16 @@ end
 function ENT:BuildDupeInfo()
 	local info = self.BaseClass.BuildDupeInfo(self) or {}
 	info.ModelType = self.ModelType
+	info.Model = self.Model
 	return info
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
-	local modelType = info.ModelType
+	local class = self:GetClass()
+	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	-- Old dupes don't have ModelType saved, default to Sitting (original behavior)
-	if not modelType or not ACE.CrewseatModels[modelType] then
-		modelType = "Sitting"
-	end
-
-	self.ModelType = modelType
-	local model = ACE.CrewseatModels[modelType]
-	if model then
-		self:SetModel(model)
-		self.Model = model
-	end
+	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE_CrewseatDeferredModelSync(self, info)
 end

--- a/lua/entities/ace_crewseat_loader/init.lua
+++ b/lua/entities/ace_crewseat_loader/init.lua
@@ -38,16 +38,22 @@ function MakeACE_Crewseat_Loader(Owner, Pos, Angle, Id, EntityData)
 	local ent = ents.Create("ace_crewseat_loader")
 	if not IsValid(ent) then return false end
 
-	ent:SetAngles(Angle)
-	ent:SetPos(Pos)
-
-	ent.CrewseatData = entData
-
 	local modelType = EntityData
+	local spawnPos = Pos
 	if not modelType or modelType == "" then
-		modelType = entData.defaultModel or "Standing"
+		modelType = "Sitting"
+		ent.ACE_LegacyCrewseatModelLocked = true
+		ent.ACE_DupeSpawnLegacy = true
+		spawnPos = Pos
 	end
 	ent.ModelType = modelType
+	ent.ACE_DupeSpawnModelType = modelType
+	ent.ACE_DupeSpawnModel = ACE.CrewseatModels and ACE.CrewseatModels[modelType] or nil
+
+	ent:SetAngles(Angle)
+	ent:SetPos(spawnPos)
+
+	ent.CrewseatData = entData
 
 	ent:Spawn()
 	ent:CPPISetOwner(Owner)
@@ -219,6 +225,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, true)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, true)
+	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
 	ACE_CrewseatDeferredModelSync(self, info)
 end

--- a/lua/entities/ace_crewseat_loader/init.lua
+++ b/lua/entities/ace_crewseat_loader/init.lua
@@ -41,6 +41,8 @@ function MakeACE_Crewseat_Loader(Owner, Pos, Angle, Id, EntityData)
 	ent:SetAngles(Angle)
 	ent:SetPos(Pos)
 
+	ent.CrewseatData = entData
+
 	local modelType = EntityData
 	if not modelType or modelType == "" then
 		modelType = entData.defaultModel or "Standing"
@@ -207,23 +209,16 @@ end
 function ENT:BuildDupeInfo()
 	local info = self.BaseClass.BuildDupeInfo(self) or {}
 	info.ModelType = self.ModelType
+	info.Model = self.Model
 	return info
 end
 
 function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	self.BaseClass.ApplyDupeInfo(self, ply, ent, info, GetEntByID)
 
-	local modelType = info.ModelType
+	local class = self:GetClass()
+	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	-- Old dupes don't have ModelType saved, default to Sitting (original behavior)
-	if not modelType or not ACE.CrewseatModels[modelType] then
-		modelType = "Sitting"
-	end
-
-	self.ModelType = modelType
-	local model = ACE.CrewseatModels[modelType]
-	if model then
-		self:SetModel(model)
-		self.Model = model
-	end
+	ACE_CrewseatApplyDupeModel(self, info, defaultModelType, true)
+	ACE_CrewseatDeferredModelSync(self, info)
 end


### PR DESCRIPTION
- Centralize crewseat dupe model handling and keep legacy loader dupes sitting to match master behavior. This means the issue isn't really fixed persay, but it happens on master aswell and in the deep dive i did seems unfixable for legacy dupes, all new dupes should be fine though.
- Sync crewseat model before legality checks to avoid stale model mismatches.
- Add ace_crewseat_dump console command for quick crewseat diagnostics.
