### PR TITLE
 Refactor points/legality and armor readout (config, trace filters, etc.)

### DIFF
--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -115,7 +115,6 @@ local IGNORED_CLASSES = {
 	gmod_ghost = true,
 	prop_ragdoll = true,
 	ace_debris = true,
-	sent_prop2mesh = true,
 }
 
 function ACF_Check( Entity )
@@ -126,7 +125,7 @@ function ACF_Check( Entity )
 	if not ( physobj:IsValid() and (physobj:GetMass() or 0) > 0 and not Entity:IsWorld() and not Entity:IsWeapon() ) then return false end
 
 	local Class = Entity:GetClass()
-	if IGNORED_CLASSES[Class] or ( Class ~= "func_breakable" and string.find( Class , "func_" )) then return false end
+	if IGNORED_CLASSES[Class] or (ACF.TraceFilter and ACF.TraceFilter[Class]) or ( Class ~= "func_breakable" and string.find( Class , "func_" )) then return false end
 	if Entity.Exploding then return false end
 
 	if not Entity.ACF or (Entity.ACF and isnumber(Entity.ACF.Material)) then

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -713,13 +713,14 @@ ACE_CalcContraptionArmor = function(ent)
 		end
 	end
 
-	local ignoredArmor = {
-		acf_gun = true,
-		acf_rack = true,
+	local ignoredArmor = table.Copy(ACF.TraceFilter or {})
+	table.Merge(ignoredArmor, {
+		acf_gun = false,
+		acf_rack = false,
 		ace_crewseat_gunner = true,
 		ace_crewseat_loader = true,
 		ace_crewseat_driver = true
-	}
+	})
 
 	-- Build an orthonormal basis from a direction.
 	local function basisFromDir(dir)

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -5,7 +5,8 @@ include("acf/shared/sh_ace_functions.lua")
 
 local IsEnt = ACE_IsEnt
 
-local MIN_DETAIL_PTS = 300
+local pointCfg = ACE.PointCostConfig or {}
+local MIN_DETAIL_PTS = tonumber(pointCfg.MinDetailPoints) or 300
 
 -- Build a readable label for detail entries.
 local function ACE_GetEntityLabel(ent)
@@ -185,7 +186,9 @@ local function ACE_CalcNonAmmoSubsystem(ents, subsystem, minDetailPts)
 			if eclass == subsystem then
 				local pts
 				if subsystem == "Crew" then
-					pts = tonumber(ACE.CrewSeatCostFlat) or 250
+					pts = tonumber(ACE.CrewSeatPointCost)
+						or tonumber((ACE.PointCostConfig or {}).CrewSeatFlat)
+						or 250
 				else
 					pts = ACE_GetEntPoints(ent)
 				end
@@ -241,11 +244,8 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 	if rpsTotal <= 0 then return 0 end
 
 	local cfg = ACE.AmmoCostConfig or {}
-	local refRps = cfg.RpsRef or 0
-	if refRps <= 0 then return 0 end
-
-	local rpsExp = cfg.RpsExp or 1
-	local rpsFactor = (rpsTotal / refRps) ^ rpsExp
+	local rpsFactor = ACE_GetRofThreatFactor(rpsTotal, cfg)
+	if rpsFactor <= 0 then return 0 end
 	local roundPts = ACE_GetAmmoRoundPoints(bdata)
 	if roundPts <= 0 then return 0 end
 
@@ -287,6 +287,8 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 		Capacity = rounds,
 		MaxPen = maxPen,
 		Rps = rpsTotal,
+		Rpm = rpsTotal * 60,
+		RofFactor = rpsFactor,
 		ReadyCount = readyCount,
 		StowCount = stowCount,
 		ReadyCost = readyCost,
@@ -691,10 +693,19 @@ ACE_CalcContraptionArmor = function(ent)
 	end
 
 	-- Critical components are sampled for forward armor bias.
+	local function isEmptyAmmoCrate(ent)
+		if not IsEnt(ent) or ent:GetClass() ~= "acf_ammo" then return false end
+		return (tonumber(ent.Ammo) or 0) <= 0
+	end
+
 	local criticals = {}
 	for _, cent in ipairs(contraptionEnts) do
 		if IsEnt(cent) then
 			local cls = cent:GetClass()
+			if cls == "acf_ammo" and isEmptyAmmoCrate(cent) then
+				continue
+			end
+
 			if cls == "acf_ammo" or cls == "acf_fueltank" or cls == "acf_engine"
 				or cls == "ace_crewseat_gunner" or cls == "ace_crewseat_loader" or cls == "ace_crewseat_driver" then
 				criticals[#criticals + 1] = cent
@@ -838,6 +849,9 @@ ACE_CalcContraptionArmor = function(ent)
 				if not skip then
 					local cls = hitEnt:GetClass()
 					local skipArmor = ignoredArmor[cls] or not ACF_Check(hitEnt)
+					if not skipArmor and cls == "acf_ammo" and isEmptyAmmoCrate(hitEnt) then
+						skipArmor = true
+					end
 					if skipArmor then
 						skip = true
 					elseif ACF_CheckClips(hitEnt, tr.HitPos) then

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -197,6 +197,24 @@ function ACF_Kinetic( Speed , Mass, LimitVel )
 	return Energy
 end
 
+-- Convert kinetic penetration energy and projectile area to RHA penetration in mm.
+function ACE_CalcPenetration(Energy, PenArea, PenMul)
+	local EnergyPen = istable(Energy) and tonumber(Energy.Penetration) or tonumber(Energy)
+	local Area = tonumber(PenArea)
+
+	if not EnergyPen or not Area or Area <= 0 then return 0 end
+
+	local Pen = (EnergyPen / Area) * (ACF.KEtoRHA or 0)
+
+	if PenMul then
+		Pen = Pen * PenMul
+	end
+
+	if Pen ~= Pen or Pen == math.huge or Pen == -math.huge then return 0 end
+
+	return math.max(Pen, 0)
+end
+
 do
 
 	--Convert old numeric IDs to the new string IDs
@@ -810,7 +828,13 @@ end
 function ACE_CalcArmorPoints(front, side)
 	front = tonumber(front) or 0
 	side = tonumber(side) or 0
-	return (front + side * 2) * 4
+
+	local cfg = ACE.PointCostConfig or {}
+	local frontWeight = tonumber(cfg.ArmorFrontWeight) or 1
+	local sideWeight = tonumber(cfg.ArmorSideWeight) or 2.5
+	local armorScale = tonumber(cfg.ArmorScale) or 4
+
+	return (front * frontWeight + side * sideWeight) * armorScale
 end
 
 -- Validate cached armor detail list structure.
@@ -846,6 +870,102 @@ function ACE_SafeRound1(value)
 	return math.Round(ACE_SafeNonNegative(value), 1)
 end
 
+do
+	-- Ensure all ACE/ACF traces respect ACF.TraceFilter, even when a local filter
+	-- is missing or incomplete in a specific trace call site.
+	if util and not ACE._TraceFilterWrapped then
+		local RawTraceLine = util.TraceLine
+		local RawTraceHull = util.TraceHull
+		local RawQuickTrace = util.QuickTrace
+		local RawLegacyTraceLine = util.LegacyTraceLine
+
+		local function shouldIgnoreByClass(ent)
+			if not IsValid(ent) then return false end
+
+			local class = ent:GetClass()
+			if not class or class == "" then return false end
+
+			local ignored = ACF and ACF.TraceFilter
+			return ignored and ignored[class] or false
+		end
+
+		local function normalizeFilter(filter)
+			if isfunction(filter) then
+				return function(ent)
+					if shouldIgnoreByClass(ent) then return true end
+					return filter(ent)
+				end
+			end
+
+			if IsValid(filter) then
+				return function(ent)
+					if shouldIgnoreByClass(ent) then return true end
+					return ent == filter
+				end
+			end
+
+			if istable(filter) then
+				local lookup = {}
+				for _, item in pairs(filter) do
+					if IsValid(item) then
+						lookup[item] = true
+					end
+				end
+
+				return function(ent)
+					if shouldIgnoreByClass(ent) then return true end
+					return lookup[ent] or false
+				end
+			end
+
+			return function(ent)
+				return shouldIgnoreByClass(ent)
+			end
+		end
+
+		if isfunction(RawTraceLine) then
+			util.TraceLine = function(traceData)
+				if not istable(traceData) then
+					return RawTraceLine(traceData)
+				end
+
+				traceData.filter = normalizeFilter(traceData.filter)
+				return RawTraceLine(traceData)
+			end
+		end
+
+		if isfunction(RawTraceHull) then
+			util.TraceHull = function(traceData)
+				if not istable(traceData) then
+					return RawTraceHull(traceData)
+				end
+
+				traceData.filter = normalizeFilter(traceData.filter)
+				return RawTraceHull(traceData)
+			end
+		end
+
+		if isfunction(RawQuickTrace) then
+			util.QuickTrace = function(startPos, delta, filter)
+				return RawQuickTrace(startPos, delta, normalizeFilter(filter))
+			end
+		end
+
+		if isfunction(RawLegacyTraceLine) then
+			util.LegacyTraceLine = function(traceData)
+				if not istable(traceData) then
+					return RawLegacyTraceLine(traceData)
+				end
+
+				traceData.filter = normalizeFilter(traceData.filter)
+				return RawLegacyTraceLine(traceData)
+			end
+		end
+
+		ACE._TraceFilterWrapped = true
+	end
+end
+
 function ACE_FormatDetailLabel(ent)
 	if not ACE_IsEnt(ent) then return "Unknown" end
 
@@ -872,9 +992,202 @@ function ACE_GetAmmoTypeFactor(ammoType)
 	return factors and factors[ammoType] or 1
 end
 
+-- Extract configurable class name from "Name:arg=val" serialized strings.
+function ACE_GetConfigurableName(value, fallback)
+	if type(value) ~= "string" or value == "" then return fallback end
+
+	local name = string.match(value, "^[^:]+")
+	if not name or name == "" then return fallback end
+
+	return name
+end
+
+-- Resolve missile guidance multiplier from guidance configuration.
+function ACE_GetMissileGuidanceFactor(guidanceValue)
+	local factors = ACE.MissileGuidanceFactors or {}
+	local fallback = tonumber(factors.Dumb) or 1
+	local name = ACE_GetConfigurableName(guidanceValue, "Dumb")
+	local factor = tonumber(factors[name]) or fallback
+
+	return math.max(factor, 0)
+end
+
+-- Resolve the gun class string for ammo bullet data.
+function ACE_GetAmmoGunClass(bdata)
+	if not bdata then return nil end
+
+	local gunClass = bdata.GunClass
+	if gunClass and gunClass ~= "" then return gunClass end
+
+	local gunData = (bdata.Id and ACF and ACF.Weapons and ACF.Weapons.Guns and ACF.Weapons.Guns[bdata.Id]) or nil
+	return gunData and gunData.gunclass or nil
+end
+
+-- Determine whether an ammo type is a GLATGM family type.
+function ACE_IsGLATGMAmmoType(ammoType)
+	return ammoType == "GLATGM" or ammoType == "GLATGM-HE"
+end
+
+-- Resolve the most authoritative ammo type for an entity/bullet pair.
+function ACE_ResolveAmmoType(ent, bdata)
+	if ACE_IsEnt(ent) then
+		local entType = ent.RoundType
+		if isstring(entType) and entType ~= "" then return entType end
+
+		if ent.GetNWString then
+			local nwType = ent:GetNWString("AmmoType", "")
+			if nwType ~= "" then return nwType end
+		end
+	end
+
+	if bdata then
+		local btype = bdata.Type or bdata.RoundType
+		if isstring(btype) and btype ~= "" then return btype end
+	end
+
+	return ""
+end
+
+-- Resolve missile warhead behavior from ammo type.
+function ACE_GetMissileWarheadType(ammoType)
+	if ammoType == "GLATGM" then return "HEAT" end
+	if ammoType == "GLATGM-HE" then return "HE" end
+	return ammoType
+end
+
+-- Resolve explosion class used by ammo cookoff logic.
+function ACE_GetAmmoCookoffClass(_, isMissile)
+	if isMissile then return "MISSILE" end
+	return "AMMO"
+end
+
+-- Resolve blast filler used by ammo cookoff logic.
+function ACE_GetAmmoCookoffBlastMass(_, bdata)
+	if not bdata then return 0 end
+
+	local boom = tonumber(bdata.BoomFillerMass)
+	if boom and boom > 0 then return boom end
+
+	local filler = tonumber(bdata.FillerMass) or 0
+	if filler > 0 then return filler end
+
+	return 0
+end
+
+-- Resolve how many rounds are assumed to sympathetically detonate.
+function ACE_GetAmmoCookoffAmmoCount(_, ammoCount, isMissile)
+	local count = tonumber(ammoCount) or 0
+	if count <= 0 then return 0 end
+
+	if isMissile then
+		return math.max(1, count * 0.15)
+	end
+
+	return count
+end
+
+-- Resolve propellant contribution multiplier by cookoff class.
+function ACE_GetAmmoCookoffPropScale(cookClass)
+	if cookClass == "HEAT" then return 0 end
+	if cookClass == "MISSILE" then return 0.08 end
+	return 1
+end
+
+-- Resolve storage scaling by cookoff class.
+function ACE_GetAmmoCookoffStorageScale(cookClass, ammoScale, missileScale)
+	local defaultAmmoScale = tonumber(ammoScale) or 0.55
+	local defaultMissileScale = tonumber(missileScale) or 0.35
+
+	if cookClass == "MISSILE" then return defaultMissileScale end
+	return defaultAmmoScale
+end
+
+-- Determine whether bullet data should be treated as missile ammo.
+function ACE_IsAmmoMissileType(bdata)
+	if not bdata then return false end
+	if ACE_IsGLATGMAmmoType(bdata.Type) then return true end
+
+	local gunClass = ACE_GetAmmoGunClass(bdata)
+	if not gunClass then return false end
+
+	local classes = ACF and ACF.Classes and ACF.Classes.GunClass
+	local classData = classes and classes[gunClass] or nil
+
+	return classData and classData.type == "missile" or false
+end
+
+-- Determine whether bullet data should use ATGM-style missile costing.
+function ACE_IsATGMCostAmmo(bdata)
+	if not bdata then return false end
+	if ACE_IsGLATGMAmmoType(bdata.Type) then return true end
+
+	return ACE_GetAmmoGunClass(bdata) == "ATGM"
+end
+
+-- Calculate per-missile legacy points (manufacturing-cost basis), including guidance.
+function ACE_CalcMissileLegacyRoundCost(bdata)
+	if not istable(bdata) then return 0 end
+
+	local ammoId = bdata.Id
+	local rackPointCost = ACF_GetRackValue and ACF_GetRackValue(bdata, "pointcost")
+	local gunPointCost = ACF_GetGunValue and ACF_GetGunValue(ammoId, "pointcost")
+	local legacyPts = tonumber(rackPointCost or 0) or tonumber(gunPointCost or 0) or 0
+	legacyPts = math.max(legacyPts, 0)
+
+	local factor = ACE_GetMissileGuidanceFactor(bdata.Data7)
+	local basePts = legacyPts
+
+	if ACE_IsATGMCostAmmo(bdata) then
+		local cfg = ACE.ATGMCostConfig or {}
+		local perfPts = ACE_GetAmmoRoundPoints(bdata)
+		local perfMul = tonumber(cfg.PerformanceMul) or 1
+		local legacyWeight = math.Clamp(tonumber(cfg.LegacyWeight) or 0, 0, 1)
+		local minBase = tonumber(cfg.MinBase) or 25
+
+		if perfPts > 0 then
+			basePts = perfPts * perfMul
+			if legacyPts > 0 and legacyWeight > 0 then
+				basePts = basePts * (1 - legacyWeight) + legacyPts * legacyWeight
+			end
+		end
+
+		basePts = math.max(basePts, minBase)
+	end
+
+	return math.max(basePts, 0) * factor
+end
+
 -- Determine whether an ammo type should use HE utility scaling.
 function ACE_IsHEAmmoType(ammoType)
 	return ammoType == "HE" or ammoType == "HEFS" or ammoType == "CHE"
+end
+
+-- Calculate penetration threat scaling using normalized penetration.
+function ACE_GetPenThreatFactor(maxPen, cfg)
+	cfg = cfg or ACE.AmmoCostConfig or {}
+
+	local refPen = tonumber(cfg.RefPen) or 0
+	if refPen <= 0 then return 0 end
+
+	local penRatio = math.max((tonumber(maxPen) or 0) / refPen, 0)
+	if penRatio <= 0 then return 0 end
+
+	-- Keep penetration scaling linear; RoF is the primary nonlinear term.
+	return penRatio
+end
+
+-- Calculate RoF threat scaling as a saturating factor.
+function ACE_GetRofThreatFactor(rps, cfg)
+	cfg = cfg or ACE.AmmoCostConfig or {}
+
+	local rpsValue = tonumber(rps) or 0
+	if rpsValue <= 0 then return 0 end
+
+	local kneeRpm = tonumber(cfg.RofKneeRpm) or 0
+	if kneeRpm <= 0 then return 0 end
+
+	local rpm = rpsValue * 60
+	return rpm / (rpm + kneeRpm)
 end
 
 -- Compute ready rack capacity for a caliber.
@@ -911,17 +1224,15 @@ function ACE_GetAmmoRoundPoints(bdata)
 	if typeFactor <= 0 then return 0 end
 
 	local cfg = ACE.AmmoCostConfig or {}
-	local refPen = cfg.RefPen or 0
 	local refCal = cfg.RefCaliber or 0
 	local baseRound = cfg.BaseRoundPts or 0
-	if refPen <= 0 or refCal <= 0 or baseRound <= 0 then return 0 end
+	if refCal <= 0 or baseRound <= 0 then return 0 end
 
-	local penExp = cfg.PenExp or 1
+	local penFactor = ACE_GetPenThreatFactor(maxPen, cfg)
 	local blastExp = cfg.BlastExp or 1
 	local blastWeight = cfg.BlastWeight or 0
 	local refBlast = cfg.RefBlastMass or 0
 
-	local penFactor = (maxPen / refPen) ^ penExp
 	local blastFactor = 0
 	if blastMass > 0 and refBlast > 0 then
 		blastFactor = (blastMass / refBlast) ^ blastExp
@@ -956,15 +1267,12 @@ function ACE_GetAmmoThreatWeight(bdata)
 	if maxPen <= 0 and blastMass <= 0 then return 0 end
 
 	local cfg = ACE.AmmoCostConfig or {}
-	local refPen = cfg.RefPen or 0
 	local refBlast = cfg.RefBlastMass or 0
-	if refPen <= 0 then return 0 end
 
-	local penExp = cfg.PenExp or 1
+	local penFactor = ACE_GetPenThreatFactor(maxPen, cfg)
 	local blastExp = cfg.BlastExp or 1
 	local blastWeight = cfg.BlastWeight or 0
 
-	local penFactor = (maxPen / refPen) ^ penExp
 	local blastFactor = 0
 	if blastMass > 0 and refBlast > 0 then
 		blastFactor = (blastMass / refBlast) ^ blastExp
@@ -1077,12 +1385,53 @@ end
 -- Collect entities belonging to a contraption.
 function ACE_GetContraptionEntities(con, fallbackEnt)
 	local ents = {}
+	local visited = {}
+	local queue = {}
+
+	local function enqueue(ent)
+		if not ACE_IsEnt(ent) then return end
+		if visited[ent] then return end
+
+		visited[ent] = true
+		ents[#ents + 1] = ent
+		queue[#queue + 1] = ent
+	end
+
 	if con and con.ents then
 		for ent in pairs(con.ents) do
-			if ACE_IsEnt(ent) then ents[#ents + 1] = ent end
+			enqueue(ent)
 		end
 	end
-	if #ents == 0 and ACE_IsEnt(fallbackEnt) then ents[1] = fallbackEnt end
+
+	if #ents == 0 and ACE_IsEnt(fallbackEnt) then
+		enqueue(fallbackEnt)
+	end
+
+	-- Include ACF-linked entities that may not be physically welded into the contraption.
+	local idx = 1
+	while idx <= #queue do
+		local cur = queue[idx]
+		idx = idx + 1
+
+		local ammoLink = cur.AmmoLink
+		if istable(ammoLink) then
+			for _, linked in pairs(ammoLink) do
+				enqueue(linked)
+			end
+		end
+
+		local master = cur.Master
+		if istable(master) then
+			for _, linked in pairs(master) do
+				enqueue(linked)
+			end
+		end
+	end
+
+	table.sort(ents, function(a, b)
+		return a:EntIndex() < b:EntIndex()
+	end)
+
 	return ents
 end
 
@@ -1639,11 +1988,30 @@ function ACE_GetEntLegacyCost(ent, massOverride)
 			rawMm = effectiveMm / armorMod
 		end
 
-		local duct = math.Clamp(tonumber(acf.Ductility) or 0, -0.8, 0.8)
-		local ductilityCostMul = 1 + duct * 0.125 -- -80 => 0.9x, +80 => 1.1x
+		local rawHP = tonumber(acf.MaxHealth or acf.Health) or 1
+		rawHP = math.max(rawHP, 1)
+
+		-- Manufacturing scalar is now driven by raw HP, not ductility:
+		-- 1 HP => 0.2x (-80%), 100 HP => 1.2x (+20%), clamped for stability.
+		local hpCostMul = math.Clamp(0.2 + (rawHP - 1) * (1.0 / 99), 0.2, 1.2)
 		local perMm = ACE.LegacyRawMmCostPerProp or 1
 
-		return math.max(rawMm * perMm * ductilityCostMul, 0)
+		return math.max(rawMm * perMm * hpCostMul, 0)
+	end
+
+	-- Missile ammo crates: derive manufacturing cost from missile round points so guidance
+	-- always affects legacy cost even when ACEPoints isn't initialized yet.
+	if class == "acf_ammo" then
+		local bdata = ent.BulletData
+		if istable(bdata) and ACE_IsAmmoMissileType(bdata) then
+			local perRound = ACE_CalcMissileLegacyRoundCost(bdata)
+			if perRound > 0 then
+				local rounds = tonumber(ent.Capacity) or tonumber(ent.Ammo) or 0
+				rounds = math.max(rounds, 1)
+
+				return perRound * rounds
+			end
+		end
 	end
 
 	local mass = massOverride
@@ -1653,7 +2021,7 @@ function ACE_GetEntLegacyCost(ent, massOverride)
 	end
 
 	mass = tonumber(mass) or 0
-	local pointsPerTon = ACF.PointsPerTon or 0
+	local pointsPerTon = ACF.LegacyManufacturingPointsPerTon or 0
 	if mass > 0 and pointsPerTon > 0 then
 		local matTable = ACE.LegacyMatCostTables or ACE.MatCostTables or {}
 		local mat = (ent.ACF and ent.ACF.Material) or "RHA"

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1006,10 +1006,55 @@ end
 function ACE_GetMissileGuidanceFactor(guidanceValue)
 	local factors = ACE.MissileGuidanceFactors or {}
 	local fallback = tonumber(factors.Dumb) or 1
-	local name = ACE_GetConfigurableName(guidanceValue, "Dumb")
-	local factor = tonumber(factors[name]) or fallback
 
-	return math.max(factor, 0)
+	local function normalizeName(name)
+		if type(name) ~= "string" or name == "" then return nil end
+		return (name:gsub("%s+", "_"):gsub("%-", "_"))
+	end
+
+	local function resolveFactorFromName(name)
+		name = normalizeName(name)
+		if not name then return nil end
+
+		local direct = tonumber(factors[name])
+		if direct then return direct end
+
+		local lower = string.lower(name)
+		for key, value in pairs(factors) do
+			if string.lower(tostring(key)) == lower then
+				return tonumber(value)
+			end
+		end
+
+		return nil
+	end
+
+	-- Direct string forms, including configurable "Name:arg=val".
+	if type(guidanceValue) == "string" then
+		local name = ACE_GetConfigurableName(guidanceValue, "Dumb")
+		local factor = resolveFactorFromName(name) or resolveFactorFromName(guidanceValue) or fallback
+		return math.max(factor, 0)
+	end
+
+	-- Configurable/table forms used at runtime by missile entities.
+	if istable(guidanceValue) then
+		local candidates = {
+			guidanceValue.Name,
+			guidanceValue.name,
+			guidanceValue.ClassName,
+			guidanceValue.class,
+			guidanceValue.GuidanceName,
+			guidanceValue.Guidance,
+			guidanceValue.Type
+		}
+
+		for _, candidate in ipairs(candidates) do
+			local factor = resolveFactorFromName(candidate)
+			if factor then return math.max(factor, 0) end
+		end
+	end
+
+	return math.max(fallback, 0)
 end
 
 -- Resolve the gun class string for ammo bullet data.
@@ -1124,6 +1169,14 @@ function ACE_IsATGMCostAmmo(bdata)
 	return ACE_GetAmmoGunClass(bdata) == "ATGM"
 end
 
+-- Resolve guidance scaling used by missile point/threat math.
+local function ACE_GetAmmoGuidancePenFactor(bdata)
+	if not bdata or not ACE_IsAmmoMissileType(bdata) then return 1 end
+	-- Guidance should act as an upward threat modifier in pen-space, not make
+	-- missiles artificially cheap when using low-end guidance packages.
+	return math.max(ACE_GetMissileGuidanceFactor(bdata.Data7), 1)
+end
+
 -- Calculate per-missile legacy points (manufacturing-cost basis), including guidance.
 function ACE_CalcMissileLegacyRoundCost(bdata)
 	if not istable(bdata) then return 0 end
@@ -1152,8 +1205,12 @@ function ACE_CalcMissileLegacyRoundCost(bdata)
 		end
 
 		basePts = math.max(basePts, minBase)
+
+		-- Guidance is already applied in missile threat/penetration scaling for ATGM perf points.
+		return math.max(basePts, 0)
 	end
 
+	-- Non-ATGM missile racks still use legacy pointcost, so guidance is applied here.
 	return math.max(basePts, 0) * factor
 end
 
@@ -1186,7 +1243,8 @@ function ACE_GetRofThreatFactor(rps, cfg)
 	local kneeRpm = tonumber(cfg.RofKneeRpm) or 0
 	if kneeRpm <= 0 then return 0 end
 
-	local rpm = rpsValue * 60
+	local minRpm = tonumber(cfg.MinRofRpm) or 0
+	local rpm = math.max(rpsValue * 60, minRpm)
 	return rpm / (rpm + kneeRpm)
 end
 
@@ -1213,7 +1271,7 @@ end
 function ACE_GetAmmoRoundPoints(bdata)
 	if not bdata then return 0 end
 
-	local maxPen = ACE_GetAmmoMaxPen(bdata)
+	local maxPen = ACE_GetAmmoMaxPen(bdata) * ACE_GetAmmoGuidancePenFactor(bdata)
 	local blastMass = ACE_GetAmmoBlastMass(bdata)
 	if maxPen <= 0 and blastMass <= 0 then return 0 end
 
@@ -1262,7 +1320,7 @@ end
 function ACE_GetAmmoThreatWeight(bdata)
 	if not bdata then return 0 end
 
-	local maxPen = ACE_GetAmmoMaxPen(bdata)
+	local maxPen = ACE_GetAmmoMaxPen(bdata) * ACE_GetAmmoGuidancePenFactor(bdata)
 	local blastMass = ACE_GetAmmoBlastMass(bdata)
 	if maxPen <= 0 and blastMass <= 0 then return 0 end
 

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -870,102 +870,6 @@ function ACE_SafeRound1(value)
 	return math.Round(ACE_SafeNonNegative(value), 1)
 end
 
-do
-	-- Ensure all ACE/ACF traces respect ACF.TraceFilter, even when a local filter
-	-- is missing or incomplete in a specific trace call site.
-	if util and not ACE._TraceFilterWrapped then
-		local RawTraceLine = util.TraceLine
-		local RawTraceHull = util.TraceHull
-		local RawQuickTrace = util.QuickTrace
-		local RawLegacyTraceLine = util.LegacyTraceLine
-
-		local function shouldIgnoreByClass(ent)
-			if not IsValid(ent) then return false end
-
-			local class = ent:GetClass()
-			if not class or class == "" then return false end
-
-			local ignored = ACF and ACF.TraceFilter
-			return ignored and ignored[class] or false
-		end
-
-		local function normalizeFilter(filter)
-			if isfunction(filter) then
-				return function(ent)
-					if shouldIgnoreByClass(ent) then return true end
-					return filter(ent)
-				end
-			end
-
-			if IsValid(filter) then
-				return function(ent)
-					if shouldIgnoreByClass(ent) then return true end
-					return ent == filter
-				end
-			end
-
-			if istable(filter) then
-				local lookup = {}
-				for _, item in pairs(filter) do
-					if IsValid(item) then
-						lookup[item] = true
-					end
-				end
-
-				return function(ent)
-					if shouldIgnoreByClass(ent) then return true end
-					return lookup[ent] or false
-				end
-			end
-
-			return function(ent)
-				return shouldIgnoreByClass(ent)
-			end
-		end
-
-		if isfunction(RawTraceLine) then
-			util.TraceLine = function(traceData)
-				if not istable(traceData) then
-					return RawTraceLine(traceData)
-				end
-
-				traceData.filter = normalizeFilter(traceData.filter)
-				return RawTraceLine(traceData)
-			end
-		end
-
-		if isfunction(RawTraceHull) then
-			util.TraceHull = function(traceData)
-				if not istable(traceData) then
-					return RawTraceHull(traceData)
-				end
-
-				traceData.filter = normalizeFilter(traceData.filter)
-				return RawTraceHull(traceData)
-			end
-		end
-
-		if isfunction(RawQuickTrace) then
-			util.QuickTrace = function(startPos, delta, filter)
-				return RawQuickTrace(startPos, delta, normalizeFilter(filter))
-			end
-		end
-
-		if isfunction(RawLegacyTraceLine) then
-			util.LegacyTraceLine = function(traceData)
-				if not istable(traceData) then
-					return RawLegacyTraceLine(traceData)
-				end
-
-				traceData.filter = normalizeFilter(traceData.filter)
-				return RawLegacyTraceLine(traceData)
-			end
-		end
-
-		ACE._TraceFilterWrapped = true
-	end
-end
-
 function ACE_FormatDetailLabel(ent)
 	if not ACE_IsEnt(ent) then return "Unknown" end
 
@@ -2136,6 +2040,7 @@ function ACE_GetArmorScan(ent)
 	local front, side = ACE_CalcContraptionArmor(ent)
 	return front, side
 end
+
 
 
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -39,9 +39,9 @@ ACF.SWEPInaccuracyMul      = 0.5
 ---------------------------------- Debris ----------------------------------
 
 ACF.DebrisIgniteChance    = 0.25
-ACF.DebrisScale           = 20                        -- Ignore debris that is less than this bounding radius.
-ACF.DebrisChance          = 0.5
-ACF.DebrisLifeTime        = 60
+ACF.DebrisScale           = 10                        -- Ignore debris that is less than this bounding radius.
+ACF.DebrisChance          = 1
+ACF.DebrisLifeTime        = 30
 
 ---------------------------------- Fuel & fuel Tank config ----------------------------------
 
@@ -107,6 +107,7 @@ ACF.TraceFilter       = {        -- entities that cause issue with acf and shoul
     prop_vehicle_crane   = true,
     prop_dynamic         = true,
     npc_strider          = true,
+    sent_prop2mesh       = true,
     worldspawn           = true, --The worldspawn in infinite maps is fake. Since the IsWorld function will not do something to avoid this case, that i will put it here.
 
 }
@@ -134,7 +135,7 @@ ACF.MaxWeight   = 200000 -- The max weight in kg.
 
 ACE.PointCostConfig = ACE.PointCostConfig or {
     ArmorFrontWeight = 1.0, -- Front armor contribution in armor points.
-    ArmorSideWeight  = 2.5, -- Side armor contribution in armor points.
+    ArmorSideWeight  = 2.2, -- Side armor contribution in armor points.
     ArmorScale       = 4.0, -- Final armor points multiplier.
     CrewSeatFlat     = 250, -- Flat point cost per crew seat entity.
     MinDetailPoints  = 300 -- Minimum points to list an entry in armor tool breakdown.
@@ -195,10 +196,11 @@ ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
     RHA = 1
 }
 ACE.AmmoCostConfig = {
-    BaseRoundPts = 385, -- Tuned so 25x APFSDS @ 750mm at 12 RPM is ~3333 pts (120/125mm class).
+    BaseRoundPts = 340, -- Tuned so 25x APFSDS @ 750mm at 12 RPM is ~3333 pts (120/125mm class).
     RefPen = 700, -- Reference penetration (mm) for pen scaling.
     RefCaliber = 100, -- Reference caliber (mm) for caliber scaling.
-    RofKneeRpm = 14, -- RoF knee for saturation: RoF/(RoF+k), using RPM.
+    RofKneeRpm = 8, -- RoF knee for saturation: RoF/(RoF+k), using RPM.
+    MinRofRpm = 6, -- Minimum RPM factored into ROF threat scaling.
     RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
     BlastExp = 1.1, -- Blast curve exponent.
     BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
@@ -324,7 +326,7 @@ if SERVER then
     CreateConVar("sbox_max_acf_ammo", 100)                    -- ammo limit
     CreateConVar("sbox_max_acf_misc", 100)                    -- misc ents limit
     CreateConVar("sbox_max_acf_rack", 24)                    -- Racks limit
-    CreateConVar("sbox_max_ace_crewseat", 100)
+    CreateConVar("sbox_max_acf_crewseat", 100)
     CreateConVar("acf_mines_max", 50)                        -- The mine limit
     CreateConVar("acf_meshvalue", 1)
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -129,13 +129,32 @@ ACF.LargeEngineThreshold = 100 --Engine size in hp required to need a driver
 ACF.LargeGunsRequireGunners = 1 --Should engines over a certain hp need a driver? Modified by console commands.
 ACF.LargeGunsThreshold = 40 --Cannon size in mm required to need a driver
 
-ACF.PointsLimit = 10000 --The maximum legal pointvalue
-ACF.MaxWeight = 200000 --The max weight in Kg
+ACF.PointsLimit = 10000 -- The maximum legal point value.
+ACF.MaxWeight   = 200000 -- The max weight in kg.
 
-ACE.CannonPointMul = 0.85 --Multiplier for cannon point cost
-ACE.EnginePointMul = 0.69 --Multiplier for engine cost in points
-ACF.PointsPerTon   = ACF.PointsPerTon or 42 -- Legacy cost per ton for the Manufacturing Cost indicator.
-ACE.AmmoPerTon     = 100 --Point cost per ton of ammo
+ACE.PointCostConfig = ACE.PointCostConfig or {
+    ArmorFrontWeight = 1.0, -- Front armor contribution in armor points.
+    ArmorSideWeight  = 2.5, -- Side armor contribution in armor points.
+    ArmorScale       = 4.0, -- Final armor points multiplier.
+    CrewSeatFlat     = 250, -- Flat point cost per crew seat entity.
+    MinDetailPoints  = 300 -- Minimum points to list an entry in armor tool breakdown.
+}
+
+ACE.GunPointCostMultiplier    = tonumber(ACE.GunPointCostMultiplier) or tonumber(ACE.CannonPointMul) or 0.85 -- Multiplier for gun/cannon point cost.
+ACE.EnginePointCostMultiplier = tonumber(ACE.EnginePointCostMultiplier) or tonumber(ACE.EnginePointMul) or 0.69 -- Multiplier for engine point cost.
+ACF.LegacyManufacturingPointsPerTon = tonumber(ACF.LegacyManufacturingPointsPerTon) or tonumber(ACF.PointsPerTon) or 42 -- Legacy manufacturing cost coefficient per ton.
+ACE.LegacyAmmoPointsPerTon    = tonumber(ACE.LegacyAmmoPointsPerTon) or tonumber(ACE.AmmoPerTon) or 100 -- Legacy non-missile ammo points per ton.
+ACE.CrewSeatPointCost         = tonumber(ACE.CrewSeatPointCost)
+    or tonumber(ACE.CrewSeatCostFlat)
+    or tonumber(ACE.PointCostConfig and ACE.PointCostConfig.CrewSeatFlat)
+    or 250 -- Flat point cost per crew seat.
+
+-- Backward-compatible aliases (deprecated names).
+ACE.CannonPointMul = ACE.GunPointCostMultiplier
+ACE.EnginePointMul = ACE.EnginePointCostMultiplier
+ACF.PointsPerTon = ACF.LegacyManufacturingPointsPerTon
+ACE.AmmoPerTon = ACE.LegacyAmmoPointsPerTon
+ACE.CrewSeatCostFlat = ACE.CrewSeatPointCost
 
 -- Deprecated: armor mass-based cost has been replaced by LOS armor scan.
 --
@@ -166,8 +185,6 @@ ACE.AmmoTypeFactors = {
     Refill = 0
 }
 
-
-
 ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
     Alum = 1.2 * (0.221 / 0.34), -- 20% cost increase for ~25% weight reduction.
     CHA = 0.8 * (0.98 / 1.25), -- 25% heavier for ~20% cost reduction.
@@ -178,17 +195,15 @@ ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
     RHA = 1
 }
 ACE.AmmoCostConfig = {
-    BaseRoundPts = 120, -- Base points per round before scaling.
-    RefPen = 720, -- Reference penetration (mm) for pen scaling.
+    BaseRoundPts = 385, -- Tuned so 25x APFSDS @ 750mm at 12 RPM is ~3333 pts (120/125mm class).
+    RefPen = 700, -- Reference penetration (mm) for pen scaling.
     RefCaliber = 100, -- Reference caliber (mm) for caliber scaling.
-    PenExp = 1.4, -- Penetration curve exponent.
+    RofKneeRpm = 14, -- RoF knee for saturation: RoF/(RoF+k), using RPM.
     RefBlastMass = 6, -- Reference HE filler mass (kg) for blast scaling.
     BlastExp = 1.1, -- Blast curve exponent.
     BlastWeight = 0.25, -- Blend weight for blast vs penetration threat.
     HeUtilWeight = 1.3, -- HE utility weight from filler mass per caliber.
     HeUtilExp = 0.5, -- HE utility exponent for filler per caliber.
-    RpsRef = 1 / 7, -- Reference rounds per second for ROF scaling.
-    RpsExp = 0.825, -- ROF curve exponent (+10%).
     ReadyRackBase = 3000, -- Ready rack baseline: base / caliber(mm).
     ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
     ReadyRackLowBoost = 1.5, -- Low-caliber boost (20mm hits 300 at base 3000).
@@ -210,7 +225,7 @@ ACE.MissileGuidanceFactors = {
     Dumb = 0.3,
     Straight_Running = 0.45,
     GPS = 0.6,
-    Antimissile = 0.6,
+    Antimissile = 1,
     AntiRadiation = 0.7,
     Beam_Riding = 0.7,
     GPS_TerrainAvoidant = 0.8,
@@ -220,9 +235,9 @@ ACE.MissileGuidanceFactors = {
     Acoustic_Straight = 1.0,
     Acoustic_Helical = 1.0,
     Laser = 1.2,
-    Infrared = 1.2,
-    Top_Attack_IR = 1.5,
-    Radar = 1.5
+    Infrared = 2.7,
+    Top_Attack_IR = 3,
+    Radar = 1.2
 }
 
 -- Armor tool UX timing.

--- a/lua/autorun/client/cl_acfm_menuinject.lua
+++ b/lua/autorun/client/cl_acfm_menuinject.lua
@@ -13,6 +13,25 @@ end
 
 local ACFEnts = ACF.Weapons
 
+local function FormatWithCommas(Value, Decimals)
+	local Number = tonumber(Value)
+	if not Number then return tostring(Value or 0) end
+
+	if Decimals and Decimals > 0 then
+		local Format = "%." .. Decimals .. "f"
+		local Text = string.format(Format, Number)
+		local Whole, Fraction = Text:match("^(%-?%d+)%.(%d+)$")
+
+		if Whole and Fraction then
+			return string.Comma(tonumber(Whole) or 0) .. "." .. Fraction
+		end
+
+		return Text
+	end
+
+	return string.Comma(math.floor(Number + 0.5))
+end
+
 function SetMissileGUIEnabled(_, enabled, gundata)
 
 	if enabled then
@@ -217,8 +236,11 @@ function CreateRackSelectGUI(node)
 				acfmenupanel:CPanelText("RackTitle", rack.name or "Missing Name","DermaDefaultBold")
 				acfmenupanel:CPanelText("RackDesc", (rack.desc or "Missing Desc") .. "\n")
 
-				acfmenupanel:CPanelText("RackEweight", "Weight when empty : " .. (rack.weight or "Missing weight") .. "kg")
-				acfmenupanel:CPanelText("RackFweight", "Weight when fully loaded : " .. ( (rack.weight or 0) + (table.Count(rack.mountpoints) * node.mytable.weight) ) .. "kg")
+				local EmptyWeight = tonumber(rack.weight) or 0
+				local FullWeight = EmptyWeight + (table.Count(rack.mountpoints) * (tonumber(node.mytable.weight) or 0))
+
+				acfmenupanel:CPanelText("RackEweight", "Weight when empty : " .. FormatWithCommas(EmptyWeight, 1) .. "kg")
+				acfmenupanel:CPanelText("RackFweight", "Weight when fully loaded : " .. FormatWithCommas(FullWeight, 1) .. "kg")
 				acfmenupanel:CPanelText("Rack_Year", "Year : " .. rack.year .. "\n")
 			end
 		end
@@ -238,7 +260,14 @@ function CreateRackSelectGUI(node)
 
 	local default = node.mytable.rack
 	for _, Value in pairs( ACF_GetCompatibleRacks(node.mytable.id) ) do
-		acfmenupanel.CData.RackSelect:AddChoice( Value, Value, Value == default )
+		local Display = Value
+		local Rack = ACF.Weapons.Racks[Value]
+		if Rack then
+			local RackWeight = tonumber(Rack.weight) or 0
+			Display = string.format("%s (%skg)", Value, FormatWithCommas(RackWeight, 1))
+		end
+
+		acfmenupanel.CData.RackSelect:AddChoice( Display, Value, Value == default )
 	end
 
 

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -30,66 +30,14 @@ local function IsMachineGunAmmo( ent )
 	return gunclass == "MG"
 end
 
-local GLATGM_TYPES = {
-	GLATGM = true,
-	["GLATGM-HE"] = true
-}
-
-local MISSILE_WARHEAD_OVERRIDES = {
-	GLATGM = "HEAT",
-	["GLATGM-HE"] = "HE"
-}
-
 local function IsMissileAmmo( ent )
 	local bullet = ent and ent.BulletData or {}
 	local id = bullet.Id or ent.RoundId
-	local roundType = bullet.Type or (ACF.RoundTypes and ACF.RoundTypes[id] and ACF.RoundTypes[id].Type) or nil
 	local gun = (id and GunTable and GunTable[id]) or nil
 	local gunclass = (gun and gun.gunclass) or bullet.GunClass or ent.GunClass
 	local classData = gunclass and GunClasses and GunClasses[gunclass] or nil
 
-	if GLATGM_TYPES[roundType] then
-		return true
-	end
-
-	if GLATGM_TYPES[id] then
-		return true
-	end
-
 	return (classData and classData.type == "missile") or false
-end
-
-local function ResolveWarheadType( bullet )
-	local roundType = bullet and bullet.Type or nil
-	local heatTypes = {
-		HEAT = true,
-		THEAT = true,
-		HEATFS = true,
-		THEATFS = true
-	}
-	local heTypes = {
-		HE = true,
-		HESH = true,
-		HEFS = true
-	}
-
-	if roundType and GLATGM_TYPES[roundType] then
-		return MISSILE_WARHEAD_OVERRIDES[roundType] or "HE"
-	end
-
-	if roundType and heatTypes[roundType] then
-		return roundType
-	end
-
-	if roundType and heTypes[roundType] then
-		return "HE"
-	end
-
-	if roundType and ACF.RoundTypes and ACF.RoundTypes[roundType] then
-		return roundType
-	end
-
-	return "HE"
 end
 
 local function SpawnMiniHEFlash(ent, pos, radius)
@@ -136,6 +84,12 @@ local function GetCookoffConfig( ent, severity )
 		maxRounds = math.Clamp(math.ceil(maxRounds * 4), 20, 220)
 	end
 	local minRounds = math.Clamp(math.ceil(maxRounds * 0.35), 2, maxRounds)
+
+	if IsMissileAmmo(ent) then
+		-- Missile cookoff should be short and sporadic, not prolonged autocannon-like detonation.
+		maxRounds = math.Clamp(maxRounds, 1, 3)
+		minRounds = math.Clamp(math.ceil(maxRounds * 0.4), 1, maxRounds)
+	end
 
 	return {
 		SizeFactor = sizeFactor,
@@ -749,10 +703,9 @@ do
 			debugoverlay.Text(self:GetPos() + Vector(0,0,10), "Total Ammo Mass: " .. self.AmmoMassMax .. "kgs", 20 )
 
 			if WeaponType ~= "missile" then
-				self.ACEPoints = math.ceil(self.AmmoMassMax / 1000 * ACE.AmmoPerTon)
+				self.ACEPoints = math.ceil(self.AmmoMassMax / 1000 * ACE.LegacyAmmoPointsPerTon)
 			else
-				local BulletData2 = ACFM_CompactBulletData(self)
-				local MissileCost = CalculateMissileCost(BulletData2)
+				local MissileCost = CalculateMissileCost(self.BulletData)
 				self.ACEPoints = Capacity * MissileCost
 			end
 
@@ -962,12 +915,15 @@ function ENT:Think()
 					CookoffBullet.ProjMass = (CookoffBullet.ProjMass or 0) * 0.5
 					CookoffBullet.PropMass = (CookoffBullet.PropMass or 0) * 0.5
 					CookoffBullet.FillerMass = (CookoffBullet.FillerMass or 0) * 0.75
+					CookoffBullet.BoomFillerMass = (CookoffBullet.BoomFillerMass or CookoffBullet.FillerMass or 0) * 0.75
 					CookoffBullet.MuzzleVel	= (CookoffBullet.MuzzleVel or 0) * 0.75
+					local IsMissile = IsMissileAmmo(self)
 					local CookoffType = CrateType
-					if IsMissileAmmo( self ) then
-						CookoffType = ResolveWarheadType( CookoffBullet )
-						CookoffBullet.Type = CookoffType
+					if not ACF.RoundTypes[CookoffType] then
+						CookoffType = CrateType
 					end
+					CookoffBullet.Type = CookoffType
+
 					self.CreateShell = ACF.RoundTypes[CookoffType].create
 					self:CreateShell( CookoffBullet )
 
@@ -990,9 +946,12 @@ function ENT:Think()
 								util.Effect( "ACF_Scaled_Explosion", HEFlash )
 							end )
 
-							local HE       = self.BulletData.FillerMass	or 0
-							local Propel   = self.BulletData.PropMass	or 0
-							local HEWeight = ((HE + Propel * ACF.APAmmoDetonateFactor * (ACF.PBase / ACF.HEPower)) * ACF.BoomMult)
+							local MiniRoundType = self.BulletData.Type
+							local MiniClass = ACE_GetAmmoCookoffClass(MiniRoundType, IsMissile)
+							local HE = ACE_GetAmmoCookoffBlastMass(MiniRoundType, self.BulletData)
+							local Propel = self.BulletData.PropMass or 0
+							local PropScale = ACE_GetAmmoCookoffPropScale(MiniClass)
+							local HEWeight = ((HE + Propel * PropScale * ACF.APAmmoDetonateFactor * (ACF.PBase / ACF.HEPower)) * ACF.BoomMult)
 							local RunHE = self.CookoffHEToggle
 							self.CookoffHEToggle = not self.CookoffHEToggle
 

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -137,7 +137,7 @@ do
 		}
 		local PtsPerHP = 2.33 / 1.5 --Added 1.5 mul from torque boost antics for any engines without a defined hp cost.
 		local FallBackCost = (Engine.peakkw / 0.7457) * PtsPerHP * (FuelCostMul[Engine.FuelType] or 1)
-		Engine.ACEPoints		= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointMul)
+		Engine.ACEPoints		= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointCostMultiplier)
 
 		Engine.TorqueScale	= ACF.TorqueScale[Engine.EngineType]
 
@@ -241,7 +241,7 @@ function ENT:Update( ArgsTable )
 	}
 	local PtsPerHP = 2.33 / 1.5 --Added 1.5 mul from torque boost antics for any engines without a defined hp cost.
 	local FallBackCost = (self.peakkw / 0.7457) * PtsPerHP * (FuelCostMul[self.FuelType] or 1)
-	self.ACEPoints			= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointMul)
+	self.ACEPoints			= math.ceil((Lookup.acepoints or FallBackCost or 0.404) * ACE.EnginePointCostMultiplier)
 
 	self.TorqueScale		= ACF.TorqueScale[self.EngineType]
 

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -172,7 +172,7 @@ do
 		Gun.Class           = Lookup.gunclass
 		Gun.Heat            = ACE.AmbientTemp
 		Gun.LinkRangeMul    = math.max(Gun.Caliber / 10,1) ^ 1.2
-		Gun.ACEPoints		= (Lookup.acepoints or 0.404) * ACE.CannonPointMul
+		Gun.ACEPoints		= (Lookup.acepoints or 0.404) * ACE.GunPointCostMultiplier
 		Gun.RequiresGunner	= false
 		local GunnerExcluded	= Lookup.gunnerexception or false
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -672,7 +672,7 @@ function ENT:AddMissile(MissileSlot) --Where the majority of the missile paramat
 	self.ReloadDelay = ACF_GetRackValue(BulletData, "reloaddelay") or ACF_GetGunValue(BulletData.Id, "reloaddelay") or 1
 	self.Inaccuracy = ACF_GetRackValue(BulletData, "inaccuracy") or ACF_GetGunValue(BulletData.Id, "inaccuracy") or 0
 
-	missile.ACEPoints = CalculateMissileCost(BulletData)
+	missile.ACEPoints = CalculateMissileCost(Crate.BulletData)
 
 	if missile:IsValid() then
 		self:EmitSound("acf_extra/tankfx/gnomefather/reload12.wav", 500, 110)
@@ -1047,9 +1047,10 @@ do
 	--Jank terrible bad hardcoded function to copy bullet data over so it can be spawned by the missle. Has variables to convert every type of round data. There has to be a better way.
 	function BulletDataMath(self)
 
+		local SourceData = self.Bulletdata2 or self.BulletData or {}
 
 		self.Bulletdata2 = {}
-		self.Bulletdata2.Type = self.BulletData.Type
+		self.Bulletdata2.Type = SourceData.Type or self.BulletData.Type
 
 		--print(self.Bulletdata2.Type)
 
@@ -1059,18 +1060,18 @@ do
 			self.Bulletdata2.FuseLength = 0.2 --The missile exploded. The shell shouldn't travel across the map.
 		end
 
-		self.Bulletdata2.Id = self.BulletData.Id
-		self.Bulletdata2.Caliber = self.BulletData.Caliber
-		self.Bulletdata2.PropLength = self.BulletData.PropLength --Volume of the case as a cylinder * Powder density converted from g to kg
-		self.Bulletdata2.ProjLength = self.BulletData.ProjLength --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
-		self.Bulletdata2.Data5 = self.BulletData.BoomFillerMass or self.BulletData.FillerMass or 0 --He Filler or Flechette count
-		self.Bulletdata2.Data6 = self.BulletData.Data6 or 55 --HEAT ConeAng or Flechette Spread
-		self.Bulletdata2.Data7 = self.BulletData.Data7
-		self.Bulletdata2.Data8 = self.BulletData.Data8
-		self.Bulletdata2.Data9 = self.BulletData.Data9
-		self.Bulletdata2.Data10 = self.BulletData.Data10 -- Tracer
-		self.Bulletdata2.Data13 = self.BulletData.Data13 or 55 --THEAT ConeAng2
-		self.Bulletdata2.Data14 = self.BulletData.Data14 or 0.05 --THEAT HE Allocation
+		self.Bulletdata2.Id = SourceData.Id or self.BulletData.Id
+		self.Bulletdata2.Caliber = SourceData.Caliber or self.BulletData.Caliber
+		self.Bulletdata2.PropLength = SourceData.PropLength or self.BulletData.PropLength --Volume of the case as a cylinder * Powder density converted from g to kg
+		self.Bulletdata2.ProjLength = SourceData.ProjLength or self.BulletData.ProjLength --Volume of the projectile as a cylinder * streamline factor (Data5) * density of steel
+		self.Bulletdata2.Data5 = SourceData.BoomFillerMass or SourceData.FillerMass or self.BulletData.BoomFillerMass or self.BulletData.FillerMass or 0 --He Filler or Flechette count
+		self.Bulletdata2.Data6 = SourceData.Data6 or self.BulletData.Data6 or 55 --HEAT ConeAng or Flechette Spread
+		self.Bulletdata2.Data7 = SourceData.Data7 or self.BulletData.Data7
+		self.Bulletdata2.Data8 = SourceData.Data8 or self.BulletData.Data8
+		self.Bulletdata2.Data9 = SourceData.Data9 or self.BulletData.Data9
+		self.Bulletdata2.Data10 = SourceData.Data10 or self.BulletData.Data10 -- Tracer
+		self.Bulletdata2.Data13 = SourceData.Data13 or self.BulletData.Data13 or 55 --THEAT ConeAng2
+		self.Bulletdata2.Data14 = SourceData.Data14 or self.BulletData.Data14 or 0.05 --THEAT HE Allocation
 
 		--print(self.BulletData.Data14)
 
@@ -1080,9 +1081,9 @@ do
 
 		--
 		self.Bulletdata2.AmmoType = self.Bulletdata2.Type
-		self.Bulletdata2.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
-		self.Bulletdata2.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
-		self.Bulletdata2.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
+		self.Bulletdata2.FrArea = 3.1416 * (self.Bulletdata2.Caliber / 2) ^ 2
+		self.Bulletdata2.ProjMass = self.Bulletdata2.FrArea * (self.Bulletdata2.ProjLength * 7.9 / 1000)
+		self.Bulletdata2.PropMass = self.Bulletdata2.FrArea * (self.Bulletdata2.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 
 
 		self.Bulletdata2.FillerMass = self.Bulletdata2.Data5
@@ -1293,53 +1294,9 @@ function ENT:ACF_OnDamage( Entity, Energy, FrArea, _, Inflictor, _, _ )	--This f
 end
 
 do
-	local DefaultGuidanceFactors = {
-		Dumb = 0.3,
-		Straight_Running = 0.45,
-		GPS = 0.6,
-		Antimissile = 0.6,
-		AntiRadiation = 0.7,
-		Beam_Riding = 0.7,
-		GPS_TerrainAvoidant = 0.8,
-		SACLOS = 0.75,
-		Semiactive = 0.85,
-		Wire = 1.0,
-		Acoustic_Straight = 1.0,
-		Acoustic_Helical = 1.0,
-		Laser = 1.2,
-		Infrared = 1.2,
-		Top_Attack_IR = 1.5,
-		Radar = 1.5
-	}
-
 	-- Calculates per-missile points for rack/ammo entities.
 	-- ATGMs use the same performance model as gun ammo, blended with legacy pointcost for continuity.
 	function CalculateMissileCost(BulletData)
-		local legacyPts = ACF_GetRackValue(BulletData, "pointcost") or ACF_GetGunValue(BulletData.Id, "pointcost") or 0
-		local guid = BulletData.Data7 or "Dumb"
-		local guidanceFactors = ACE.MissileGuidanceFactors or DefaultGuidanceFactors
-		local factor = guidanceFactors[guid] or guidanceFactors.Dumb or 1
-
-		local gunClass = ACF_GetGunValue(BulletData.Id, "gunclass")
-		local basePts = legacyPts
-
-		if gunClass == "ATGM" then
-			local cfg = ACE.ATGMCostConfig or {}
-			local perfPts = ACE_GetAmmoRoundPoints(BulletData)
-			local perfMul = cfg.PerformanceMul or 1
-			local legacyWeight = math.Clamp(cfg.LegacyWeight or 0, 0, 1)
-			local minBase = cfg.MinBase or 25
-
-			if perfPts > 0 then
-				basePts = perfPts * perfMul
-				if legacyPts > 0 and legacyWeight > 0 then
-					basePts = basePts * (1 - legacyWeight) + legacyPts * legacyWeight
-				end
-			end
-
-			basePts = math.max(basePts, minBase)
-		end
-
-		return basePts * factor
+		return ACE_CalcMissileLegacyRoundCost(BulletData)
 	end
 end

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -14,8 +14,10 @@ if CLIENT then
 	TOOL.Information = {
 		{ name = "left" },
 		{ name = "right" },
-		{ name = "reload" }
+		{ name = "reloadhint" }
 	}
+
+	language.Add("tool.acfarmorprop.reloadhint", "Get information about contraption (double-tap R for preview values)")
 end
 
 -- Shared panel state used across panel rebuilds to keep UI controls stable.
@@ -162,17 +164,13 @@ function TOOL:Reload( trace )
 		return value
 	end
 
-	local function normalizePointDetails(rawDetails, armorLineSource)
+	local function normalizePointDetails(rawDetails)
 		local source = istable(rawDetails) and rawDetails or {}
 		local details = {
 			Items = istable(source.Items) and source.Items or {},
-			AmmoLines = istable(source.AmmoLines) and source.AmmoLines or {},
-			ArmorLines = istable(source.ArmorLines) and source.ArmorLines or {}
+			AmmoLines = {},
+			ArmorLines = {}
 		}
-
-		if istable(armorLineSource) then
-			details.ArmorLines = armorLineSource
-		end
 
 		return details
 	end
@@ -188,7 +186,6 @@ function TOOL:Reload( trace )
 
 	local Contraption = ent:GetContraption() or nil
 	local details = Contraption and Contraption.ACEPointsDetails or nil
-	local armorLines = Contraption and Contraption.ACEArmorDetails or nil
 	local PointVal		= 0
 
 	local PtsArmor = 0
@@ -288,7 +285,7 @@ function TOOL:Reload( trace )
 		sideArm = HypoSide
 	end
 
-	local netDetails = normalizePointDetails(details, armorLines)
+	local netDetails = normalizePointDetails(details)
 
 	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {}, netDetails }
 	local ToJSON		= util.TableToJSON( GeneralTb )
@@ -795,6 +792,7 @@ if CLIENT then
 		local power		= net.ReadFloat() -- Preserve precision for hp/ton calculation.
 		local LegacyCost	= math.Round( net.ReadFloat(), 1 )
 		local CostDisplay	= math.Round( LegacyCost * 100, 0 )
+		local CostDisplayText = string.Comma(math.max(math.floor(CostDisplay), 0))
 
 
 		local hpton		= math.Round( power / (total / 1000), 1 )
@@ -806,7 +804,7 @@ if CLIENT then
 		local PtsAmmo = math.Round( net.ReadFloat(), 1 )
 		local PtsAmmoReady = math.Round( net.ReadFloat(), 1 )
 		local PtsAmmoBackup = math.Round( net.ReadFloat(), 1 )
-		local AmmoReadyRounds = math.Round( net.ReadFloat(), 0 )
+		net.ReadFloat()
 		local _ = math.Round( net.ReadFloat(), 0 )
 		local PtsCrew = math.Round( net.ReadFloat(), 1 )
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
@@ -919,7 +917,7 @@ if CLIENT then
 		SummaryPoints = { Color4, "-Points Cost: ", Color3, "" .. PointVal .. "pts" .. Sep }
 	end
 
-	local SummaryCost = { Color4, "-Manufacturing Cost: ", Color3, "$" .. CostDisplay .. Sep }
+	local SummaryCost = { Color4, "-Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep }
 	local TMass2 = {
 		Color4, "-Mass Ratio: ", Color3, "" .. phystotal .. "kg",
 		Color4, " physical, ", Color3, "" .. parenttotal .. "kg",
@@ -998,7 +996,7 @@ if CLIENT then
 			})
 		end
 		if not ArmorInitMissing and fullReadout then
-			table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplay .. Sep })
+			table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep })
 		end
 	else
 		Tabletxt = table.Add(Tabletxt, PTBreakdownHeader)
@@ -1018,7 +1016,7 @@ if CLIENT then
 			TPoints = { Color4, totalLabel, Color3, "" .. PointVal .. "pts" .. Sep }
 		end
 		table.Add(Tabletxt, TPoints)
-		table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplay .. Sep })
+		table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep })
 		if ArmorDirty then
 			table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
 		elseif ArmorInitMissing and not HypoUsed then
@@ -1059,8 +1057,6 @@ if CLIENT then
 					end
 					table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
 				end
-			elseif AmmoReadyRounds > 0 then
-				table.Add(Tabletxt, { Color3, "    " .. AmmoReadyRounds .. " rds READY" .. Sep })
 			end
 		end
 		table.Add(Tabletxt, { Color4, "Crew: ", Color3, "(" .. pct(PtsCrew, PointVal) .. "%) - ", PtsCrew .. FractionalPts .. Sep })
@@ -1150,7 +1146,6 @@ if CLIENT then
 
 	-- Draw the hover tooltip and popup text.
 	function TOOL:DrawHUD()
-
 		local ent = self:GetOwner():GetEyeTrace().Entity
 		if not IsValid( ent ) or ent:IsPlayer() then return end
 
@@ -1174,8 +1169,17 @@ if CLIENT then
 
 		local pointLine = ""
 		if acepointcost > 0 then
-			pointLine = string.format("%s: %spts\n", pointLabel, math.Round(acepointcost, 1))
+			local roundedPoints = math.Round(acepointcost, 1)
+			local whole = math.floor(roundedPoints)
+			local frac = math.floor((roundedPoints - whole) * 10 + 0.5)
+			local pointText = string.Comma(whole)
+			if frac > 0 then
+				pointText = pointText .. "." .. frac
+			end
+			pointLine = string.format("%s: %spts\n", pointLabel, pointText)
 		end
+
+		local costText = string.Comma(math.max(math.Round(acecost * 100, 0), 0))
 
 		local text = string.format(overlayTextFormat,
 			math.Round(curmass, 2),
@@ -1187,7 +1191,7 @@ if CLIENT then
 			math.Round(health, 2),
 			MatData.sname,
 			pointLine,
-			math.Round(acecost * 100, 0)
+			costText
 		)
 
 		local pos = ent:WorldSpaceCenter()

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -411,6 +411,25 @@ local function ACE_GetAmmoCostForCaliber(con, caliberMm)
 	return total
 end
 
+-- Sum ammo points for crates compatible with a rack.
+local function ACE_GetAmmoCostForRack(con, rack)
+	if not con or not con.ents or not IsValid(rack) then return 0 end
+	if not ACF_CanLinkRack or not rack.Id then return 0 end
+
+	local total = 0
+
+	for ent in pairs(con.ents) do
+		if IsValid(ent) and ent:GetClass() == "acf_ammo" then
+			local bdata = ent.BulletData
+			if istable(bdata) and ACF_CanLinkRack(rack.Id, bdata.Id, bdata, rack) then
+				total = total + (ACE_GetAmmoCratePointsForContraption(ent, con, ent) or 0)
+			end
+		end
+	end
+
+	return total
+end
+
 -- Resolve point category for a class.
 local function ACE_GetPointsCategory(ent)
 	if not IsValid(ent) then return nil end
@@ -423,7 +442,7 @@ end
 
 -- Compute popup points and label for an entity.
 -- Order: entity points, gun-caliber ammo total, then category total.
-local ArmorPopupDebug = SERVER and CreateConVar("ace_debug_armor_popup", "0", FCVAR_ARCHIVE, "Debug armor popup per-entity contribution lookup.", 0, 1) or nil
+local ArmorPopupDebug = SERVER and CreateConVar("acf_debug_armor_popup", "0", FCVAR_ARCHIVE, "Debug armor popup per-entity contribution lookup.", 0, 1) or nil
 local ArmorPopupDebugLast = {}
 
 local function ACE_DebugArmorPopup(ply, ent, con, matchedRow)
@@ -473,6 +492,14 @@ local function ACE_GetPopupPoints(ent, ply)
 			end
 
 			return points, label
+		end
+	end
+
+	-- Racks fall back to the ammo cost of crates compatible with this rack.
+	if cls == "acf_rack" then
+		local ammoCost = ACE_GetAmmoCostForRack(con, ent)
+		if ammoCost > 0 then
+			return ammoCost, "Total Rack Ammo Cost"
 		end
 	end
 

--- a/resource/localization/en/armoredcombatextended.properties
+++ b/resource/localization/en/armoredcombatextended.properties
@@ -4,6 +4,7 @@ tool.acfarmorprop.desc=Sets the ACE armour of an entity
 tool.acfarmorprop.left=Apply armour settings
 tool.acfarmorprop.right=Copy armour settings
 tool.acfarmorprop.reload=Get information about contraption
+tool.acfarmorprop.reloadhint=Get information about contraption (double-tap R for preview values)
 tool.acfarmorprop.thickness=Thickness
 tool.acfarmorprop.thicknessdesc=Set the desired armor thickness (in mm) and the mass will be adjusted accordingly.
 tool.acfarmorprop.ductility=Ductility


### PR DESCRIPTION
## Summary
Splits out the points/cost and legality-readout changes into an isolated PR for easier review.

## Included commits
- Refactor point/cost config and armor tool readouts
- Show total linked rack ammo cost in armor tool popup
- Fix missile guidance factor resolution in ammo threat cost
- Unify trace filter integration and update core cost config defaults

## Main areas touched
- `sv_pointshandling.lua`
- `sv_contraptionlegality.lua` + related legality/readout helpers
- `acfarmorprop` tool readout flow
- `acf_globals` point/cost defaults and aliases
- related ammo/rack cost-path plumbing

## Intent
Keep cost/readout behavior coherent and tunable while improving consistency in legality + UI-facing totals.

## Validation
- Focused lint on changed files
- Runtime smoke checks recommended:
  - armor popup values
  - linked rack ammo total display
  - legality dirty/cache clear behavior
`