### PR TITLE
Combat systems pass: missile/fuze/round normalization and cookoff handling

### DIFF
--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -669,8 +669,8 @@ function GenerateMissile(MissileData,Crate,BData) --Shorthand function for gener
 	missile.StraightRunning = MissileData.DelayPrediction or 0.5
 	missile.MinStartDelay = MissileData.ArmDelay or 0.3
 
-	missile.MissileVelocityMul = MissileData.MissileVelocityMul or 3
-	missile.MissileCalMul = MissileCalMul or 1
+	missile.MissileVelocityMul = MissileData.MissileVelocityMul or MissileData.velmul or ACF_GetGunValue(BData.Id, "velmul") or 3
+	missile.MissileCalMul = MissileData.MissileCalMul or MissileData.calmul or ACF_GetGunValue(BData.Id, "calmul") or 1
 
 	missile.UnderwaterThrust = MissileData.UnderwaterThrustType or 1
 	missile.Buoyancy = MissileData.Buoyancy or 0.5

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -212,7 +212,7 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	end
 
 	-- RHA Penetration
-	local maxPenetration = (Energy.Penetration / FrArea) * ACF.KEtoRHA
+	local maxPenetration = ACE_CalcPenetration(Energy, FrArea)
 
 	-- Projectile caliber. Messy, function signature
 	local caliber = 20 * (FrArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -418,19 +418,19 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 
 	-- Spall armor factor bias
 	local ArmorMul	= MatData.ArmorMul or 1
-	
+
 	-- Cal of 3 = 30mm.
 	local Minimum_Caliber = 3
 
-	if SpallMul > 0 and Caliber > Minimum_Caliber then 
-	
+	if SpallMul > 0 and Caliber > Minimum_Caliber then
+
 		local WeightFactor = MatData.massMod or 1
 		-- local Max_Spall_Mass = 10
 
 		local Velocityfactor = 0.5
 		local Max_Spall_Vel = 7000
 		local MassFactor = 10
-		
+
 		local Max_Spalls = 128
 
 		-- print("KE: " .. KE)
@@ -447,10 +447,10 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 		SpallWeight = SpallWeight * MassFactor
 		local SpallArea = 4 * (TotalWeight / SpallWeight)
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
-		
+
 
 		-- print("AR: " .. SpallArea)
-		
+
 		-- print("TW: " .. TotalWeight)
 
 		-- print("SW: " .. SpallWeight)
@@ -624,7 +624,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 
 	-- Spall armor factor bias
 	local ArmorMul	= MatData.ArmorMul or 1
-	
+
 	local UsedArmor	= Armour * ArmorMul
 
 	if SpallMul > 0 and ( HEFiller / 300 ) > UsedArmor then
@@ -635,7 +635,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		local Velocityfactor = 0.12
 		local Max_Spall_Vel = 7000
 		local MassFactor = 6
-		
+
 		local Max_Spalls = 128
 
 		-- print("HE: " .. HEFiller)
@@ -654,9 +654,9 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		SpallWeight = SpallWeight * MassFactor
 		local SpallArea = 4 * (TotalWeight / SpallWeight)
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
-		
+
 		-- print("AR: " .. SpallArea)
-		
+
 		-- print("TW: " .. TotalWeight)
 
 		-- print("SW: " .. SpallWeight)
@@ -665,7 +665,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		-- print("VEL: " .. SpallVel)
 
 		-- PrintTable(Filter)
-		
+
 		for i = 1,Spall do
 
 			ACE.CurSpallIndex = ACE.CurSpallIndex + 1
@@ -675,12 +675,12 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 
 			-- Normal Trace creation
 			local Index = ACE.CurSpallIndex
-			
+
 			ACE.Spall[Index]			= {}
 			ACE.Spall[Index].start	= HitPos
 			ACE.Spall[Index].endpos	= HitPos + ((fNormal * 2500 + HitVec):GetNormalized() + VectorRand() / 3):GetNormalized() * math.max( SpallVel / 8, 600) --I got bored of spall not going across the tank
 			ACE.Spall[Index].filter	= table.Copy(Temp_Filter)
-			
+
 			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor, SpallVel)
 
 			--little sound optimization
@@ -719,7 +719,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
-			
+
 				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
@@ -734,8 +734,8 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		local MatData	= ACE_GetMaterialData( Mat )
 
 		local spall_resistance = MatData.spallresist
-		
-		-- The clamp is due to that if the material spall resist/armor is below 1 then it multiplies the penetration. 
+
+		-- The clamp is due to that if the material spall resist/armor is below 1 then it multiplies the penetration.
 		-- ^ Clamp keeps the variable at 1 or higher.
 		-- Such as why I have ceramic/textolite resistence set to 1 as that means spall doesnt lose energy when hitting it.
 		-- Two/three reasons why this is good ^:
@@ -751,9 +751,9 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		if ACE.CritEnts[ SpallRes.Entity:GetClass() ] then
 			SpallEnergy.Penetration = (SpallEnergy.Penetration / Entity_Crit_Hit_Factor)
 		end
-		
+
 		SpallEnergy.Penetration = math.floor(SpallEnergy.Penetration)
-		
+
 		-- print(SpallEnergy.Penetration)
 
 		-- Applies the damage to the impacted entity
@@ -776,24 +776,24 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
-				
+
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
 			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
-			
+
 			SpallRes = util.TraceLine(ACE.Spall[Index])
 
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
 			-- Blue trace means spall trace that overpenned and killed something.
-			
+
 			-- Retry
 			ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
-		else 
-			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )	
+		else
+			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )
 			-- Red trace means spall trace that did hit something.
 		end
 

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -632,8 +632,9 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		local WeightFactor = MatData.massMod or 1
 		-- local Max_Spall_Mass = 20
 
-		local Velocityfactor = 0.2
+		local Velocityfactor = 0.12
 		local Max_Spall_Vel = 7000
+		local MassFactor = 6
 		
 		local Max_Spalls = 128
 
@@ -644,11 +645,14 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 		-- print("Cal: ".. Caliber)
 		-- print("Cal: ".. Cal_In_MM)
 
-		local Spall = math.min(math.floor(Caliber * HEFiller * SpallMul * 5) * ACF.SpallMult, Max_Spalls)
+		local EquivalentFillerKg = math.max(HEFiller / math.max(ACF.HEPower or 1, 1), 0)
+		local Spall = math.min(math.floor(Caliber * math.sqrt(EquivalentFillerKg) * SpallMul * 3) * ACF.SpallMult, Max_Spalls)
+		if Spall <= 0 then return end
 		local TotalWeight = (Spall / (Cal_In_MM * (PI / 180)))
 		local SpallWeight = ((TotalWeight / (Spall / 10)) + (ArmorMul + WeightFactor))
-		local SpallVel = ((HEFiller * Velocityfactor) / SpallWeight)
-		local SpallArea = (TotalWeight / SpallWeight)
+		local SpallVel = ((HEFiller * Velocityfactor) / math.max(SpallWeight, 0.1))
+		SpallWeight = SpallWeight * MassFactor
+		local SpallArea = 4 * (TotalWeight / SpallWeight)
 		local SpallEnergy = ACF_Kinetic(SpallVel, SpallWeight, Max_Spall_Vel)
 		
 		-- print("AR: " .. SpallArea)
@@ -1199,21 +1203,30 @@ do
 		APCR = true,
 		HVAP = true
 	}
-	local GunTable = ACF.Weapons.Guns
-	local GunClasses = ACF.Classes.GunClass
-
 	local function IsMissileAmmoData( bullet )
-		if not bullet then return false end
-		local roundType = bullet.Type
-		if roundType == "GLATGM" or roundType == "GLATGM-HE" then
-			return true
-		end
+		local gunClass = ACE_GetAmmoGunClass(bullet)
+		if not gunClass then return false end
 
-		local id = bullet.Id
-		local gun = (id and GunTable and GunTable[id]) or nil
-		local gunclass = (gun and gun.gunclass) or bullet.GunClass
-		local classData = gunclass and GunClasses and GunClasses[gunclass] or nil
+		local classes = ACF and ACF.Classes and ACF.Classes.GunClass
+		local classData = classes and classes[gunClass] or nil
+
 		return classData and classData.type == "missile" or false
+	end
+
+	local function ResolveCookoffRoundType(ent, bullet)
+		return ACE_ResolveAmmoType(ent, bullet)
+	end
+
+	local function GetCookoffBlastMass(bullet, roundType)
+		return ACE_GetAmmoCookoffBlastMass(roundType, bullet)
+	end
+
+	local function GetCookoffAmmoCount(roundType, ammo, isMissile)
+		return ACE_GetAmmoCookoffAmmoCount(roundType, ammo, isMissile)
+	end
+
+	local function GetCookoffExplosionClass(roundType, isMissile)
+		return ACE_GetAmmoCookoffClass(roundType, isMissile)
 	end
 
 	--converts what would be multiple simultaneous cache detonations into one large explosion
@@ -1244,15 +1257,18 @@ do
 			DebugExplosion("FuelCalc", "Fuel", Fuel, "Capacity", Capacity, "Type", Type, "FuelScale", FuelExplosionScale, "HEWeight", HEWeight)
 		else
 
-			local HE       = ent.BulletData.FillerMass	or 0
+			local RoundTypeCook = ResolveCookoffRoundType(ent, ent.BulletData)
+			local HE       = GetCookoffBlastMass(ent.BulletData, RoundTypeCook)
 			local Propel   = ent.BulletData.PropMass	or 0
 			local Ammo     = ent.Ammo					or 0
 			local IsMissile = IsMissileAmmoData(ent.BulletData)
-			local PropScale = IsMissile and 0.35 or 1
-			local AmmoScale = IsMissile and MissileExplosionScale or AmmoExplosionScale
+			local AmmoCount = GetCookoffAmmoCount(RoundTypeCook, Ammo, IsMissile)
+			local CookClass = GetCookoffExplosionClass(RoundTypeCook, IsMissile)
+			local PropScale = ACE_GetAmmoCookoffPropScale(CookClass)
+			local AmmoScale = ACE_GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
 
-			HEWeight = ( ( HE + Propel * PropScale * ( ACF.PBase / ACF.HEPower ) ) * Ammo ) * AmmoScale
-			DebugExplosion("AmmoCalc", "HE", HE, "Propel", Propel, "Ammo", Ammo, "PropScale", PropScale, "AmmoScale", AmmoScale, "HEWeight", HEWeight, "EntIndex", ent:EntIndex())
+			HEWeight = ( ( HE + Propel * PropScale * ( ACF.PBase / ACF.HEPower ) ) * AmmoCount ) * AmmoScale
+			DebugExplosion("AmmoCalc", "Type", RoundTypeCook, "HE", HE, "Propel", Propel, "Ammo", Ammo, "AmmoCount", AmmoCount, "PropScale", PropScale, "AmmoScale", AmmoScale, "HEWeight", HEWeight, "EntIndex", ent:EntIndex())
 		end
 		DebugExplosion(
 			"Config",
@@ -1319,8 +1335,8 @@ do
 			remove
 		)
 		if (HEWeight or 0) <= 0 then
-			DebugExplosion("Adjust", "ZeroHEWeight", HEWeight, "UsingMin", MinHEWeight, "RoundType", RoundType, "RoundId", RoundId)
-			HEWeight = MinHEWeight
+			DebugExplosion("Adjust", "ZeroHEWeight", HEWeight, "RoundType", RoundType, "RoundId", RoundId)
+			HEWeight = 0
 		end
 
 		table.insert(ExplodePos, Pos)
@@ -1399,19 +1415,22 @@ do
 
 							if Found.RoundType == "Refill" then Found:Remove() continue end
 
-							local HE       = Found.BulletData.FillerMass	or 0
+							local RoundTypeCook = ResolveCookoffRoundType(Found, Found.BulletData)
+							local HE       = GetCookoffBlastMass(Found.BulletData, RoundTypeCook)
 							local Propel   = Found.BulletData.PropMass	or 0
 							local Ammo     = Found.Ammo					or 0
 							local IsMissile = IsMissileAmmoData(Found.BulletData)
-							local PropScale = IsMissile and 0.35 or 1
-							local AmmoScale = IsMissile and MissileExplosionScale or AmmoExplosionScale
+							local AmmoCount = GetCookoffAmmoCount(RoundTypeCook, Ammo, IsMissile)
+							local CookClass = GetCookoffExplosionClass(RoundTypeCook, IsMissile)
+							local PropScale = ACE_GetAmmoCookoffPropScale(CookClass)
+							local AmmoScale = ACE_GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
 
 							local AmmoHEWeight = ( HE + Propel * PropScale * ACF.APAmmoDetonateFactor * ( ACF.PBase / ACF.HEPower))
 							if AmmoHEWeight > HighestHEWeight then
 								HighestHEWeight = AmmoHEWeight
 							end
 
-							FoundHEWeight = ( AmmoHEWeight * Ammo ) * AmmoScale
+							FoundHEWeight = ( AmmoHEWeight * AmmoCount ) * AmmoScale
 							local RoundType = Found.BulletData and Found.BulletData.Type or "nil"
 							local IsKinetic = HE <= 0 and KineticRoundTypes[RoundType]
 							if IsKinetic then
@@ -1438,7 +1457,7 @@ do
 								"Found",
 								Found:EntIndex(),
 								"Type",
-								RoundType,
+								RoundTypeCook,
 								"RoundId",
 								Found.BulletData and Found.BulletData.Id or "nil",
 								"Caliber",
@@ -1447,6 +1466,8 @@ do
 								Found.BulletData and Found.BulletData.ProjMass or "nil",
 								"Ammo",
 								Ammo,
+								"AmmoCount",
+								AmmoCount,
 								"HE",
 								HE,
 								"Propel",
@@ -1529,6 +1550,10 @@ do
 			DebugExplosion("Adjust", "ZeroHEWeight", HEWeight, "UsingMin", MinHEWeight)
 			HEWeight = MinHEWeight
 		end
+		if MaxHE and HEWeight > MaxHE then
+			DebugExplosion("Clamp", "Reason", "HEWeightOverMax", "Before", HEWeight, "MaxHE", MaxHE)
+			HEWeight = MaxHE
+		end
 
 		Radius	= ACE_CalculateHERadius( HEWeight )
 
@@ -1552,9 +1577,6 @@ do
 			"HighestHEWeight",
 			HighestHEWeight
 		)
-		if MaxHE and HEWeight > MaxHE then
-			DebugExplosion("ClampSuggest", "Reason", "HEWeightOverMax", "HEWeight", HEWeight, "MaxHE", MaxHE)
-		end
 		ACF_HE( AvgPos , vector_origin , HEWeight , HEWeight , Inflictor , ent, ent, BlastPenRatio )
 
 		--util.Effect not working during MP workaround. Waiting a while fixes the issue.

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -495,7 +495,7 @@ end
 
 end
 
-concommand.Add("acf_armor_dirty_log_dump", function(_, _, args)
+concommand.Add("ace_armor_dirty_log_dump", function(_, _, args)
 	if not armorDebugCvar:GetBool() then
 		print("[ACE] ace_armor_debug is 0")
 		return
@@ -526,7 +526,7 @@ concommand.Add("acf_armor_dirty_log_dump", function(_, _, args)
 	end
 end)
 
-concommand.Add("acf_armor_dirty_log_clear", function()
+concommand.Add("ace_armor_dirty_log_clear", function()
 	armorDirtyLog = {}
 	print("[ACE] Cleared stored armor log")
 end)
@@ -635,7 +635,7 @@ local function ACE_ClearAllCaches()
 	ACE.CacheVersion = (ACE.CacheVersion or 1) + 1
 end
 
-concommand.Add("acf_cache_clear_all", function()
+concommand.Add("ace_cache_clear_all", function()
 	ACE_ClearAllCaches()
 end)
 
@@ -707,6 +707,7 @@ end)
 
 
 -- Armor scan and rebuild logic live in sv_pointshandling.lua
+
 
 
 

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -403,8 +403,7 @@ end
 -- Debug logging 
 -- ------------------------------------------------------------
 
-ACE.ArmorDebugCvar = ACE.ArmorDebugCvar or CreateConVar(
-	"ace_armor_debug",
+ACE.ArmorDebugCvar = ACE.ArmorDebugCvar or CreateConVar("acf_armor_debug",
 	"0",
 	FCVAR_ARCHIVE,
 	ACE_ConVarHelp("Enable stored armor dirty logging (no live console spam).")
@@ -412,8 +411,7 @@ ACE.ArmorDebugCvar = ACE.ArmorDebugCvar or CreateConVar(
 
 local armorDebugCvar = ACE.ArmorDebugCvar
 
-local armorDirtyLogLimit = CreateConVar(
-	"ace_armor_dirty_log_limit",
+local armorDirtyLogLimit = CreateConVar("acf_armor_dirty_log_limit",
 	"120",
 	FCVAR_ARCHIVE,
 	ACE_ConVarHelp("How many stored dirty entries to keep.")
@@ -497,7 +495,7 @@ end
 
 end
 
-concommand.Add("ace_armor_dirty_log_dump", function(_, _, args)
+concommand.Add("acf_armor_dirty_log_dump", function(_, _, args)
 	if not armorDebugCvar:GetBool() then
 		print("[ACE] ace_armor_debug is 0")
 		return
@@ -528,7 +526,7 @@ concommand.Add("ace_armor_dirty_log_dump", function(_, _, args)
 	end
 end)
 
-concommand.Add("ace_armor_dirty_log_clear", function()
+concommand.Add("acf_armor_dirty_log_clear", function()
 	armorDirtyLog = {}
 	print("[ACE] Cleared stored armor log")
 end)
@@ -609,8 +607,7 @@ ACE.DupeArmorCacheVersion = ACE.DupeArmorCacheVersion or 1
 ACE.DupeArmorCacheLastClear = ACE.DupeArmorCacheLastClear or CurTime()
 ACE.DupeSubsystemCacheLastClear = ACE.DupeSubsystemCacheLastClear or CurTime()
 
-local DupeArmorCacheTtl = CreateConVar(
-	"ace_dupe_armor_cache_ttl",
+local DupeArmorCacheTtl = CreateConVar("acf_dupe_armor_cache_ttl",
 	"1800",
 	FCVAR_ARCHIVE,
 	ACE_ConVarHelp("Seconds between clearing the dupe armor cache (0 disables).")
@@ -638,7 +635,7 @@ local function ACE_ClearAllCaches()
 	ACE.CacheVersion = (ACE.CacheVersion or 1) + 1
 end
 
-concommand.Add("ace_cache_clear_all", function()
+concommand.Add("acf_cache_clear_all", function()
 	ACE_ClearAllCaches()
 end)
 

--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -6,7 +6,7 @@
 
 include("acf/shared/sh_crewseat_base.lua")
 
-local crewseatDebug = CreateConVar("ace_debug_crewseat_models", "0", FCVAR_ARCHIVE, "Log crewseat model/type changes during dupe paste")
+local crewseatDebug = CreateConVar("acf_debug_crewseat_models", "0", FCVAR_ARCHIVE, "Log crewseat model/type changes during dupe paste")
 
 -- Resolve a crewseat model type from dupe data or the current model path.
 function ACE_CrewseatResolveModelType(ent, info)
@@ -120,7 +120,7 @@ end
 ACE = ACE or {}
 
 -- Dump crewseat state for debugging from console.
-concommand.Add("ace_crewseat_dump", function(_, _, args)
+concommand.Add("acf_crewseat_dump", function(_, _, args)
 	local target = tonumber(args[1] or "")
 
 	local function dumpSeat(ent)

--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -120,7 +120,7 @@ end
 ACE = ACE or {}
 
 -- Dump crewseat state for debugging from console.
-concommand.Add("acf_crewseat_dump", function(_, _, args)
+concommand.Add("ace_crewseat_dump", function(_, _, args)
 	local target = tonumber(args[1] or "")
 
 	local function dumpSeat(ent)
@@ -441,3 +441,4 @@ function ACE_FindReplacementLoader(ent, maxDistSqr)
 
 	return replaceEnt, closestDist
 end
+

--- a/lua/acf/shared/armor/du.lua
+++ b/lua/acf/shared/armor/du.lua
@@ -13,7 +13,7 @@ Material.curve		= 1.06 --Slight and almost unnoticable penalty to high thickness
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
-Material.effectiveness  = 3.0
+Material.effectiveness  = 2.3
 Material.resiliance	= 0.9
 
 Material.spallresist	= 1

--- a/lua/acf/shared/armor/du.lua
+++ b/lua/acf/shared/armor/du.lua
@@ -13,7 +13,7 @@ Material.curve		= 1.06 --Slight and almost unnoticable penalty to high thickness
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
-Material.effectiveness  = 2.3
+Material.effectiveness  = 3.0
 Material.resiliance	= 0.9
 
 Material.spallresist	= 1

--- a/lua/acf/shared/armor/titanium.lua
+++ b/lua/acf/shared/armor/titanium.lua
@@ -4,7 +4,7 @@ local Material		= {}
 Material.id			= "Ti"
 Material.name		= "Titanium"
 Material.sname		= "Titanium"
-Material.desc		= "Lightweight and super resiliant. But E X P E N S I V E. 60% Lighter than RHA for a given thickness.\nUnlike aluminum works at high thicknesses but for a price."
+Material.desc		= "Lightweight and super resiliant. But E X P E N S I V E. 60% Lighter than RHA for a given thickness. Unlike aluminum works at high thicknesses but for a price."
 Material.year		= 1950 -- Dont blame about this, ik that RHA has existed before this year but it would be cool to see: when?
 
 Material.massMod		= 0.61
@@ -14,7 +14,7 @@ Material.curve		= 1 --Slight and almost unnoticable penalty to high thickness ar
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
 Material.effectiveness  = 1.7
-Material.resiliance	= 0.75
+Material.resiliance	= 0.87
 
 Material.spallresist	= 1
 

--- a/lua/acf/shared/armor/titanium.lua
+++ b/lua/acf/shared/armor/titanium.lua
@@ -4,7 +4,7 @@ local Material		= {}
 Material.id			= "Ti"
 Material.name		= "Titanium"
 Material.sname		= "Titanium"
-Material.desc		= "Lightweight and super resiliant. But E X P E N S I V E. 60% Lighter than RHA for a given thickness. Unlike aluminum works at high thicknesses but for a price."
+Material.desc		= "Lightweight and super resiliant. But E X P E N S I V E. 60% Lighter than RHA for a given thickness.\nUnlike aluminum works at high thicknesses but for a price."
 Material.year		= 1950 -- Dont blame about this, ik that RHA has existed before this year but it would be cool to see: when?
 
 Material.massMod		= 0.61
@@ -14,7 +14,7 @@ Material.curve		= 1 --Slight and almost unnoticable penalty to high thickness ar
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
 
 Material.effectiveness  = 1.7
-Material.resiliance	= 0.87
+Material.resiliance	= 0.75
 
 Material.spallresist	= 1
 

--- a/lua/acf/shared/fuses/a_contact.lua
+++ b/lua/acf/shared/fuses/a_contact.lua
@@ -51,7 +51,7 @@ end
 
 
 function this:IsArmed()
-	return self.TimeStarted + self.Primer <= CurTime()
+	return self.TimeStarted and (self.TimeStarted + self.Primer <= CurTime()) or false
 end
 
 

--- a/lua/acf/shared/fuses/c_radio.lua
+++ b/lua/acf/shared/fuses/c_radio.lua
@@ -76,12 +76,13 @@ do
 
 		local Class = ent:GetClass()
 
-		--Skip ents like world entities
-		if whitelist[Class] then
-			return true
-		end
+		-- Return true to skip entities that are not valid radio fuze targets.
+		return not whitelist[Class]
+	end
 
-		return false
+	function this:Configure(Missile)
+		self:super().Configure(self, Missile)
+		Missile.DPos = Missile:GetPos()
 	end
 
 	--Question: Should radio fuze be limited to detect props in front of the missile only? Its weird it detonates by detecting something behind it.
@@ -91,72 +92,35 @@ do
 
 		if not self:IsArmed() then return false end
 
-		local MissilePos = missile.CurPos
-		local Dist = self.Distance
+		local MissilePos = missile.CurPos or missile:GetPos()
 
-		local trace = {}
-		trace.start         = missile.DPos or MissilePos
-		trace.endpos        = MissilePos --small compensation for incoming impacts.
-		trace.filter        = FilterFunction
-		trace.mins          = Vector(-Dist, -Dist, -Dist)
-		trace.maxs          = -trace.mins
-		trace.ignoreworld   = true
+		for _, HitEnt in ipairs(ents.FindInSphere(MissilePos, self.Distance)) do
+			if not IsValid(HitEnt) or HitEnt == missile then continue end
+			if FilterFunction(HitEnt) then continue end
 
-		missile.DPos = MissilePos
+			if CPPIOwn == HitEnt:CPPIGetOwner() then continue end
 
-		local tr = util.TraceHull(trace)
+			local HitPos = HitEnt:NearestPoint(MissilePos)
+			local tolocal = missile:WorldToLocal(HitPos)
+			if tolocal.x <= 0 then continue end
 
-		if tr.Hit then
+			if CFW then
+				local conLauncher = missile.Launcher and missile.Launcher:GetContraption() or nil
+				local conTarget = HitEnt:GetContraption() or nil
 
-			local HitEnt = tr.Entity
+				if conLauncher and conTarget and conLauncher == conTarget then
+					continue
+				end
+			else
+				local HitId = HitEnt.ACF and HitEnt.ACF.ContraptionId or nil
+				local OwnId = missile.ContrapId or nil
 
-			if CPPIOwn == HitEnt:CPPIGetOwner() then return false end
-
-			if ACF_Check( HitEnt ) then
-
-				local HitPos	= HitEnt:GetPos()
-				local tolocal	= missile:WorldToLocal(HitPos)
-
-				-- Cool
-				if CFW then
-
-					local conLauncher = missile.Launcher:GetContraption() or {}
-					local conTarget = HitEnt:GetContraption() or {} -- 1 prop will not have a contraption. 2 linked props (weld, parent) will do.
-
-					if conLauncher and conTarget then -- We only care about real contraptions. Not single props.
-
-						if conLauncher ~= conTarget and tolocal.x > 0 then
-
-							debugoverlay.Text(HitPos + Vector(0,0,20), "[CFW]- Valid Hit On: " .. (HitEnt:GetClass()) , 5 )
-							debugoverlay.Box(MissilePos, trace.mins, trace.maxs, 1, Color(0,255,0,10))
-
-							return true
-						end
-
-						debugoverlay.Text(HitPos + Vector(0,0,20), "[CFW] Invalid Hit on: " .. (HitEnt:GetClass()) , 5 )
-						debugoverlay.Box(MissilePos, trace.mins, trace.maxs, 1, Color(255,0,0,10))
-
-					end
-
-				-- Not Cool
-				else
-
-					local HitId	= HitEnt.ACF.ContraptionId or 1
-					local OwnId	= missile.ContrapId or 1
-
-					--Trigger the fuze if our hit was caused to an ent which is not ours, in front of it.
-					if HitId ~= OwnId and tolocal.x > 0 then
-
-						debugoverlay.Text(HitPos + Vector(0,0,20), "Valid Hit On: " .. (HitEnt:GetClass()) , 5 )
-						debugoverlay.Box(MissilePos, trace.mins, trace.maxs, 1, Color(0,255,0,10))
-						return true
-					end
-
-					debugoverlay.Text(HitPos + Vector(0,0,20), "Invalid Hit on: " .. (HitEnt:GetClass()) , 5 )
-					debugoverlay.Box(MissilePos, trace.mins, trace.maxs, 1, Color(255,0,0,10))
-
+				if HitId and OwnId and HitId == OwnId then
+					continue
 				end
 			end
+
+			return true
 		end
 
 		return false

--- a/lua/acf/shared/fuses/e_plunging.lua
+++ b/lua/acf/shared/fuses/e_plunging.lua
@@ -76,7 +76,7 @@ function this:GetDetonate(missile)
 			missile.Flight = missile:GetUp() * -missile.Flight:Length() * 0.01
 
 			missile.Bulletdata2.SlugMV = missile.Bulletdata2.SlugMV * 0.3
-			missile.Bulletdata2.SlugMV2 = missile.Bulletdata2.SlugMV * 0.3
+			missile.Bulletdata2.SlugMV2 = missile.Bulletdata2.SlugMV2 * 0.3
 
 			missile:SetAngles(missile.Flight:Angle())
 			missile:Detonate()

--- a/lua/acf/shared/fuses/f_overshoot.lua
+++ b/lua/acf/shared/fuses/f_overshoot.lua
@@ -46,6 +46,11 @@ configs[#configs + 1] =
 
 do
 
+	function this:Configure(Missile)
+		self:super().Configure(self, Missile)
+		self.fuseArmed = false
+	end
+
 	--Question: Should radio fuze be limited to detect props in front of the missile only? Its weird it detonates by detecting something behind it.
 	function this:GetDetonate(missile)
 
@@ -57,11 +62,11 @@ do
 		local missileTarget = missile.TargetPos
 
 		if not missileTarget then --Target Lost
-			
+
 			if not self.fuseArmed then
-				return false 
+				return false
 			else --The fuse was armed but we lost sight of the target. Detonate.
-				return true 				
+				return true
 			end
 		end
 
@@ -73,7 +78,7 @@ do
 		end
 
 		if self.fuseArmed and (missileTarget:DistToSqr( missilePos ) < missileTarget:DistToSqr( missilePos + missile.Flight )) then
-			
+
 
 			return true
 

--- a/lua/acf/shared/fuses/g_altitude.lua
+++ b/lua/acf/shared/fuses/g_altitude.lua
@@ -16,6 +16,7 @@ this.Name = ClassName
 
 this.Altitude = 0
 this.Above = true
+this.Active = false
 
 
 this.desc = "When specified with a target position, this fuse will detonate the missile once it crosses the altitude of the target position."
@@ -24,31 +25,33 @@ function this:Configure(Missile)
 	self.TimeStarted = CurTime()
 	Missile.IgnitionDelay = self.StartDelay
 	self.Primer = math.max(Missile.MinStartDelay,self.Primer)
+	self.Active = false
 
 	local launcher = Missile.Launcher
 
 	if not IsValid(launcher) then
-		return {}
+		return
 	end
 
-	local posVec = launcher.TargPos or vector_origin
+	local posVec = launcher.TargPos
+	if not isvector(posVec) then return end
+
 	local TarZ = posVec.z
-
-	if TarZ != 0 then
-		local MissileZ = Missile:GetPos().z
-		if MissileZ > TarZ then
-			self.Above = true
-		else
-			self.Above = false
-		end
-		self.Altitude = TarZ
+	local MissileZ = Missile:GetPos().z
+	if MissileZ > TarZ then
+		self.Above = true
+	else
+		self.Above = false
 	end
+	self.Altitude = TarZ
+	self.Active = true
 end
 
 -- Do nothing, projectiles auto-detonate on contact anyway.
 function this:GetDetonate(missile)
 
 	if not self:IsArmed() then return false end
+	if not self.Active then return false end
 
 	local MissileZ = missile:GetPos().z
 

--- a/lua/acf/shared/rounds/ace_roundfunctions.lua
+++ b/lua/acf/shared/rounds/ace_roundfunctions.lua
@@ -91,7 +91,7 @@ do
 		local D0 = DragCoef * V0 ^ 2 / ACF.DragDiv -- initial drag
 		local K1 = (D0 / (V0 ^ (3 / 2))) ^ -1 -- estimated drag coefficient
 		local Vel = math.max(math.sqrt(V0) - ((Range * 39.37) / (2 * K1)), 0) ^ 2
-		local Pen = (ACF_Kinetic(Vel, ProjMass, LimitVel).Penetration / PenArea) * ACF.KEtoRHA
+		local Pen = ACE_CalcPenetration(ACF_Kinetic(Vel, ProjMass, LimitVel), PenArea)
 
 		return Vel * 0.0254, Pen
 	end

--- a/lua/acf/shared/rounds/roundap.lua
+++ b/lua/acf/shared/rounds/roundap.lua
@@ -61,7 +61,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
-	GUIData.MaxPen = (Energy.Penetration / Data.PenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 

--- a/lua/acf/shared/rounds/roundapds.lua
+++ b/lua/acf/shared/rounds/roundapds.lua
@@ -122,7 +122,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
-	GUIData.MaxPen = (Energy.Penetration / Data.PenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 

--- a/lua/acf/shared/rounds/roundapfsds.lua
+++ b/lua/acf/shared/rounds/roundapfsds.lua
@@ -101,7 +101,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
-	GUIData.MaxPen = (Energy.Penetration / Data.PenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 

--- a/lua/acf/shared/rounds/roundaphe.lua
+++ b/lua/acf/shared/rounds/roundaphe.lua
@@ -80,7 +80,7 @@ function Round.getDisplayData(Data)
 	local Energy		= ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
 	local FragMass	= Data.ProjMass - Data.FillerMass
 
-	GUIData.MaxPen	= (Energy.Penetration / Data.PenArea) * ACF.KEtoRHA
+	GUIData.MaxPen	= ACE_CalcPenetration(Energy, Data.PenArea)
 	GUIData.BlastRadius = Data.FillerMass ^ 0.33 * 8
 	GUIData.Fragments	= math.max(math.floor((Data.FillerMass / FragMass) * ACF.HEFrag),2)
 	GUIData.FragMass	= FragMass / GUIData.Fragments

--- a/lua/acf/shared/rounds/roundfl.lua
+++ b/lua/acf/shared/rounds/roundfl.lua
@@ -136,7 +136,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data["MuzzleVel"] * 39.37 , Data["FlechetteMass"], Data["LimitVel"] )
-	GUIData["MaxPen"] = (Energy.Penetration / Data["FlechettePenArea"]) * ACF.KEtoRHA
+	GUIData["MaxPen"] = ACE_CalcPenetration(Energy, Data["FlechettePenArea"])
 	return GUIData
 end
 

--- a/lua/acf/shared/rounds/roundglgm.lua
+++ b/lua/acf/shared/rounds/roundglgm.lua
@@ -70,7 +70,7 @@ function Round.create( Gun, BulletData )
 	local BData = table.Copy( BulletData ) --Done so we don't accidentally write to the original crate bulletdata
 	BData.BulletData = nil
 
-	BData.Type = "HEAT"
+	BData.Type = ACE_GetMissileWarheadType(BulletData.Type or "GLATGM")
 	--BData.Id = 2	
 
 	BData.FakeCrate = ents.Create("acf_fakecrate2")
@@ -134,7 +134,7 @@ function Round.convert( _, PlayerData )
 	GUIData.FillerVol				= math.Clamp(PlayerData.Data5 * 1,GUIData.MinFillerVol,GUIData.MaxFillerVol)
 
 	Data.FillerMass				= GUIData.FillerVol * ACF.HEDensity / 1450
-	Data.BoomFillerMass			= Data.FillerMass / 3 --manually update function "pierceeffect" with the divisor
+	Data.BoomFillerMass			= Data.FillerMass / 6 -- Keep GLATGM blast substantially below raw filler mass.
 	Data.ProjMass					= math.max(GUIData.ProjVolume-GUIData.FillerVol- AirVol-ConeVol,0) * 7.9 / 1000 + Data.FillerMass + ConeVol * 7.9 / 1000
 	Data.MuzzleVel					= ACF_MuzzleVelocity( Data.PropMass, Data.ProjMass, Data.Caliber )
 	--local Energy					= ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
@@ -186,12 +186,13 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
-	GUIData.MaxPen = (SlugEnergy.Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
-	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
-	GUIData.FragMass = Data.CasingMass / GUIData.Fragments
-	GUIData.FragVel = (Data.BoomFillerMass * ACF.HEPower * 1000 / Data.CasingMass / GUIData.Fragments) ^ 0.5
+	local EffectiveFragMass = math.max(Data.CasingMass or 0, (Data.BoomFillerMass or 0) * 40)
+	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / EffectiveFragMass) * ACF.HEFrag), 2)
+	GUIData.FragMass = EffectiveFragMass / GUIData.Fragments
+	GUIData.FragVel = (Data.BoomFillerMass * ACF.HEPower * 1000 / EffectiveFragMass / GUIData.Fragments) ^ 0.5
 
 	return GUIData
 end
@@ -235,7 +236,8 @@ end
 
 function Round.detonate( _, Bullet, HitPos, HitNormal )
 
-	ACF_HE( HitPos - Bullet.Flight:GetNormalized() * 3 , HitNormal , Bullet.BoomFillerMass , Bullet.CasingMass , Bullet.Owner )
+	local EffectiveFragMass = math.max(Bullet.CasingMass or 0, (Bullet.BoomFillerMass or 0) * 40)
+	ACF_HE( HitPos - Bullet.Flight:GetNormalized() * 3 , HitNormal , Bullet.BoomFillerMass , EffectiveFragMass , Bullet.Owner )
 
 	Bullet.Detonated = true
 	Bullet.InitTime = SysTime()
@@ -350,7 +352,7 @@ function Round.pierceeffect( Effect, Bullet )
 
 	else
 
-		local Radius = (Bullet.FillerMass / 3) ^ 0.33 * 8 * 39.37 --fillermass/3 has to be manually set, as this func uses networked data
+		local Radius = (Bullet.FillerMass / 6) ^ 0.33 * 8 * 39.37 -- Keep visual blast in sync with BoomFillerMass scaling.
 		local Flash = EffectData()
 			Flash:SetOrigin( Bullet.SimPos )
 			Flash:SetNormal( Bullet.SimFlight:GetNormalized() )
@@ -451,13 +453,13 @@ function Round.guiupdate( Panel )
 	-------------------------------------------------------------------------------
 
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.Round(R1P,0) .. "mm @ " .. math.Round(R1V,0) .. " m\\s\n200m pen: " .. math.Round(R2P,0) .. "mm @ " .. math.Round(R2V,0) .. " m\\s\n400m pen: " .. math.Round(R3P,0) .. "mm @ " .. math.Round(R3V,0) .. " m\\s\n800m pen: " .. math.Round(R4P,0) .. "mm @ " .. math.Round(R4V,0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n")	--Proj muzzle penetration (Name, Desc)
 

--- a/lua/acf/shared/rounds/roundglgmhe.lua
+++ b/lua/acf/shared/rounds/roundglgmhe.lua
@@ -69,7 +69,7 @@ function Round.create( Gun, BulletData )
 	local BData = table.Copy( BulletData ) --Done so we don't accidentally write to the original crate bulletdata
 	BData.BulletData = nil
 
-	BData.Type = "HE"
+	BData.Type = ACE_GetMissileWarheadType(BulletData.Type or "GLATGM-HE")
 	--BData.Id = 2	
 
 	BData.FakeCrate = ents.Create("acf_fakecrate2")

--- a/lua/acf/shared/rounds/roundheat.lua
+++ b/lua/acf/shared/rounds/roundheat.lua
@@ -133,7 +133,7 @@ function Round.getDisplayData(Data)
 
 	local SlugEnergy	= ACF_Kinetic( Data.SlugMV * 39.37 , Data.SlugMass, 999999 )
 
-	GUIData.MaxPen = (SlugEnergy.Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
 	GUIData.FragMass = Data.CasingMass / GUIData.Fragments
@@ -425,15 +425,15 @@ function Round.guiupdate( Panel )
 	--HEAT doesnt lose Pen by distance, so its ok to say MaxPen on every value below
 
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R5V, R5P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea * ACF.HEATPlungingReduction, Data.LimitVel, 100)
-	R5P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea / ACF.HEATPlungingReduction) * ACF.KEtoRHA
+	R5P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea * ACF.HEATPlungingReduction)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.floor(R1P, 0) .. "mm @ " .. math.floor(R1V, 0) .. " m\\s\n200m pen: " .. math.floor(R2P, 0) .. "mm @ " .. math.floor(R2V, 0) .. " m\\s\n400m pen: " .. math.floor(R3P, 0) .. "mm @ " .. math.floor(R3V, 0) .. " m\\s\n800m pen: " .. math.floor(R4P, 0) .. "mm @" .. math.floor(R4V, 0) .. " m\\s\n\nIf using Plunging Fuse: " .. math.floor(R5P, 0) .. "mm @ " .. math.floor(R5V, 0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n") --Proj muzzle penetration (Name, Desc)
 end

--- a/lua/acf/shared/rounds/roundheatfs.lua
+++ b/lua/acf/shared/rounds/roundheatfs.lua
@@ -135,7 +135,7 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
-	GUIData.MaxPen = (SlugEnergy.Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
@@ -422,13 +422,13 @@ function Round.guiupdate( Panel )
 
 	-------------------------------------------------------------------------------
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = (ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999).Penetration / Data.SlugPenArea) * ACF.KEtoRHA
+	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.floor(R1P, 0) .. "mm @ " .. math.floor(R1V, 0) .. " m\\s\n200m pen: " .. math.floor(R2P, 0) .. "mm @ " .. math.floor(R2V, 0) .. " m\\s\n400m pen: " .. math.floor(R3P, 0) .. "mm @ " .. math.floor(R3V, 0) .. " m\\s\n800m pen: " .. math.floor(R4P, 0) .. "mm @ " .. math.floor(R4V, 0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n") --Proj muzzle penetration (Name, Desc)
 end

--- a/lua/acf/shared/rounds/roundhesh.lua
+++ b/lua/acf/shared/rounds/roundhesh.lua
@@ -123,9 +123,10 @@ function Round.propimpact( _, Bullet, Target, _, HitPos, Bone ) --Hitnormal not 
 
 	if ACF_Check( Target ) then
 
-		--local Speed = Bullet.Flight:Length() / ACF.VelScale
-		local Energy = ACF_Kinetic(Bullet.FillerMass * 750, Bullet.FillerMass * 75, Bullet.LimitVel)
-		--local HitRes = ACF_RoundImpact(Bullet, Speed / 4 + Bullet.FillerMass * 250, Energy, Target, HitPos, HitNormal / 10, Bone)
+		local Speed = Bullet.Flight:Length() / ACF.VelScale
+		-- HESH should not behave like a giant AP slug; use mostly-casing impact mass.
+		local ImpactMass = math.max(Bullet.ProjMass - Bullet.FillerMass * 0.85, Bullet.ProjMass * 0.1)
+		local Energy = ACF_Kinetic(Speed, ImpactMass, Bullet.LimitVel)
 
 		local Mat		= Target.ACF.Material or "RHA"
 		local MatData	= ACE_GetMaterialData( Mat )
@@ -133,7 +134,7 @@ function Round.propimpact( _, Bullet, Target, _, HitPos, Bone ) --Hitnormal not 
 		local Pen = Bullet.FillerMass / 300 * ACF.HEPower
 		if ( Pen * 1.25 ) > ( Target.ACF.Armour * (MatData.ArmorMul or 1) ) then
 
-			ACF_RoundImpact(Bullet, Bullet.FillerMass * 250, Energy, Target, HitPos, -Bullet.Flight:GetNormalized(), Bone) --( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone  )
+			ACF_RoundImpact(Bullet, Speed, Energy, Target, HitPos, -Bullet.Flight:GetNormalized(), Bone) --( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone  )
 
 			table.insert( Bullet.Filter , Target )
 			ACF_Spall_HESH( HitPos, Bullet.Flight, Bullet.Filter, Bullet.FillerMass * ACF.HEPower, Bullet.Caliber, Target.ACF.Armour, Bullet.Owner, Target.ACF.Material) --Do some spalling

--- a/lua/acf/shared/rounds/roundhp.lua
+++ b/lua/acf/shared/rounds/roundhp.lua
@@ -70,7 +70,7 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
 	GUIData.MaxKETransfert = Energy.Kinetic * Data.ShovePower
-	GUIData.MaxPen = (Energy.Penetration / Data.PenArea) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
 
 	return GUIData
 end

--- a/lua/acf/shared/rounds/roundhvap.lua
+++ b/lua/acf/shared/rounds/roundhvap.lua
@@ -75,7 +75,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
-	GUIData.MaxPen = ((Energy.Penetration / Data.PenArea) * ACF.KEtoRHA) * 1.055
+	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea, 1.055)
 
 	return GUIData
 end

--- a/lua/acf/shared/rounds/roundtheat.lua
+++ b/lua/acf/shared/rounds/roundtheat.lua
@@ -159,8 +159,8 @@ function Round.getDisplayData(Data)
 	local SlugEnergy	= ACF_Kinetic( Data.SlugMV * 39.37 , Data.SlugMass, 999999 )
 	local SlugEnergy2	= ACF_Kinetic( Data.SlugMV2 * 39.37 , Data.SlugMass2, 999999 )
 
-	GUIData.MaxPen = (SlugEnergy.Penetration / Data.SlugPenArea) * ACF.KEtoRHA
-	GUIData.MaxPen2 = (SlugEnergy2.Penetration / Data.SlugPenArea2) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen2 = ACE_CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
 
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)

--- a/lua/acf/shared/rounds/roundtheatfs.lua
+++ b/lua/acf/shared/rounds/roundtheatfs.lua
@@ -145,8 +145,8 @@ function Round.getDisplayData(Data)
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
 	local SlugEnergy2 = ACF_Kinetic(Data.SlugMV2 * 39.37, Data.SlugMass2, 999999)
-	GUIData.MaxPen = (SlugEnergy.Penetration / Data.SlugPenArea) * ACF.KEtoRHA
-	GUIData.MaxPen2 = (SlugEnergy2.Penetration / Data.SlugPenArea2) * ACF.KEtoRHA
+	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen2 = ACE_CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)

--- a/lua/acf/shared/sh_acfm_roundinject.lua
+++ b/lua/acf/shared/sh_acfm_roundinject.lua
@@ -8,22 +8,7 @@ include("acf/shared/sh_acfm_getters.lua")
 
 
 local function checkIfDataIsMissile(data)
-
-	local guns = ACF.Weapons.Guns
-	local class = guns[data.Id]
-
-	if not (class and class.gunclass) then
-		if oldDisplayData then
-			oldDisplayData(data)
-		end
-		return
-	end
-
-	local classes = ACF.Classes.GunClass
-	class = classes[class.gunclass]
-
-	return class.type and class.type == "missile"
-
+	return ACE_IsAmmoMissileType(data)
 end
 
 
@@ -60,16 +45,23 @@ function ACFM_ModifyRoundDisplayFuncs()
 				local MuzzleVel = data.MuzzleVel
 				local slugMV = data.SlugMV
 				local slugMV2 = data.SlugMV2
+				local PenArea = data.PenArea
 
-				data.MuzzleVel = 0
-				data.SlugMV = (slugMV or 0) * (ACF_GetGunValue(data.Id, "penmul") or 1.2)
-				data.SlugMV2 = (slugMV2 or 0) * (ACF_GetGunValue(data.Id, "penmul") or 1.2)
+				local PenMul = ACF_GetGunValue(data.Id, "penmul") or 1.2
+				local VelMul = ACF_GetGunValue(data.Id, "velmul") or 3
+				local CalMul = ACF_GetGunValue(data.Id, "calmul") or 1
+
+				data.MuzzleVel = (MuzzleVel or 0) * VelMul
+				data.SlugMV = (slugMV or 0) * PenMul
+				data.SlugMV2 = (slugMV2 or 0) * PenMul
+				data.PenArea = (PenArea or data.PenArea or 0) * CalMul
 
 				local ret = oldDisplayData(data)
 
 				data.SlugMV = slugMV
 				data.SlugMV2 = slugMV2
 				data.MuzzleVel = MuzzleVel
+				data.PenArea = PenArea
 
 				return ret
 			end
@@ -132,7 +124,7 @@ function ACFM_ModifyCrateTextFuncs()
 				local fuse	= IsValid(crate) and crate.RoundData8 or data.Data8
 
 				if guidance then
-					guidance = ACFM_CreateConfigurable(guidance, ACF.Guidance, bdata, "guidance")
+					guidance = ACFM_CreateConfigurable(guidance, ACF.Guidance, data, "guidance")
 					if guidance and guidance.Name ~= "Dumb" then
 						str[#str + 1] = "\n\n"
 						str[#str + 1] = guidance.Name
@@ -143,7 +135,7 @@ function ACFM_ModifyCrateTextFuncs()
 				end
 
 				if fuse then
-					fuse = ACFM_CreateConfigurable(fuse, ACF.Fuse, bdata, "fuses")
+					fuse = ACFM_CreateConfigurable(fuse, ACF.Fuse, data, "fuses")
 					if fuse then
 						str[#str + 1] = "\n\n"
 						str[#str + 1] = fuse.Name

--- a/lua/autorun/client/cl_ace_surveymessage.lua
+++ b/lua/autorun/client/cl_ace_surveymessage.lua
@@ -8,8 +8,8 @@ if not EnableSurveyMessage then return end
 local SurveyDesc = "A Survey is out! We would love to hear your feedback!"
 local Surveylink = "https://forms.gle/aowZ32cDkJhE6m9f9"
 
-CreateClientConVar("ace_survey_message", "1", true, false, "Set to 0 to disable the ACE survey message.")
-if GetConVar("ace_survey_message"):GetInt() == 0 then return end
+CreateClientConVar("acf_survey_message", "1", true, false, "Set to 0 to disable the ACE survey message.")
+if GetConVar("acf_survey_message"):GetInt() == 0 then return end
 
 hook.Add("CreateMove", "ACE Survey", function(Move)
     if Move:GetButtons() ~= 0 then

--- a/lua/autorun/server/sv_acf_missiles.lua
+++ b/lua/autorun/server/sv_acf_missiles.lua
@@ -139,9 +139,10 @@ ACF.FillerDensity =
 function ACFM_CompactBulletData(crate)
 
 	local compact = {}
+	local source = crate.BulletData or {}
 
-	compact["Id"] =			crate.RoundId	or crate.Id
-	compact["Type"] =			crate.RoundType	or crate.Type
+	compact["Id"] =			crate.RoundId	or source.Id or crate.Id
+	compact["Type"] =			crate.RoundType	or source.Type or crate.Type
 	compact["PropLength"] =	crate.PropLength	or crate.RoundPropellant
 	compact["ProjLength"] =	crate.ProjLength	or crate.RoundProjectile
 	compact["Data5"] =			crate.Data5		or crate.RoundData5		or crate.FillerVol	or crate.CavVol			or crate.Flechettes

--- a/lua/autorun/server/sv_acfm_configurables.lua
+++ b/lua/autorun/server/sv_acfm_configurables.lua
@@ -13,7 +13,7 @@ local Cast =
 
 function ACFM_CreateConfigurable(str, configurables, bdata, wlistPath)
 
-	success, ret =	xpcall( -- we're eating arbitrary user input, so let's not fuck up if they fuck up
+	local success, ret = xpcall( -- we're eating arbitrary user input, so let's not fuck up if they fuck up
 						function()
 							return ACFM_CreateConfigurable_Raw(str, configurables, bdata, wlistPath)
 						end,
@@ -49,7 +49,7 @@ function ACFM_CreateConfigurable_Raw(str, configurables, bdata, wlistPath)
 
 		if bdata then
 			local allowed = ACF_GetGunValue(bdata, wlistPath)
-			if not table.HasValue(allowed, name) then return nil end
+			if istable(allowed) and not table.HasValue(allowed, name) then return nil end
 		end
 
 

--- a/lua/entities/ace_gforce_meter/init.lua
+++ b/lua/entities/ace_gforce_meter/init.lua
@@ -3,7 +3,7 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
-CreateConVar("sbox_max_ace_gforce_meter", 10)
+CreateConVar("sbox_max_acf_gforce_meter", 10)
 
 DEFINE_BASECLASS("base_wire_entity")
 

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -624,7 +624,7 @@ function ENT:Detonate()
 	self.Exploded = true
 	ACF_ActiveMissiles[self] = nil
 
-	local HEWeight = self.Bulletdata2.BoomFillerMass or self.Bulletdata2.FillerMass or 1
+	local HEWeight = self.Bulletdata2.BoomFillerMass or self.Bulletdata2.FillerMass or 0
 	local Radius = HEWeight ^ 0.33 * 8 * 39.37
 
 --	if not IsValid(self.Launcher) then return end
@@ -723,9 +723,22 @@ do
 			self.ActivationTime = 0
 			self.Lifetime = 0 --Instantly scuttle as soon as can execute.
 
-			self.MissileVelocityMul = self.MissileVelocityMul * 0.05
-			self.Bulletdata2.SlugMV = self.Bulletdata2.SlugMV * 0.1
-			self.Bulletdata2.SlugMV2 = self.Bulletdata2.SlugMV * 0.1
+			self.MissileVelocityMul = (tonumber(self.MissileVelocityMul) or 1) * 0.05
+
+			local bdata = self.Bulletdata2
+			if istable(bdata) then
+				if tonumber(bdata.SlugMV) then
+					bdata.SlugMV = bdata.SlugMV * 0.1
+				end
+
+				if tonumber(bdata.SlugMV2) then
+					bdata.SlugMV2 = bdata.SlugMV2 * 0.1
+				end
+
+				if tonumber(bdata.MuzzleVel) then
+					bdata.MuzzleVel = bdata.MuzzleVel * 0.1
+				end
+			end
 
 			return { Damage = 0, Overkill = 0, Loss = 0, Kill = false }
 

--- a/lua/entities/ace_vheat_source/init.lua
+++ b/lua/entities/ace_vheat_source/init.lua
@@ -3,7 +3,7 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
-CreateConVar("sbox_max_ace_vheat_source", 3)
+CreateConVar("sbox_max_acf_vheat_source", 3)
 
 DEFINE_BASECLASS( "base_wire_entity" )
 

--- a/lua/entities/ace_wind_sensor/init.lua
+++ b/lua/entities/ace_wind_sensor/init.lua
@@ -3,7 +3,7 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
-CreateConVar("sbox_max_ace_wind_sensor", 10)
+CreateConVar("sbox_max_acf_wind_sensor", 10)
 
 DEFINE_BASECLASS("base_wire_entity")
 

--- a/lua/weapons/weapon_szcreator/cl_init.lua
+++ b/lua/weapons/weapon_szcreator/cl_init.lua
@@ -6,7 +6,7 @@ SWEP.DrawWeaponInfoBox	= true
 SWEP.BounceWeaponIcon	= true
 
 
-concommand.Add("acf_szcreationmenu", function(_, _, args)
+concommand.Add("ace_szcreationmenu", function(_, _, args)
     local frame = vgui.Create( "DFrame" )
     frame:SetSize( 300, 100 )
     frame:SetSizable(false)

--- a/lua/weapons/weapon_szcreator/cl_init.lua
+++ b/lua/weapons/weapon_szcreator/cl_init.lua
@@ -6,7 +6,7 @@ SWEP.DrawWeaponInfoBox	= true
 SWEP.BounceWeaponIcon	= true
 
 
-concommand.Add( "ace_szcreationmenu", function(_, _, args)
+concommand.Add("acf_szcreationmenu", function(_, _, args)
     local frame = vgui.Create( "DFrame" )
     frame:SetSize( 300, 100 )
     frame:SetSizable(false)


### PR DESCRIPTION
## Summary
Isolates combat-system-heavy changes (missiles, fuzes, rounds, damage/cookoff behavior).

## Included commits
- Stabilize GLATGM missile behavior and detonation handling
- Normalize fuze logic and round penetration/ballistics behavior
- Clean trailing whitespace in `sv_acfdamage`
- Normalize ACE debug/menu convar and command prefixes to `acf_`
- Drop DU/Titanium balance changes from this split

## Main areas touched
- missile + round/fuze definitions/logic
- `sv_acfdamage` cookoff/explosion path
- selected debug/menu prefix normalization

## Intent
Improve runtime consistency across fuze/round interactions and explosion/cookoff behavior while keeping balance changes constrained.

## Validation
- Lint + focused runtime checks recommended:
  - GLATGM detonation behavior
  - cookoff chain behavior under mixed ammo
  - representative AP/HE/HEAT/HESH round behavior