### PR TITLE
Refactor missile caliber model to real body calibers and retire warhead overrides

### DIFF
--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -250,7 +250,7 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 153 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 38,							-- Real diameter (380 mm).
 	weight           = 463,								-- Don't scale down the weight though!
 	year             = 1974,
 	modeldiameter    = 30,--Already in ammocrate units
@@ -323,7 +323,7 @@ ACF_defineGun("SRAAM AAM", {								-- id
 	gunclass         = "AAM",
 	rack             = "2x SRAAM",							-- Which rack to spawn this missile on?
 	length           = 115 * 2.53, --Convert to ammocrate units
-	caliber          = 10,		--Actual is 165. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead	
+	caliber          = 16.5,	-- Real diameter (165 mm).
 	weight           = 70,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1984,
 	modeldiameter    = 8,--Already in ammocrate units
@@ -695,7 +695,7 @@ ACF_defineGun("R-73 AAM", {								-- id
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 116 * 2.53, --Convert to ammocrate units
-	caliber          = 10,		--Actual is 165. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead	
+	caliber          = 16.5,	-- Real diameter (165 mm).
 	weight           = 105,								-- Don't scale down the weight though! --was 152, I cut that down to 1/2 an AIM-7s weight
 	year             = 1984,
 	modeldiameter    = 15,--Already in ammocrate units
@@ -917,7 +917,7 @@ ACF_defineGun("R-33 AAM", {							-- id
 	gunclass         = "AAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 163 * 2.53, --Convert to ammocrate units
-	caliber          = 20,		--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 38,		-- Real diameter (380 mm).
 	weight           = 490,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 27,--Already in ammocrate units

--- a/lua/acf/shared/missiles/missile_asm.lua
+++ b/lua/acf/shared/missiles/missile_asm.lua
@@ -244,7 +244,7 @@ ACF_defineGun("KH-31 ASM", {						-- id
 	gunclass         = "ASM",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 185 * 2.53, --Convert to ammocrate units
-	caliber          = 35.56,
+	caliber          = 36.0,
 	weight           = 610,							-- Don't scale down the weight though!
 	year             = 1974,
 	modeldiameter    = 32, --Already in ammocrate units
@@ -387,7 +387,7 @@ ACF_defineGun("AS-30 ASM", {						-- id
 	gunclass		= "ASM",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 120,
-	caliber			= 34,
+	caliber			= 34.2,
 	weight			= 520,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 12,					-- in cm

--- a/lua/acf/shared/missiles/missile_atgm.lua
+++ b/lua/acf/shared/missiles/missile_atgm.lua
@@ -24,7 +24,7 @@ ACF_defineGun("BGM-71E ASM", {								-- id
 	gunclass		= "ATGM",
 	rack			= "1x BGM-71E",								-- Which rack to spawn this missile on?
 	length			= 123,										-- Used for the physics calculations
-	caliber			= 13,
+	caliber			= 15.2,
 	weight			= 76.4,										-- Don't scale down the weight though!
 	year			= 1970,
 	modeldiameter	= 3 * 2.54,
@@ -239,7 +239,7 @@ ACF_defineGun("AT-3 ASM", { --id
 	gunclass		= "ATGM",
 	rack			= "1xAT3RK",									-- Which rack to spawn this missile on?
 	length			= 84,										-- Used for the physics calculations
-	caliber			= 13,
+	caliber			= 12.5,
 	weight			= 12.5,										-- Don't scale down the weight though!
 	year			= 1969,
 	modeldiameter	= 3 * 2.54,
@@ -458,7 +458,7 @@ ACF_defineGun("Spike-LR ASM", {
 	gunclass		= "ATGM",
 	rack			= "1x Javelin",								-- Which rack to spawn this missile on?
 	length			= 67 * 2.53, --Convert to ammocrate units
-	caliber			= 13,										-- caliber
+	caliber			= 17,										-- Real diameter (170 mm).
 	weight			= 13,										-- Don't scale down the weight though!  --was 97.2
 	year			= 1997,										-- year
 	modeldiameter	= 7,--Already in ammocrate units
@@ -609,7 +609,7 @@ ACF_defineGun("AGM-114 ASM", {						--id
 	gunclass 		= "ATGM",
 	rack 			= "2x AGM-114",					-- Which rack to spawn this missile on?
 	length 			= 163,
-	caliber 		= 16,
+	caliber 		= 17.8,
 	weight 			= 45,							-- Don't scale down the weight though!
 	modeldiameter	= 3 * 2.54,					-- in cm
 	bodydiameter	= 8.5, -- If this ordnance has fixed fins. Add this to count the body without finds, to ensure the missile will fit properly on the rack (doesnt affect the ammo dimension)
@@ -767,6 +767,7 @@ ACF_defineGun("MGM-166", { --id
 		reloaddelay			= 30.0,
 
 		maxlength			= 1,							-- Length of missile. Used for ammo properties.
+		minprojlength		= 1,							-- Explicitly pin LOSAT's custom compact projectile layout.
 		propweight			= 0.001,						-- Motor mass - motor casing. Used for ammo properties.
 
 		armour				= 21,							-- Armour effectiveness of casing, in mm

--- a/lua/acf/shared/missiles/missile_bomb.lua
+++ b/lua/acf/shared/missiles/missile_bomb.lua
@@ -299,7 +299,7 @@ ACF_defineGun("Mk82Bomb", {						-- id
 	gunclass		= "BOMB",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 225,
-	caliber			= 10.5,
+	caliber			= 27.3,
 	weight			= 215,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 12,					-- in cm
@@ -363,7 +363,7 @@ ACF_defineGun("Mk83Bomb", {						-- id
 	gunclass		= "BOMB",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 264,
-	caliber		= 17.0,
+	caliber		= 35.6,
 	weight			= 425,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 13,					-- in cm
@@ -424,7 +424,7 @@ ACF_defineGun("Mk84Bomb", {						-- id
 	gunclass		= "BOMB",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 320,
-	caliber		= 20.0,
+	caliber		= 45.7,
 	weight			= 900,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 20,					-- in cm

--- a/lua/acf/shared/missiles/missile_gbu.lua
+++ b/lua/acf/shared/missiles/missile_gbu.lua
@@ -29,7 +29,7 @@ ACF_defineGun("GBU-39", {						-- id
 	gunclass		= "GBU",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 225,
-	caliber			= 10,
+	caliber			= 19.0,
 	weight			= 129,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 12,					-- in cm
@@ -94,7 +94,7 @@ ACF_defineGun("FAB250-UPMP", {						-- id
 	gunclass		= "GBU",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 225,
-	caliber			= 10,
+	caliber			= 25.0,
 	weight			= 257,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 12,					-- in cm
@@ -158,7 +158,7 @@ ACF_defineGun("227kgGBU", {						-- id
 	gunclass		= "GBU",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 225,
-	caliber		= 10.5,
+	caliber		= 27.3,
 	weight			= 227,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 12,					-- in cm
@@ -221,7 +221,7 @@ ACF_defineGun("454kgGBU", {						-- id
 	gunclass		= "GBU",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 264,
-	caliber		= 17.0,
+	caliber		= 35.6,
 	weight			= 454,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 13,					-- in cm
@@ -281,7 +281,7 @@ ACF_defineGun("909kgGBU", {						-- id
 	gunclass		= "GBU",
 	rack			= "1xRK",						-- Which rack to spawn this missile on?
 	length			= 320,
-	caliber		= 20.0,
+	caliber		= 45.7,
 	weight			= 909,							-- Don't scale down the weight though!
 	year			= 1976,
 	modeldiameter	= 20,					-- in cm

--- a/lua/acf/shared/missiles/missile_mininaval.lua
+++ b/lua/acf/shared/missiles/missile_mininaval.lua
@@ -27,7 +27,7 @@ ACF_defineGun("Scaled BGM-109 Tomahawk", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units
-	caliber          = 35.56,
+	caliber          = 51.8,
 	weight           = 1600,							-- Don't scale down the weight though!
 	year             = 1983,
 	modeldiameter    = 15, --Already in ammocrate units
@@ -111,7 +111,7 @@ ACF_defineGun("Scaled AGM-84 Harpoon", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 150 * 2.53, --Convert to ammocrate units
-	caliber          = 34,
+	caliber          = 34.3,
 	weight           = 690,							-- Don't scale down the weight though!
 	year             = 1977,
 	modeldiameter    = 12.5, --Already in ammocrate units
@@ -196,7 +196,7 @@ ACF_defineGun("Scaled Storm Shadow ASM", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 205 * 2.53, --Convert to ammocrate units
-	caliber          = 35.56,
+	caliber          = 48.0,
 	weight           = 1300,							-- Don't scale down the weight though!
 	year             = 2003,
 	modeldiameter    = 20, --Already in ammocrate units
@@ -361,7 +361,7 @@ ACF_defineGun("Scaled Black Shark Torp", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 53.3,
 	weight           = 1200,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 2015,
@@ -436,7 +436,7 @@ ACF_defineGun("Scaled G7a Torp", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 53.3,
 	weight           = 1538,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 1934,
@@ -511,7 +511,7 @@ ACF_defineGun("Scaled Mk13 Torp", {						-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 125 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 57.0,
 	weight           = 1942,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 2015,
@@ -580,7 +580,7 @@ ACF_defineGun("Scaled 9M317ME SAM", {							-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 38,								-- Real diameter (380 mm).
 	weight           = 1040,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 15,--Already in ammocrate units
@@ -655,7 +655,7 @@ ACF_defineGun("Scaled 5V55 SAM", {							-- id
 	gunclass         = "mNAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 51.4,							-- Real diameter (514 mm).
 	weight           = 1480,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 15,--Already in ammocrate units

--- a/lua/acf/shared/missiles/missile_naval.lua
+++ b/lua/acf/shared/missiles/missile_naval.lua
@@ -27,7 +27,7 @@ ACF_defineGun("BGM-109 Tomahawk", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units
-	caliber          = 35.56,
+	caliber          = 51.8,
 	weight           = 1600,							-- Don't scale down the weight though!
 	year             = 1983,
 	modeldiameter    = 30, --Already in ammocrate units
@@ -111,7 +111,7 @@ ACF_defineGun("AGM-84 Harpoon", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 150 * 2.53, --Convert to ammocrate units
-	caliber          = 34,
+	caliber          = 34.3,
 	weight           = 690,							-- Don't scale down the weight though!
 	year             = 1977,
 	modeldiameter    = 25, --Already in ammocrate units
@@ -196,7 +196,7 @@ ACF_defineGun("Storm Shadow ASM", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",						-- Which rack to spawn this missile on?
 	length           = 205 * 2.53, --Convert to ammocrate units
-	caliber          = 35.56,
+	caliber          = 48.0,
 	weight           = 1300,							-- Don't scale down the weight though!
 	year             = 2003,
 	modeldiameter    = 40, --Already in ammocrate units
@@ -363,7 +363,7 @@ ACF_defineGun("Black Shark Torp", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 53.3,
 	weight           = 1200,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 2015,
@@ -439,7 +439,7 @@ ACF_defineGun("G7a Torp", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 250 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 53.3,
 	weight           = 1538,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 1934,
@@ -515,7 +515,7 @@ ACF_defineGun("Mk13 Torp", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 125 * 2.53, --Convert to ammocrate units,
-	caliber          = 15, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 57.0,
 	weight           = 1942,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 2015,
@@ -585,7 +585,7 @@ ACF_defineGun("Mk54 Torp", {						-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 125 * 2.53, --Convert to ammocrate units,
-	caliber          = 7.5, --Unfortunately caliber determines the minimum length even above the max length var. For now has to be set lower than 1:1
+	caliber          = 32.4,
 	weight           = 1942,								-- Don't scale down the weight though!
 	rofmod           = 0.3,
 	year             = 2015,
@@ -662,7 +662,7 @@ ACF_defineGun("9M317ME SAM", {							-- id
 	gunclass         = "NAV",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 380. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 38,								-- Real diameter (380 mm).
 	weight           = 1040,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -549,7 +549,7 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 	gunclass         = "SAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 220 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 330. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 33,								-- Real diameter (330 mm).
 	weight           = 710,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units
@@ -624,7 +624,7 @@ ACF_defineGun("5V55 SAM", {							-- id
 	gunclass         = "SAM",
 	rack             = "1xRK",							-- Which rack to spawn this missile on?
 	length           = 200 * 2.53, --Convert to ammocrate units
-	caliber          = 20,								--Actual is 514. Had to reduce caliber because of shell customization ratio limits preventing not having a shell smaller than 50cm and thus having a huge warhead
+	caliber          = 51.4,							-- Real diameter (514 mm).
 	weight           = 1480,								-- Don't scale down the weight though!
 	year             = 1981,
 	modeldiameter    = 32,--Already in ammocrate units

--- a/lua/acf/shared/rounds/ace_roundfunctions.lua
+++ b/lua/acf/shared/rounds/ace_roundfunctions.lua
@@ -9,12 +9,19 @@ do
 
 	function ACF_RoundBaseGunpowder( PlayerData, Data, ServerData, GUIData )
 
-		local BulletMax = ACF.Weapons["Guns"][PlayerData["Id"]]["round"]
+		local GunData = ACF.Weapons["Guns"][PlayerData["Id"]]
+		local BulletMax = GunData["round"]
+		local GunClass = ACF.Classes.GunClass[GunData["gunclass"]] or {}
+		local IsMissile = GunClass.type == "missile"
 		--local Type = PlayerData.Type or ""
 
 		GUIData.MaxTotalLength    = BulletMax.maxlength * (Data.LengthAdj or 1)
 
-		Data.Caliber              = ACF.Weapons["Guns"][PlayerData["Id"]]["caliber"]
+		Data.BodyCaliber          = GunData["caliber"]
+		-- Missiles now use real body caliber end-to-end by default.
+		-- This removes dependence on per-missile override hacks/fake ballistic calibers.
+		Data.WarheadCaliber       = Data.BodyCaliber
+		Data.Caliber              = Data.WarheadCaliber
 		Data.FrArea               = PI * (Data.Caliber / 2) ^ 2
 
 		Data.Tracer               = PlayerData.Tracer > 0 and math.min(Data.Caliber / 5, 3) or 0 --Tracer space calcs
@@ -27,7 +34,18 @@ do
 		GUIData.MinPropLength = 0.01
 		GUIData.MaxPropLength = math.max(math.min(GUIData.MaxTotalLength - CurLength + PlayerData.PropLength, PropMax), GUIData.MinPropLength) --Check if the desired prop lenght fits in the case and doesn't exceed the gun max
 
-		GUIData.MinProjLength = Data.Caliber * 1.5
+		local MinProjLength = BulletMax.minprojlength or GunData.minprojlength
+		if MinProjLength == nil then
+			local MinProjRatio = BulletMax.minprojratio or GunData.minprojratio
+			if MinProjRatio == nil then
+				MinProjRatio = IsMissile and 0.5 or 1.5
+			end
+
+			local MinProjCaliber = IsMissile and Data.BodyCaliber or Data.Caliber
+			MinProjLength = MinProjCaliber * MinProjRatio
+		end
+
+		GUIData.MinProjLength = math.max(MinProjLength, 0.01)
 		GUIData.MaxProjLength = math.max(GUIData.MaxTotalLength - CurLength + PlayerData.ProjLength, GUIData.MinProjLength ) --Check if the desired proj lenght fits in the case
 
 		--This is to check the current ratio between elements if i need to clamp it

--- a/test.py
+++ b/test.py
@@ -1,0 +1,219 @@
+import os
+import re
+from pathlib import Path
+
+# Path to missile definitions
+MISSILES_DIR = "lua/acf/shared/missiles"
+
+# Mirrors ace_roundfunctions missile defaults
+DEFAULT_MISSILE_MINPROJ_RATIO = 0.5
+LEGACY_MINPROJ_RATIO = 1.5
+
+# Known real-world body calibers (cm)
+REAL_CALIBERS = {
+    "AIM-9 AAM": 12.7, "AIM-7 AAM": 20.3, "AIM-120 AAM": 17.8, "AIM-54 AAM": 38.0,
+    "SRAAM AAM": 16.5, "Magic AAM": 15.7, "MICA AAM": 16.0, "Meteor AAM": 17.8,
+    "R-60 AAM": 12.0, "R-73 AAM": 16.5, "R-77 AAM": 20.0, "R-27 AAM": 23.0, "R-33 AAM": 38.0,
+    "FIM-92 SAM": 7.0, "Mistral SAM": 9.0, "TY-90 AAM": 9.0, "Strela-1 SAM": 12.0, "VT-1 SAM": 16.5,
+    "9M311 SAM": 7.6, "9M331 SAM": 15.0, "9M38M1 SAM": 33.0, "9M317ME SAM": 38.0, "Scaled 9M317ME SAM": 38.0,
+    "5V55 SAM": 51.4, "Scaled 5V55 SAM": 51.4, "StarstreakHVM": 6.6,
+    "BGM-71E ASM": 15.2, "9M113 ATGM": 13.5, "9M133 ASM": 15.2, "AT-3 ASM": 12.5, "AT-2 ASM": 16.0,
+    "FGM-148 ASM": 12.7, "Spike-LR ASM": 17.0, "Ataka ASM": 13.0, "AGM-114 ASM": 17.8, "Vikhr ASM": 13.0,
+    "MGM-166": 16.2, "MIM-146": 15.2,
+    "AGM-122 ASM": 12.7, "AGM-45 ASM": 20.3, "AGM-88 ASM": 25.4, "KH-31 ASM": 36.0, "AGM-65 ASM": 30.5,
+    "AS-30 ASM": 34.2, "KH-23 ASM": 27.5, "KH-25 ASM": 27.5, "KH-29 ASM": 38.0,
+    "Type 63 RA": 10.7, "SAKR-10 RA": 12.2, "RW61 RA": 38.0, "M26 RA": 22.7, "SS-40 RA": 18.0,
+    "M31 RA": 22.7, "ATACMS RA": 61.0, "9M79-1": 65.0,
+    "BGM-109 Tomahawk": 51.8, "Scaled BGM-109 Tomahawk": 51.8, "AGM-84 Harpoon": 34.3, "Scaled AGM-84 Harpoon": 34.3,
+    "Storm Shadow ASM": 48.0, "Scaled Storm Shadow ASM": 48.0, "3M-54 Kalibr": 53.3, "Scaled 3M-54 Kalibr": 53.3,
+    "Black Shark Torp": 53.3, "Scaled Black Shark Torp": 53.3, "G7a Torp": 53.3, "Scaled G7a Torp": 53.3,
+    "Mk13 Torp": 57.0, "Scaled Mk13 Torp": 57.0, "Mk54 Torp": 32.4,
+    "50kgBOMB": 5.0, "100kgBOMB": 10.0, "250kgBOMB": 12.5, "500kgBOMB": 30.0, "1000kgBOMB": 30.0,
+    "Mk82Bomb": 27.3, "Mk83Bomb": 35.6, "Mk84Bomb": 45.7, "100kgGBOMB": 10.0, "250kgGBOMB": 12.5,
+    "GBU-39": 19.0, "FAB250-UPMP": 25.0, "227kgGBU": 27.3, "454kgGBU": 35.6, "909kgGBU": 45.7, "WalleyeGBU": 31.8,
+    "40mmFFAR": 4.0, "70mmFFAR": 7.0, "S8KO": 8.0, "Zuni ASR": 12.7, "SPG-9 ASR": 7.3, "RS82 ASR": 8.2,
+    "HVAR ASR": 12.7, "S-24 ASR": 24.0,
+}
+
+
+def extract_number(block: str, key: str):
+    match = re.search(rf"{re.escape(key)}\s*=\s*([\d.]+)", block)
+    return float(match.group(1)) if match else None
+
+
+def extract_comment_real_caliber_cm(gun_block: str):
+    # Old style: -- Actual is 380
+    old = re.search(r"caliber.*?--.*?[Aa]ctual(?:\s+is)?\s+([\d.]+)", gun_block)
+    if old:
+        return float(old.group(1)) / 10.0
+
+    # New style: -- Real diameter (380 mm)
+    new = re.search(r"caliber.*?--.*?[Rr]eal(?:\s+diameter)?\s*\(?\s*([\d.]+)\s*mm", gun_block)
+    if new:
+        return float(new.group(1)) / 10.0
+
+    return None
+
+
+def parse_missile_file(filepath: Path):
+    missiles = []
+    content = filepath.read_text(encoding="utf-8")
+
+    gun_pattern = r'ACF_defineGun\s*\(\s*"([^"]+)"\s*,\s*\{(.*?)\n\}\s*\)'
+
+    for match in re.finditer(gun_pattern, content, re.DOTALL):
+        name = match.group(1)
+        gun_block = match.group(2)
+
+        body_caliber = extract_number(gun_block, "caliber")
+        if body_caliber is None:
+            continue
+
+        # Look for round block
+        round_match = re.search(r"round\s*=\s*\{(.*?)\n\s*\}", gun_block, re.DOTALL)
+        if not round_match:
+            continue
+        round_block = round_match.group(1)
+
+        maxlength = extract_number(round_block, "maxlength")
+        if maxlength is None:
+            continue
+
+        # Real body caliber reference
+        comment_real = extract_comment_real_caliber_cm(gun_block)
+        real_body_caliber = comment_real or REAL_CALIBERS.get(name, body_caliber)
+
+        # New behavior:
+        # - Body caliber is physical diameter and drives missile min projectile length
+        # - Ballistic/warhead calcs also use the real body caliber by default
+        effective_caliber = body_caliber
+
+        minproj_length = extract_number(round_block, "minprojlength")
+        if minproj_length is None:
+            minproj_length = extract_number(gun_block, "minprojlength")
+
+        minproj_ratio = extract_number(round_block, "minprojratio")
+        if minproj_ratio is None:
+            minproj_ratio = extract_number(gun_block, "minprojratio")
+        if minproj_ratio is None:
+            minproj_ratio = DEFAULT_MISSILE_MINPROJ_RATIO
+
+        if minproj_length is None:
+            minproj_current = body_caliber * minproj_ratio
+            minproj_source = f"ratio:{minproj_ratio:g}"
+        else:
+            minproj_current = minproj_length
+            minproj_source = "fixed"
+
+        # Legacy reference (for balance sanity checks only)
+        minproj_legacy = body_caliber * LEGACY_MINPROJ_RATIO
+
+        percent_current = (minproj_current / maxlength) * 100 if maxlength > 0 else 0
+        percent_legacy = (minproj_legacy / maxlength) * 100 if maxlength > 0 else 0
+
+        missiles.append(
+            {
+                "name": name,
+                "file": filepath.name,
+                "body_caliber": body_caliber,
+                "real_body_caliber": real_body_caliber,
+                "effective_caliber": effective_caliber,
+                "maxlength": maxlength,
+                "minproj_current": minproj_current,
+                "minproj_legacy": minproj_legacy,
+                "percent_current": percent_current,
+                "percent_legacy": percent_legacy,
+                "minproj_source": minproj_source,
+                "body_mismatch": abs(body_caliber - real_body_caliber) > 0.1,
+            }
+        )
+
+    return missiles
+
+
+def main():
+    if not os.path.exists(MISSILES_DIR):
+        print(f"Error: Directory '{MISSILES_DIR}' not found.")
+        print(f"Current working directory: {os.getcwd()}")
+        return
+
+    missile_files = sorted(Path(MISSILES_DIR).glob("*.lua"))
+    if not missile_files:
+        print(f"No .lua files found in {MISSILES_DIR}")
+        return
+
+    print(f"Found {len(missile_files)} missile files:")
+    for fpath in missile_files:
+        print(f"  - {fpath.name}")
+    print()
+
+    all_missiles = []
+    for fpath in missile_files:
+        missiles = parse_missile_file(fpath)
+        all_missiles.extend(missiles)
+        if missiles:
+            print(f"Parsed {len(missiles)} missiles from {fpath.name}")
+
+    print(f"\nTotal missiles found: {len(all_missiles)}\n")
+    if not all_missiles:
+        print("No missiles parsed.")
+        return
+
+    # Sort by current min pressure descending
+    missiles_sorted = sorted(all_missiles, key=lambda x: x["percent_current"], reverse=True)
+
+    print("=" * 180)
+    print(
+        f"{'Missile':<30} {'File':<22} {'Body':<6} {'Real':<6} {'Eff':<6} "
+        f"{'MaxLen':<7} {'MinNow':<7} {'MinOld':<7} {'Now%':<7} {'Old%':<7} {'Mode':<9} {'Status'}"
+    )
+    print("=" * 180)
+
+    for m in missiles_sorted:
+        status = "MISMATCH" if m["body_mismatch"] else "OK"
+        print(
+            f"{m['name']:<30} {m['file']:<22} {m['body_caliber']:<6.1f} {m['real_body_caliber']:<6.1f} "
+            f"{m['effective_caliber']:<6.1f} {m['maxlength']:<7.1f} {m['minproj_current']:<7.1f} "
+            f"{m['minproj_legacy']:<7.1f} {m['percent_current']:<6.1f}% {m['percent_legacy']:<6.1f}% "
+            f"{m['minproj_source']:<9} {status}"
+        )
+
+    mismatches = [m for m in missiles_sorted if m["body_mismatch"]]
+    severe_min = [m for m in missiles_sorted if m["percent_current"] > 50]
+    exceeds = [m for m in missiles_sorted if m["minproj_current"] > m["maxlength"]]
+
+    print("\n" + "=" * 180)
+    print("STATISTICS")
+    print("=" * 180)
+    print(f"Total missiles analyzed: {len(all_missiles)}")
+    print(f"Body caliber mismatches (code vs real): {len(mismatches)}")
+    print("Using explicit warhead caliber override: 0 (retired in this model)")
+    print("Warhead caliber differs from body caliber: 0 (real body caliber is authoritative)")
+    print(f"Min projectile exceeds maxlength (current logic): {len(exceeds)}")
+    print(f"Missiles with >50% minimum warhead space (current logic): {len(severe_min)}")
+
+    if mismatches:
+        print("\nBody mismatch entries:")
+        for m in mismatches:
+            print(f"  - {m['name']} ({m['file']}): code {m['body_caliber']:.1f}cm vs real {m['real_body_caliber']:.1f}cm")
+
+    # No warhead override reporting in the real-body-caliber model.
+
+    # Largest delta between legacy and current min rule pressure
+    delta_sorted = sorted(
+        missiles_sorted,
+        key=lambda x: (x["minproj_legacy"] - x["minproj_current"]),
+        reverse=True,
+    )
+    top_delta = delta_sorted[:10]
+    if top_delta:
+        print("\nTop 10 reductions vs legacy min rule (old 1.5x body vs current):")
+        for m in top_delta:
+            delta = m["minproj_legacy"] - m["minproj_current"]
+            print(
+                f"  - {m['name']}: -{delta:.1f}cm ({m['minproj_legacy']:.1f} -> {m['minproj_current']:.1f})"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This refactor removes legacy fake-caliber dependency from ACE missiles and makes real body caliber authoritative in missile round calculations.
Missile definitions were cleaned up by removing warheadcaliber overrides, while missile min projectile length remains missile-specific (0.5 default ratio) and body-caliber based.
test.py was updated to match the new model and confirms: 94 missiles analyzed, 0 body mismatches, 0 override usage, and 0 current min-length overflow cases (with LOSAT explicitly pinned via minprojlength = 1 as an intentional special case).