### PR TITLE
ACE points/cost cleanup: armor detail stability, popup accuracy, and targeted tuning

### DIFF
--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -564,11 +564,24 @@ end
 -- Armor dirty wrapper
 -- ------------------------------------------------------------
 
+local ArmorDirtyReasonPolicy = {
+	rempts = false,
+	setmass = true,
+	["addpts-existing"] = true,
+	["addpts-new"] = true
+}
+
 -- Mark armor as dirty and capture context.
 function ACE_MarkArmorDirty(con, ent, reason)
 	if not con then return end
 	if ACE_ShouldIgnoreDirty(con) then return end
 	if ACE_ShouldIgnoreDirtyEnt(ent) then return end
+
+	local policy = ArmorDirtyReasonPolicy[reason]
+	if policy == false then
+		ACE_DebugDirty(con, "skip-reason:" .. tostring(reason), ent, nil, "MarkDirty")
+		return
+	end
 
 	local cls = IsEnt(ent) and ent:GetClass() or ""
 	if cls == "primitive_shape" and not ent.ACEArmorDirtySeen then

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -183,7 +183,12 @@ local function ACE_CalcNonAmmoSubsystem(ents, subsystem, minDetailPts)
 			local cls = ent:GetClass()
 			local eclass = ACE_GetPtsType(cls)
 			if eclass == subsystem then
-				local pts = ACE_GetEntPoints(ent)
+				local pts
+				if subsystem == "Crew" then
+					pts = tonumber(ACE.CrewSeatCostFlat) or 250
+				else
+					pts = ACE_GetEntPoints(ent)
+				end
 				if pts ~= 0 then
 					total = total + pts
 					ACE_AddDetailItem(
@@ -222,9 +227,6 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 	local calMm = ACE_GetAmmoCaliberMm(bdata)
 	if calMm <= 0 then return 0 end
 
-	local typeFactor = ACE_GetAmmoTypeFactor(bdata.Type)
-	if typeFactor <= 0 then return 0 end
-
 	local ammoId = bdata.Id
 	if not ammoId then return 0 end
 
@@ -239,30 +241,13 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 	if rpsTotal <= 0 then return 0 end
 
 	local cfg = ACE.AmmoCostConfig or {}
-	local refPen = cfg.RefPen or 0
-	local refCal = cfg.RefCaliber or 0
 	local refRps = cfg.RpsRef or 0
-	local baseRound = cfg.BaseRoundPts or 0
-	if refPen <= 0 or refCal <= 0 or refRps <= 0 or baseRound <= 0 then return 0 end
+	if refRps <= 0 then return 0 end
 
-	local penExp = cfg.PenExp or 1
-	local blastExp = cfg.BlastExp or 1
-	local blastWeight = cfg.BlastWeight or 0
 	local rpsExp = cfg.RpsExp or 1
-	local refBlast = cfg.RefBlastMass or 0
-
-	local penFactor = (maxPen / refPen) ^ penExp
-	local blastFactor = 0
-	if blastMass > 0 and refBlast > 0 then
-		blastFactor = (blastMass / refBlast) ^ blastExp
-	end
-
-	local threatFactor = penFactor + blastFactor * blastWeight
-	if threatFactor <= 0 then return 0 end
-
-	local calFactor = calMm / refCal
 	local rpsFactor = (rpsTotal / refRps) ^ rpsExp
-	local roundPts = baseRound * threatFactor * calFactor * typeFactor
+	local roundPts = ACE_GetAmmoRoundPoints(bdata)
+	if roundPts <= 0 then return 0 end
 
 	local stowFactor = cfg.StowFactor or 1
 	local tailFactor = cfg.TailFactor or 0
@@ -757,7 +742,8 @@ ACE_CalcContraptionArmor = function(ent)
 	local frontU, frontV = basisFromDir(frontDir)
 	local sideU, sideV = basisFromDir(sideDir)
 
-	local regionSnap = 2
+	local scanCfg = ACE.ArmorScanConfig or {}
+	local regionSnap = scanCfg.RegionSnap or 2
 	local origin = ent:WorldSpaceCenter()
 
 	-- Build a region bucket key.
@@ -778,6 +764,40 @@ ACE_CalcContraptionArmor = function(ent)
 		end
 	end
 
+	local hullSize = scanCfg.TraceHullSize or 3
+	local TRACE_HULL_MINS = Vector(-hullSize, -hullSize, -hullSize)
+	local TRACE_HULL_MAXS = Vector(hullSize, hullSize, hullSize)
+	local TRACE_MAX_STEPS = scanCfg.TraceMaxSteps or 128
+
+	-- Calculate effective LOS armor at a trace impact point.
+	local function calcLosArmor(hitEnt, hitNormal, shotDir)
+		local acf = hitEnt.ACF
+		if not istable(acf) then return 0 end
+
+		local mat = acf.Material or "RHA"
+		local matData = ACE_GetMaterialData(mat)
+		local armor = acf.Armour or 0
+		if armor <= 0 then return 0 end
+
+		local armorData = hitEnt.acfPropArmorData and hitEnt:acfPropArmorData()
+		local effKE = (armorData and armorData.Effectiveness) or (matData and matData.effectiveness) or 1
+		local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
+			or (matData and (matData.HEATeffectiveness or matData.effectiveness))
+			or effKE
+
+		local eff = effKE * 0.8 + effCHEM * 0.2
+		local curve = (armorData and armorData.Curve) or 1
+		local ang = ACF_GetHitAngle(hitNormal, shotDir)
+
+		if ang >= 89 then
+			return (armor ^ curve) * eff
+		end
+
+		local cosAng = math.max(math.cos(math.rad(ang)), 0.01)
+		local los = (armor / (cosAng ^ ACF.SlopeEffectFactor)) ^ curve
+		return los * eff
+	end
+
 	-- Line-of-sight test with filter rules.
 	local function losFiltered(startPos, endPos, targetComp)
 		local filter = {}
@@ -785,16 +805,13 @@ ACE_CalcContraptionArmor = function(ent)
 		local dir = (endPos - startPos):GetNormalized()
 		local hitTarget = false
 
-		local hullMins = Vector(-3, -3, -3)
-		local hullMaxs = Vector(3, 3, 3)
-
-		for _ = 1, 128 do
+		for _ = 1, TRACE_MAX_STEPS do
 			-- Small hull keeps thin props from slipping through the trace.
 			local tr = util.TraceHull({
 				start = startPos,
 				endpos = endPos,
-				mins = hullMins,
-				maxs = hullMaxs,
+				mins = TRACE_HULL_MINS,
+				maxs = TRACE_HULL_MAXS,
 				filter = filter,
 				mask = MASK_SOLID
 			})
@@ -832,41 +849,9 @@ ACE_CalcContraptionArmor = function(ent)
 					filter[#filter + 1] = hitEnt
 					startPos = tr.HitPos + dir * 0.1
 				else
-					-- Defensive ACF lookup for non-ACF props and holograms.
-					local acf = hitEnt.ACF
-					if not istable(acf) then
-						filter[#filter + 1] = hitEnt
-						startPos = tr.HitPos + dir * 0.1
-					else
-						local Mat = acf.Material or "RHA"
-						local MatData = ACE_GetMaterialData(Mat)
-
-						local armor = acf.Armour or 0
-						local armorData = hitEnt.acfPropArmorData and hitEnt:acfPropArmorData()
-
-						local effKE = (armorData and armorData.Effectiveness) or (MatData and MatData.effectiveness) or 1
-						local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
-							or (MatData and (MatData.HEATeffectiveness or MatData.effectiveness))
-							or effKE
-
-						local eff = effKE * 0.8 + effCHEM * 0.2
-						local curve = (armorData and armorData.Curve) or 1
-
-						local ang = ACF_GetHitAngle(tr.HitNormal, dir)
-						local los
-						if ang >= 89 then
-							los = (armor ^ curve) * eff
-						else
-							local cosAng = math.max(math.cos(math.rad(ang)), 0.01)
-							los = (armor / (cosAng ^ ACF.SlopeEffectFactor)) ^ curve
-							los = los * eff
-						end
-
-						total = total + los
-
-						filter[#filter + 1] = hitEnt
-						startPos = tr.HitPos + dir * 0.1
-					end
+					total = total + calcLosArmor(hitEnt, tr.HitNormal, dir)
+					filter[#filter + 1] = hitEnt
+					startPos = tr.HitPos + dir * 0.1
 				end
 			end
 		end
@@ -900,6 +885,7 @@ ACE_CalcContraptionArmor = function(ent)
 	local debugMaxLOS = 0
 
 	local frontRegions, sideRegions = {}, {}
+	local compContrib = {}
 
 	for _, comp in ipairs(criticals) do
 		local center = comp:WorldSpaceCenter()
@@ -930,6 +916,8 @@ ACE_CalcContraptionArmor = function(ent)
 		local sampleCount = #samples
 		local weightF = (sampleCount > 0) and (frontArea / sampleCount) or 0
 		local weightS = (sampleCount > 0) and (sideArea / sampleCount) or 0
+		local compFrontWeight = 0
+		local compSideWeight = 0
 
 		for _, pt in ipairs(samples) do
 			local frontVal = losFiltered(pt - frontDir * frontDist, pt, comp)
@@ -955,10 +943,20 @@ ACE_CalcContraptionArmor = function(ent)
 
 			if frontVal > 0 then
 				updateRegion(frontRegions, regionKey(pt, frontU, frontV), frontVal, weightF)
+				compFrontWeight = compFrontWeight + frontVal * weightF
 			end
 			if sideVal > 0 then
 				updateRegion(sideRegions, regionKey(pt, sideU, sideV), sideVal, weightS)
+				compSideWeight = compSideWeight + sideVal * weightS
 			end
+		end
+
+		local compWeight = compFrontWeight + compSideWeight * 2
+		if compWeight > 0 then
+			compContrib[#compContrib + 1] = {
+				Ent = comp,
+				Weight = compWeight
+			}
 		end
 	end
 
@@ -988,8 +986,93 @@ ACE_CalcContraptionArmor = function(ent)
 		countSide = countSide + e.weight
 	end
 
-	return (countFront > 0 and (accumFront / countFront) or 0),
-		   (countSide  > 0 and (accumSide  / countSide)  or 0)
+	local frontAvg = countFront > 0 and (accumFront / countFront) or 0
+	local sideAvg = countSide > 0 and (accumSide / countSide) or 0
+
+	local quantStep = scanCfg.ResultQuantizeMm or 0
+	if quantStep > 0 then
+		frontAvg = math.Round(frontAvg / quantStep) * quantStep
+		sideAvg = math.Round(sideAvg / quantStep) * quantStep
+	end
+
+	local totalArmorPts = ACE_CalcArmorPoints(frontAvg, sideAvg)
+
+	-- Build per-entity armor detail weights.
+	-- Prefer trace-derived armor entities if available; otherwise fallback to armor prop projected area weighting.
+	local detailWeights = {}
+	local detailWeightTotal = 0
+	for _, row in ipairs(compContrib) do
+		local comp = row.Ent
+		if IsEnt(comp) then
+			local cls = comp:GetClass()
+			if ACE.ArmorClasses and ACE.ArmorClasses[cls] then
+				local w = tonumber(row.Weight) or 0
+				if w > 0 then
+					detailWeights[#detailWeights + 1] = { Ent = comp, Weight = w }
+					detailWeightTotal = detailWeightTotal + w
+				end
+			end
+		end
+	end
+
+	if detailWeightTotal <= 0 then
+		for _, ent in ipairs(contraptionEnts) do
+			if IsEnt(ent) then
+				local cls = ent:GetClass()
+				if ACE.ArmorClasses and ACE.ArmorClasses[cls] then
+					local w = projectedData(ent, frontDir) + projectedData(ent, sideDir) * 2
+					if w > 0 then
+						detailWeights[#detailWeights + 1] = { Ent = ent, Weight = w }
+						detailWeightTotal = detailWeightTotal + w
+					end
+				end
+			end
+		end
+	end
+
+	local armorDetails = {}
+	if totalArmorPts > 0 and detailWeightTotal > 0 then
+		for _, row in ipairs(detailWeights) do
+			local comp = row.Ent
+			if IsEnt(comp) then
+				local pts = totalArmorPts * (row.Weight / detailWeightTotal)
+				local label = ACE_FormatDetailLabel(comp)
+				armorDetails[#armorDetails + 1] = {
+					Label = label,
+					RawPoints = pts,
+					Points = ACE_SafeRound1(pts),
+					EntIndex = comp:EntIndex()
+				}
+			end
+		end
+	end
+
+	table.sort(armorDetails, function(a, b)
+		if a.Points == b.Points then
+			if a.EntIndex == b.EntIndex then return tostring(a.Label) < tostring(b.Label) end
+			return a.EntIndex < b.EntIndex
+		end
+		return a.Points > b.Points
+	end)
+
+	-- Keep detail sum aligned with displayed armor total after rounding.
+	if #armorDetails > 0 then
+		local detailTotal = 0
+		for _, entry in ipairs(armorDetails) do
+			detailTotal = detailTotal + (entry.Points or 0)
+		end
+
+		local correction = ACE_SafeRound1(totalArmorPts - detailTotal)
+		if correction ~= 0 then
+			armorDetails[1].Points = ACE_SafeNonNegative((armorDetails[1].Points or 0) + correction)
+		end
+
+		for _, entry in ipairs(armorDetails) do
+			entry.RawPoints = nil
+		end
+	end
+
+	return frontAvg, sideAvg, armorDetails
 end
 
 
@@ -998,28 +1081,33 @@ function ACE_EnsureArmor(con, baseEnt, force)
 	if not con then return end
 
 	local cacheStale = ACE_EnsureCacheVersion and ACE_EnsureCacheVersion(con) or false
-	if not force and not con.ACEArmorDirty and not cacheStale then return end
+	local needsInit = not con.ACEArmorCalculated or (con.ACEArmorLastCalc or 0) <= 0
+	if not force and not needsInit and not con.ACEArmorDirty and not cacheStale then return end
 
 	local base = baseEnt
 	if (not IsEnt(base)) and con.GetACEBaseplate then base = con:GetACEBaseplate() end
 
 	local front, side = 0, 0
+	local armorDetails = con.ACEArmorDetails or {}
 	local usedCache = false
 
 	local cacheKey = con.ACEArmorCacheKey
+	local cached = con.ACEArmorCachedData
 	if ACE_DebugCache then
 		local info = string.format("key=%s cached=%s", tostring(cacheKey or "nil"), tostring(cached ~= nil))
 		ACE_DebugCache(con, "ensure-cache", base, info, "EnsureArmor")
 	end
-
-	local cached = con.ACEArmorCachedData
 	if cached then
 		front = cached.Front or cached.front or 0
 		side = cached.Side or cached.side or 0
+		local cachedDetails = cached.Details or cached.details
+		local cacheVersion = cached.Version or cached.version or 1
+		local expectedVersion = ACE.ArmorCacheVersion or 1
 
-		if ACE_IsValidArmorResult(front, side) then
+		if cacheVersion == expectedVersion and ACE_IsValidArmorResult(front, side) and ACE_IsValidArmorDetails(cachedDetails) then
 			con.ACEArmorFront = front
 			con.ACEArmorSide = side
+			armorDetails = cachedDetails or armorDetails
 			usedCache = true
 		else
 			front, side = 0, 0
@@ -1028,7 +1116,7 @@ function ACE_EnsureArmor(con, baseEnt, force)
 	end
 
 	if not usedCache and IsEnt(base) then
-		front, side = ACE_CalcContraptionArmor(base)
+		front, side, armorDetails = ACE_CalcContraptionArmor(base)
 		con.ACEArmorFront = front
 		con.ACEArmorSide = side
 	end
@@ -1037,12 +1125,13 @@ function ACE_EnsureArmor(con, baseEnt, force)
 		ACE_RebuildNonArmorPoints(con, base)
 	end
 
-	local newArmorPts = (front + side * 2) * 4
+	local newArmorPts = ACE_CalcArmorPoints(front, side)
 
 	con.ACEPointsPerType = con.ACEPointsPerType or {}
 	con.ACEPointsPerType.Armor = newArmorPts
 
 	con.ACEArmorPoints = newArmorPts
+	con.ACEArmorDetails = armorDetails or {}
 	con.ACEArmorDirty = false
 	con.ACEArmorCalculated = true
 	con.ACEArmorLastCalc = CurTime()
@@ -1056,7 +1145,12 @@ function ACE_EnsureArmor(con, baseEnt, force)
 	local cacheKey = con.ACEArmorCacheKey
 	if cacheKey and not usedCache and ACE_IsValidArmorResult(front, side) then
 		ACE.DupeArmorCache = ACE.DupeArmorCache or {}
-		ACE.DupeArmorCache[cacheKey] = { Front = front, Side = side }
+		ACE.DupeArmorCache[cacheKey] = {
+			Version = ACE.ArmorCacheVersion or 1,
+			Front = front,
+			Side = side,
+			Details = armorDetails
+		}
 		if ACE_DebugCache then
 			local info = string.format("write key=%s", tostring(cacheKey))
 			ACE_DebugCache(con, "cache-write", base, info, "EnsureArmor")

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -806,6 +806,66 @@ function ACE_IsValidArmorResult(front, side)
 	return true
 end
 
+-- Convert front/side scan values to armor points.
+function ACE_CalcArmorPoints(front, side)
+	front = tonumber(front) or 0
+	side = tonumber(side) or 0
+	return (front + side * 2) * 4
+end
+
+-- Validate cached armor detail list structure.
+function ACE_IsValidArmorDetails(details)
+	if details == nil then return true end
+	if not istable(details) then return false end
+
+	for _, row in ipairs(details) do
+		if not istable(row) then return false end
+		if not isnumber(row.Points) then return false end
+	end
+
+	return true
+end
+
+-- Safe helpers for point/readout math.
+function ACE_SafeNonNegative(value)
+	value = tonumber(value) or 0
+	if value ~= value or value == math.huge or value == -math.huge then return 0 end
+	return math.max(value, 0)
+end
+
+function ACE_SafeRatio(numerator, denominator)
+	numerator = tonumber(numerator) or 0
+	denominator = tonumber(denominator) or 0
+	if denominator <= 0 then return 0 end
+	local value = numerator / denominator
+	if value ~= value or value == math.huge or value == -math.huge then return 0 end
+	return value
+end
+
+function ACE_SafeRound1(value)
+	return math.Round(ACE_SafeNonNegative(value), 1)
+end
+
+function ACE_FormatDetailLabel(ent)
+	if not ACE_IsEnt(ent) then return "Unknown" end
+
+	local name = ""
+	if ent.GetNWString then
+		name = ent:GetNWString("WireName", "")
+	end
+	if name == "" and ent.GetName then
+		name = ent:GetName() or ""
+	end
+	if name == "" and ent.PrintName and ent.PrintName ~= "" then
+		name = ent.PrintName
+	end
+	if name == "" then
+		name = ent:GetClass() or "unknown"
+	end
+
+	return string.format("%s [#%d]", name, ent:EntIndex())
+end
+
 -- Resolve the ammo type multiplier for cost/points.
 function ACE_GetAmmoTypeFactor(ammoType)
 	local factors = ACE.AmmoTypeFactors
@@ -877,6 +937,11 @@ function ACE_GetAmmoRoundPoints(bdata)
 	local threatFactor = penFactor + blastFactor * blastWeight + utilFactor
 	if threatFactor <= 0 then return 0 end
 
+	local threatExp = cfg.ThreatExp or 1
+	if threatExp > 0 and threatExp ~= 1 then
+		threatFactor = threatFactor ^ threatExp
+	end
+
 	local calFactor = calMm / refCal
 
 	return baseRound * threatFactor * calFactor * typeFactor
@@ -915,7 +980,13 @@ function ACE_GetAmmoThreatWeight(bdata)
 		end
 	end
 
-	return penFactor + blastFactor * blastWeight + utilFactor
+	local threatFactor = penFactor + blastFactor * blastWeight + utilFactor
+	local threatExp = cfg.ThreatExp or 1
+	if threatExp > 0 and threatExp ~= 1 then
+		threatFactor = threatFactor ^ threatExp
+	end
+
+	return threatFactor
 end
 
 -- Compute sustained rounds per second for a gun/rack.
@@ -1084,7 +1155,11 @@ function ACE_BuildAmmoReadyAlloc(ents)
 
 				table.sort(entries, function(a, b)
 					if a.frac == b.frac then
-						if a.rounds == b.rounds then return tostring(a.ent) < tostring(b.ent) end
+						if a.rounds == b.rounds then
+							local aIdx = IsValid(a.ent) and a.ent:EntIndex() or 0
+							local bIdx = IsValid(b.ent) and b.ent:EntIndex() or 0
+							return aIdx < bIdx
+						end
 						return a.rounds < b.rounds
 					end
 					return a.frac > b.frac
@@ -1535,6 +1610,42 @@ function ACE_GetEntLegacyCost(ent, massOverride)
 	local points = ent.ACEPoints or 0
 	if points ~= 0 then return points end
 
+	local class = ent:GetClass()
+	local acf = ent.ACF or {}
+
+	-- Armor props: derive manufacturing cost from raw thickness (mm), then apply ductility scalar.
+	if ACE.ArmorClasses and ACE.ArmorClasses[class] then
+		local mat = acf.Material or "RHA"
+		local matData = ACE_GetMaterialData and ACE_GetMaterialData(mat)
+		local armorData = ent.acfPropArmorData and ent:acfPropArmorData()
+		local armorMod = ACF.ArmorMod or 1
+		local armorMm = tonumber(acf.MaxArmour or acf.Armour) or 0
+		local curve = (armorData and armorData.Curve) or 1
+
+		-- Match point-scan weighting: KE 80% + CHEM 20% effectiveness.
+		local effKE = (armorData and armorData.Effectiveness) or (matData and matData.effectiveness) or 1
+		local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
+			or (matData and (matData.HEATeffectiveness or matData.effectiveness))
+			or effKE
+		local weightedEff = effKE * 0.8 + effCHEM * 0.2
+
+		local effectiveMm = 0
+		if armorMm > 0 then
+			effectiveMm = (armorMm ^ curve) * weightedEff
+		end
+
+		local rawMm = 0
+		if effectiveMm > 0 and armorMod > 0 then
+			rawMm = effectiveMm / armorMod
+		end
+
+		local duct = math.Clamp(tonumber(acf.Ductility) or 0, -0.8, 0.8)
+		local ductilityCostMul = 1 + duct * 0.125 -- -80 => 0.9x, +80 => 1.1x
+		local perMm = ACE.LegacyRawMmCostPerProp or 1
+
+		return math.max(rawMm * perMm * ductilityCostMul, 0)
+	end
+
 	local mass = massOverride
 	if mass == nil then
 		local phys = ent:GetPhysicsObject()
@@ -1596,7 +1707,8 @@ end
 -- Run the armor scan for a contraption.
 function ACE_GetArmorScan(ent)
 	if not ACE_CalcContraptionArmor then return 0, 0 end
-	return ACE_CalcContraptionArmor(ent)
+	local front, side = ACE_CalcContraptionArmor(ent)
+	return front, side
 end
 
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -178,10 +178,10 @@ ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
     RHA = 1
 }
 ACE.AmmoCostConfig = {
-    BaseRoundPts = 120, -- Base points per round before scaling.
+    BaseRoundPts = 200, -- Base points per round before scaling.
     RefPen = 720, -- Reference penetration (mm) for pen scaling.
     RefCaliber = 100, -- Reference caliber (mm) for caliber scaling.
-    PenExp = 1.6, -- Penetration curve exponent.
+    PenExp = 1.4, -- Penetration curve exponent.
     RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
     BlastExp = 1.1, -- Blast curve exponent.
     BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
@@ -627,6 +627,7 @@ AddCSLuaFile("autorun/acf_missile/folder.lua")
 include("autorun/acf_missile/folder.lua")
 
 print("[ACE | INFO]- Done!")
+
 
 
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -143,7 +143,7 @@ ACE.AmmoPerTon     = 100 --Point cost per ton of ammo
 ACE.AmmoTypeFactors = {
     AP = 0.5,
     APHE = 0.6,
-    APDS = 0.9,
+    APDS = 1.0,
     APFSDS = 1.2,
     HVAP = 0.7,
     HEAT = 0.75,
@@ -151,8 +151,8 @@ ACE.AmmoTypeFactors = {
     THEAT = 0.95,
     THEATFS = 1.0,
     HESH = 0.4,
-    HE = 1.2,
-    HEFS = 1.3,
+    HE = 0.66,
+    HEFS = 0.715,
     HP = 0.1,
     CAP = 0.6,
     CHEAT = 0.8,
@@ -178,17 +178,17 @@ ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
     RHA = 1
 }
 ACE.AmmoCostConfig = {
-    BaseRoundPts = 200, -- Base points per round before scaling.
+    BaseRoundPts = 120, -- Base points per round before scaling.
     RefPen = 720, -- Reference penetration (mm) for pen scaling.
     RefCaliber = 100, -- Reference caliber (mm) for caliber scaling.
     PenExp = 1.4, -- Penetration curve exponent.
     RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
     BlastExp = 1.1, -- Blast curve exponent.
     BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
-    HeUtilWeight = 1.5, -- HE utility weight from filler mass per caliber.
+    HeUtilWeight = 1.3, -- HE utility weight from filler mass per caliber.
     HeUtilExp = 0.5, -- HE utility exponent for filler per caliber.
     RpsRef = 1 / 7, -- Reference rounds per second for ROF scaling.
-    RpsExp = 0.5, -- ROF curve exponent.
+    RpsExp = 0.825, -- ROF curve exponent (+10%).
     ReadyRackBase = 3000, -- Ready rack baseline: base / caliber(mm).
     ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
     ReadyRackLowBoost = 1.5, -- Low-caliber boost (20mm hits 300 at base 3000).
@@ -197,9 +197,45 @@ ACE.AmmoCostConfig = {
     TailStartMultiplier = 2 -- Tail start = readyCap * multiplier.
 }
 
+-- ATGM rack/ammo pricing blend.
+-- Performance uses the same ammo threat model as guns; legacy keeps continuity with existing per-missile pointcost.
+ACE.ATGMCostConfig = {
+    PerformanceMul = 1.0, -- Multiplier for performance-derived base points.
+    LegacyWeight = 0.2, -- 0 = pure performance, 1 = pure legacy pointcost.
+    MinBase = 1 -- Safety floor before guidance multiplier.
+}
+
+-- Guidance multipliers applied on top of missile base cost.
+ACE.MissileGuidanceFactors = {
+    Dumb = 0.3,
+    Straight_Running = 0.45,
+    GPS = 0.6,
+    Antimissile = 0.6,
+    AntiRadiation = 0.7,
+    Beam_Riding = 0.7,
+    GPS_TerrainAvoidant = 0.8,
+    SACLOS = 0.75,
+    Semiactive = 0.85,
+    Wire = 1.0,
+    Acoustic_Straight = 1.0,
+    Acoustic_Helical = 1.0,
+    Laser = 1.2,
+    Infrared = 1.2,
+    Top_Attack_IR = 1.5,
+    Radar = 1.5
+}
+
 -- Armor tool UX timing.
 ACE.ArmorPreviewTapWindow = ACE.ArmorPreviewTapWindow or 0.35 -- Seconds between reload taps to trigger preview.
 ACE.ArmorPreviewCooldown = ACE.ArmorPreviewCooldown or 5 -- Seconds between preview requests per player.
+
+-- Armor scan tuning values for LOS trace consistency.
+ACE.ArmorScanConfig = ACE.ArmorScanConfig or {
+    RegionSnap = 2,
+    TraceHullSize = 3,
+    TraceMaxSteps = 128,
+    ResultQuantizeMm = 1.0 -- Quantize scan outputs to reduce tiny trace jitter.
+}
 
 ---------------------------------- Misc & other ----------------------------------
 
@@ -402,7 +438,7 @@ elseif CLIENT then
     CreateClientConVar( "acf_sens_scopes", 0.2, true, false, "Reduce mouse sensitivity by this amount when zoomed in with scopes on ACE SWEPs.", 0.01, 1)
     CreateClientConVar( "acf_tinnitus", 1, true, false, "Allows the ear tinnitus effect to be applied when an explosive was detonated too close to your position, improving the inmersion during combat.", 0, 1 )
     CreateClientConVar( "acf_sound_volume", 100, true, false, "Adjusts the volume of explosions and gunshots.", 0, 100 )
-    CreateClientConVar( "acf_armor_readout_full", 1, true, false, "Show full armor readout in the ACF armor tool.", 0, 1 )
+    CreateClientConVar( "acf_armor_readout_full", 0, true, false, "Show full armor readout in the ACF armor tool.", 0, 1 )
 
 end
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -1293,32 +1293,53 @@ function ENT:ACF_OnDamage( Entity, Energy, FrArea, _, Inflictor, _, _ )	--This f
 end
 
 do
-	local MissileGuidanceFactors = {
-		Dumb				= 0.3,
-		Straight_Running	= 0.45,
-		GPS					= 0.6,
-		Antimissile			= 0.6,
-		AntiRadiation		= 0.7,
-		Beam_Riding			= 0.7,
+	local DefaultGuidanceFactors = {
+		Dumb = 0.3,
+		Straight_Running = 0.45,
+		GPS = 0.6,
+		Antimissile = 0.6,
+		AntiRadiation = 0.7,
+		Beam_Riding = 0.7,
 		GPS_TerrainAvoidant = 0.8,
-		SACLOS				= 0.75,
-		Semiactive			= 0.85,
-		Wire				= 1.0,
-		Acoustic_Straight 	= 1.0,
-		Acoustic_Helical	= 1.0,
-		Laser				= 1.2,
-		Infrared			= 1.2,
-		Top_Attack_IR		= 1.5,
-		Radar				= 1.5
+		SACLOS = 0.75,
+		Semiactive = 0.85,
+		Wire = 1.0,
+		Acoustic_Straight = 1.0,
+		Acoustic_Helical = 1.0,
+		Laser = 1.2,
+		Infrared = 1.2,
+		Top_Attack_IR = 1.5,
+		Radar = 1.5
 	}
 
-	function CalculateMissileCost(BulletData) --Used for both the missiles on the rack and the ammo entities
-		local Pts = ACF_GetRackValue(BulletData, "pointcost") or ACF_GetGunValue(BulletData.Id, "pointcost") or 0.9
-		local Guid = BulletData.Data7 or "Dumb"
-		local factor = MissileGuidanceFactors[Guid] or MissileGuidanceFactors.Dumb or 1
-		Pts = Pts * factor
-		return Pts
+	-- Calculates per-missile points for rack/ammo entities.
+	-- ATGMs use the same performance model as gun ammo, blended with legacy pointcost for continuity.
+	function CalculateMissileCost(BulletData)
+		local legacyPts = ACF_GetRackValue(BulletData, "pointcost") or ACF_GetGunValue(BulletData.Id, "pointcost") or 0
+		local guid = BulletData.Data7 or "Dumb"
+		local guidanceFactors = ACE.MissileGuidanceFactors or DefaultGuidanceFactors
+		local factor = guidanceFactors[guid] or guidanceFactors.Dumb or 1
+
+		local gunClass = ACF_GetGunValue(BulletData.Id, "gunclass")
+		local basePts = legacyPts
+
+		if gunClass == "ATGM" then
+			local cfg = ACE.ATGMCostConfig or {}
+			local perfPts = ACE_GetAmmoRoundPoints(BulletData)
+			local perfMul = cfg.PerformanceMul or 1
+			local legacyWeight = math.Clamp(cfg.LegacyWeight or 0, 0, 1)
+			local minBase = cfg.MinBase or 25
+
+			if perfPts > 0 then
+				basePts = perfPts * perfMul
+				if legacyPts > 0 and legacyWeight > 0 then
+					basePts = basePts * (1 - legacyWeight) + legacyPts * legacyWeight
+				end
+			end
+
+			basePts = math.max(basePts, minBase)
+		end
+
+		return basePts * factor
 	end
-
-
 end

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -162,6 +162,21 @@ function TOOL:Reload( trace )
 		return value
 	end
 
+	local function normalizePointDetails(rawDetails, armorLineSource)
+		local source = istable(rawDetails) and rawDetails or {}
+		local details = {
+			Items = istable(source.Items) and source.Items or {},
+			AmmoLines = istable(source.AmmoLines) and source.AmmoLines or {},
+			ArmorLines = istable(source.ArmorLines) and source.ArmorLines or {}
+		}
+
+		if istable(armorLineSource) then
+			details.ArmorLines = armorLineSource
+		end
+
+		return details
+	end
+
 	local data		= ACF_CalcMassRatio(ent, true) or {}
 
 	local total		= tonumber(ent.acftotal) or 0
@@ -173,6 +188,7 @@ function TOOL:Reload( trace )
 
 	local Contraption = ent:GetContraption() or nil
 	local details = Contraption and Contraption.ACEPointsDetails or nil
+	local armorLines = Contraption and Contraption.ACEArmorDetails or nil
 	local PointVal		= 0
 
 	local PtsArmor = 0
@@ -245,7 +261,7 @@ function TOOL:Reload( trace )
 			HypoFront, HypoSide = ACE_GetArmorScan(scanEnt)
 			HypoFront = safeNumber(HypoFront)
 			HypoSide = safeNumber(HypoSide)
-			HypoPts = safeNumber((HypoFront + HypoSide * 2) * 4)
+			HypoPts = safeNumber(ACE_CalcArmorPoints(HypoFront, HypoSide))
 			HypoUsed = true
 			if ACE_CalcNonArmorPoints and Contraption then
 				local nonArmor, totals, hypoDetails = ACE_CalcNonArmorPoints(Contraption, scanEnt)
@@ -272,7 +288,9 @@ function TOOL:Reload( trace )
 		sideArm = HypoSide
 	end
 
-	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {}, details }
+	local netDetails = normalizePointDetails(details, armorLines)
+
+	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {}, netDetails }
 	local ToJSON		= util.TableToJSON( GeneralTb )
 	local Compressed	= util.Compress(ToJSON) or ""
 
@@ -401,14 +419,33 @@ local function ACE_GetPointsCategory(ent)
 	if not IsValid(ent) then return nil end
 
 	local cls = ent:GetClass()
-	if ArmorPointClasses[cls] then return "Armor" end
+	if (ACE.ArmorClasses and ACE.ArmorClasses[cls]) or ArmorPointClasses[cls] then return "Armor" end
 
 	return PointClassToType[cls]
 end
 
 -- Compute popup points and label for an entity.
 -- Order: entity points, gun-caliber ammo total, then category total.
-local function ACE_GetPopupPoints(ent)
+local ArmorPopupDebug = SERVER and CreateConVar("ace_debug_armor_popup", "0", FCVAR_ARCHIVE, "Debug armor popup per-entity contribution lookup.", 0, 1) or nil
+local ArmorPopupDebugLast = {}
+
+local function ACE_DebugArmorPopup(ply, ent, con, matchedRow)
+	if not SERVER then return end
+	if not ArmorPopupDebug or not ArmorPopupDebug:GetBool() then return end
+	if not IsValid(ply) or not IsValid(ent) then return end
+
+	local key = tostring(ply:EntIndex()) .. ":" .. tostring(ent:EntIndex())
+	local now = CurTime()
+	if (ArmorPopupDebugLast[key] or 0) + 1 > now then return end
+	ArmorPopupDebugLast[key] = now
+
+	local detailsCount = (con and istable(con.ACEArmorDetails) and #con.ACEArmorDetails) or 0
+	local msg = string.format("[ACE popup dbg] ent=%s[#%d] class=%s details=%d matched=%s pts=%s", tostring(ent:GetNWString("WireName", ent:GetClass())), ent:EntIndex(), ent:GetClass(), detailsCount, tostring(matchedRow ~= nil), tostring(matchedRow and matchedRow.Points or 0))
+	print(msg)
+	ply:PrintMessage(HUD_PRINTCONSOLE, msg)
+end
+
+local function ACE_GetPopupPoints(ent, ply)
 	if not IsValid(ent) then return 0, "Entity Cost" end
 
 	local cls = ent:GetClass()
@@ -442,8 +479,33 @@ local function ACE_GetPopupPoints(ent)
 		end
 	end
 
+	if con and ACE_EnsureArmor then
+		ACE_EnsureArmor(con, ent, false)
+	end
+
 	local pointsPerType = con and con.ACEPointsPerType or nil
 	local category = pointsPerType and ACE_GetPointsCategory(ent) or nil
+
+	-- Armor props should use only their per-entity contribution from the armor detail table.
+	if category == "Armor" then
+		local matchedRow = nil
+		if con and istable(con.ACEArmorDetails) then
+			local idx = ent:EntIndex()
+			for _, row in ipairs(con.ACEArmorDetails) do
+				if istable(row) and row.EntIndex == idx then
+					matchedRow = row
+					local armorPts = tonumber(row.Points) or 0
+					ACE_DebugArmorPopup(ply, ent, con, matchedRow)
+					return armorPts, "Entity Armor Cost"
+				end
+			end
+		end
+
+		ACE_DebugArmorPopup(ply, ent, con, matchedRow)
+		-- Never fall back armor entities to total armor category in popup.
+		return 0, "Entity Armor Cost"
+	end
+
 	local categoryPts = category and pointsPerType[category] or 0
 	categoryPts = tonumber(categoryPts) or 0
 	if categoryPts > 0 then
@@ -472,7 +534,7 @@ function TOOL:Think()
 
 		local Mat = ent.ACF.Material or "RHA"
 		local MatData = ACE_GetMaterialData( Mat )
-		local AcePts, pointsLabel = ACE_GetPopupPoints(ent)
+		local AcePts, pointsLabel = ACE_GetPopupPoints(ent, ply)
 
 		if not MatData then return end
 
@@ -748,8 +810,17 @@ if CLIENT then
 		local _ = math.Round( net.ReadFloat(), 0 )
 		local PtsCrew = math.Round( net.ReadFloat(), 1 )
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
-		local FrontArm = math.Round( net.ReadFloat(), 2 )
-		local SideArm = math.Round( net.ReadFloat(), 2 )
+
+		local quantStep = (ACE and ACE.ArmorScanConfig and ACE.ArmorScanConfig.ResultQuantizeMm) or 0
+		local armDigits = 2
+		if quantStep >= 1 then
+			armDigits = 0
+		elseif quantStep >= 0.1 then
+			armDigits = 1
+		end
+
+		local FrontArm = math.Round( net.ReadFloat(), armDigits )
+		local SideArm = math.Round( net.ReadFloat(), armDigits )
 		local ArmorDirty = net.ReadBool()
 		local ArmorInitMissing = net.ReadBool()
 		local HypoRequested = net.ReadBool()
@@ -792,16 +863,19 @@ if CLIENT then
 		end
 
 		table.sort(entries, function(a, b)
-			if a.caliber == b.caliber then
-				if a.atype == b.atype then
-					if a.state == b.state then
-						return a.count > b.count
+			if a.points == b.points then
+				if a.caliber == b.caliber then
+					if a.atype == b.atype then
+						if a.state == b.state then
+							return a.count > b.count
+						end
+						return a.state == "READY"
 					end
-					return a.state == "READY"
+					return a.atype < b.atype
 				end
-				return a.atype < b.atype
+				return a.caliber > b.caliber
 			end
-			return a.caliber > b.caliber
+			return a.points > b.points
 		end)
 
 		local formatted = {}
@@ -829,6 +903,10 @@ if CLIENT then
 		return math.Round(part / total * 100, 0)
 	end
 
+	local function getMaxReadoutLines()
+		return 3
+	end
+
 	-- Prebuild readout labels and summary rows.
 	local PTBreakdownHeader = { Color2, "<|", Color1, "|============|", Color2, "[- Cost Breakdown -]", Color1, "|============|", Color2, "|>" .. Sep }
 
@@ -853,8 +931,48 @@ if CLIENT then
 		Color4, " hp -> ", Color3, "" .. hpton, Color4, " hp/ton" .. Sep
 	}
 
-	local Details = FromJSON and FromJSON[3] or nil
-	local ammoLines = formatAmmoLines(Details and Details.AmmoLines)
+	local function formatArmorLines(lines)
+		if not istable(lines) then return {} end
+
+		local entries = {}
+		for _, entry in ipairs(lines) do
+			if istable(entry) then
+				entries[#entries + 1] = {
+					label = tostring(entry.Label or entry.label or "Armor Segment"),
+					points = tonumber(entry.Points or entry.points) or 0,
+				}
+			end
+		end
+
+		table.sort(entries, function(a, b)
+			if a.points == b.points then
+				return a.label < b.label
+			end
+			return a.points > b.points
+		end)
+
+		local formatted = {}
+		for _, entry in ipairs(entries) do
+			formatted[#formatted + 1] = string.format("%s: %.1f pts", entry.label, entry.points)
+		end
+
+		return formatted
+	end
+
+	local function normalizeDecodedDetails(raw)
+		if not istable(raw) then
+			return { Items = {}, AmmoLines = {}, ArmorLines = {} }
+		end
+		return {
+			Items = istable(raw.Items) and raw.Items or {},
+			AmmoLines = istable(raw.AmmoLines) and raw.AmmoLines or {},
+			ArmorLines = istable(raw.ArmorLines) and raw.ArmorLines or {}
+		}
+	end
+
+	local Details = normalizeDecodedDetails(FromJSON and FromJSON[3] or nil)
+	local ammoLines = formatAmmoLines(Details.AmmoLines)
+	local armorLines = formatArmorLines(Details.ArmorLines)
 
 	-- Full readout is optional; collapsed mode only shows warnings and cost.
 	local showBreakdown = not (ArmorInitMissing and not HypoUsed)
@@ -908,10 +1026,21 @@ if CLIENT then
 		end
 
 		local FractionalPts = "/" .. PointVal
+		local armFmt = string.format("front=%%.%dfmm  side=%%.%dfmm", armDigits, armDigits)
 		table.Add(Tabletxt, {
-			Color4, "Armor scan: ", Color3, string.format("front=%.2fmm  side=%.2fmm", FrontArm, SideArm) .. Sep
+			Color4, "Armor scan: ", Color3, string.format(armFmt, FrontArm, SideArm) .. Sep
 		})
 		table.Add(Tabletxt, { Color4, "Armor: ", Color3, "(" .. pct(PtsArmor, PointVal) .. "%) - ", PtsArmor .. FractionalPts .. Sep })
+		if #armorLines > 0 then
+			local maxArmorLines = getMaxReadoutLines()
+			for i, line in ipairs(armorLines) do
+				if i > maxArmorLines then
+					table.Add(Tabletxt, { Color3, "    ..." .. (#armorLines - maxArmorLines) .. " more" .. Sep })
+					break
+				end
+				table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
+			end
+		end
 		table.Add(Tabletxt, { Color4, "Engines: ", Color3, "(" .. pct(PtsEngine, PointVal) .. "%) - ", PtsEngine .. FractionalPts .. Sep })
 		if PtsFirepower > 0 then
 			table.Add(Tabletxt, {
@@ -922,7 +1051,12 @@ if CLIENT then
 		if PtsAmmo > 0 or #ammoLines > 0 or PtsAmmoReady > 0 or PtsAmmoBackup > 0 then
 			table.Add(Tabletxt, { Color4, "Ammo: ", Color3, "(" .. pct(PtsAmmo, PointVal) .. "%) - ", PtsAmmo .. FractionalPts .. Sep })
 			if #ammoLines > 0 then
-				for _, line in ipairs(ammoLines) do
+				local maxAmmoLines = getMaxReadoutLines()
+				for i, line in ipairs(ammoLines) do
+					if i > maxAmmoLines then
+						table.Add(Tabletxt, { Color3, "    ..." .. (#ammoLines - maxAmmoLines) .. " more" .. Sep })
+						break
+					end
 					table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
 				end
 			elseif AmmoReadyRounds > 0 then
@@ -1011,7 +1145,7 @@ if CLIENT then
 		getPhrase("tool.acfarmorprop.armor") .. ": %s\n" ..
 		getPhrase("tool.acfarmorprop.health") .. ": %s\n" ..
 		getPhrase("tool.acfarmorprop.material") .. ": %s\n\n" ..
-		"%s: %spts\n" ..
+		"%s" ..
 		"Manufacturing Cost: $%s"
 
 	-- Draw the hover tooltip and popup text.
@@ -1038,6 +1172,11 @@ if CLIENT then
 		local mass, armor, health = CalcArmor( area, ductility / 100, thickness , mat)
 		mass = math.min( mass, 50000 )
 
+		local pointLine = ""
+		if acepointcost > 0 then
+			pointLine = string.format("%s: %spts\n", pointLabel, math.Round(acepointcost, 1))
+		end
+
 		local text = string.format(overlayTextFormat,
 			math.Round(curmass, 2),
 			math.Round(curarmor, 2),
@@ -1047,8 +1186,7 @@ if CLIENT then
 			math.Round(armor, 2),
 			math.Round(health, 2),
 			MatData.sname,
-			pointLabel,
-			math.Round(acepointcost, 1),
+			pointLine,
 			math.Round(acecost * 100, 0)
 		)
 


### PR DESCRIPTION
- Stabilizes armor scan/cache/readout behavior and init flow.
- Makes armor popup use per-entity armor contributions (not total armor fallback).
- Sorts/caps armor+ammo readout lines for clarity.
- Updates prop manufacturing-cost logic to raw-mm + ductility with KE/CHEM-weighted basis.
- Includes requested tuning updates (crew flat cost, HE reduction, ROF/guidance adjustments).