### PR TITLE
Fix ammo crate Length/Lenght compatibility and legacy shell crate dimension mismatch

### DIFF
--- a/lua/acf/shared/ammocrates/ammocrates.lua
+++ b/lua/acf/shared/ammocrates/ammocrates.lua
@@ -9,7 +9,7 @@ ACE_DefineAmmoCrate( "Shell75mm", {
 	desc = "A single 75mm Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_75mm.mdl",
 	weight = 5,
-	Lenght = 3,
+	Length = 3,
 	Width = 3,
 	Height = 31,
 

--- a/lua/acf/shared/sh_ace_loader.lua
+++ b/lua/acf/shared/sh_ace_loader.lua
@@ -165,6 +165,17 @@ end
 
 function ACE_DefineAmmoCrate( id, data )
 	data.id = id
+
+	-- Backwards/forwards compatibility for legacy typo key.
+	if data.Length == nil and data.Lenght ~= nil then
+		data.Length = data.Lenght
+	elseif data.Lenght == nil and data.Length ~= nil then
+		data.Lenght = data.Length
+	elseif data.Length ~= nil and data.Lenght ~= nil and data.Length ~= data.Lenght then
+		-- Prefer canonical key when both are present but disagree.
+		data.Lenght = data.Length
+	end
+
 	table.Inherit( data, ammo_base )
 	AmmoTable[ id ] = data
 end

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -468,7 +468,19 @@ do
 
 				Model = AmmoData.model
 				Weight = AmmoData.weight
-				Dimensions = Vector( AmmoData.Lenght, AmmoData.Width, AmmoData.Height )
+
+				local Length = tonumber(AmmoData.Length or AmmoData.Lenght)
+				local Width = tonumber(AmmoData.Width)
+				local Height = tonumber(AmmoData.Height)
+
+				if not Length or not Width or not Height then
+					ErrorNoHalt(string.format("[ACE] Invalid ammo crate dimensions for '%s' (Length/Lenght=%s, Width=%s, Height=%s). Falling back to 1x1x1.\n", tostring(Id), tostring(AmmoData.Length or AmmoData.Lenght), tostring(AmmoData.Width), tostring(AmmoData.Height)))
+					Length = Length or 1
+					Width = Width or 1
+					Height = Height or 1
+				end
+
+				Dimensions = Vector( Length, Width, Height )
 
 				Ammo:SetModel( Model )
 				Ammo:PhysicsInit( SOLID_VPHYSICS )


### PR DESCRIPTION
Addressing Issue #83. Title:
Fix ammo crate Length/Lenght compatibility and legacy shell crate dimension mismatch

Description:
## Summary
Fixes legacy shell ammo crate fit/capacity issues caused by inconsistent dimension keys (`Lenght` vs `Length`), while preserving compatibility for old and new crate definitions.

## Changes
- Normalized ammo crate key handling in `ACE_DefineAmmoCrate`:
- maps `Lenght -> Length` when needed
- keeps reverse alias for compatibility
- resolves conflicts by preferring canonical `Length`
- Updated ammo crate spawn dimension read path to use:
- `AmmoData.Length or AmmoData.Lenght`
- Added guarded numeric validation for dimensions with safe fallback (`1x1x1`) + `ErrorNoHalt` warning, preventing hard failures from malformed crate defs
- Normalized `Shell75mm` in `ammocrates.lua` to use canonical `Length`

## Why
Issue #83 stems from mixed dimension keys in shell crate defs after legacy recovery, while runtime code expected `Lenght` in key paths. This patch makes both keys work now and prevents future regressions.

## Validation
- Focused `glualint` passed on:
- `lua/acf/shared/sh_ace_loader.lua`
- `lua/entities/acf_ammo/init.lua`
- `lua/acf/shared/ammocrates/ammocrates.lua`