### PR TITLE
Fix #231: correct gun ready and shots-left reporting

### DIFF
--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -702,10 +702,11 @@ function ENT:Think()
 		Wire_TriggerOutput(self, "AmmoCount", Ammo)
 
 
+		local isEmpty = self.BulletData.Type == "Empty"
 		if self.MagSize then
-			Wire_TriggerOutput(self, "Shots Left", self.MagSize - self.CurrentShot)
+			Wire_TriggerOutput(self, "Shots Left", isEmpty and 0 or (self.MagSize - self.CurrentShot))
 		else
-			Wire_TriggerOutput(self, "Shots Left", 1)
+			Wire_TriggerOutput(self, "Shots Left", isEmpty and 0 or 1)
 		end
 
 		self:SetNWString("GunType", self.Id)
@@ -720,8 +721,13 @@ function ENT:Think()
 	end
 
 	if self.NextFire <= Time then
-		self.Ready = true
-		Wire_TriggerOutput(self, "Ready", 1)
+		if self.BulletData.Type and self.BulletData.Type ~= "Empty" then
+			self.Ready = true
+			Wire_TriggerOutput(self, "Ready", 1)
+		else
+			self.Ready = false
+			Wire_TriggerOutput(self, "Ready", 0)
+		end
 
 		if self.MagSize and self.MagSize == 1 then
 			self.CurrentShot = 0


### PR DESCRIPTION
## Addresses #231 

This updates acf_gun state reporting so wire outputs reflect the actual chamber state instead of just the reload timer. Guns now report Ready = 1 only when NextFire has elapsed and a non-empty round is still loaded, which fixes the case where a gun could stay "ready" after running out of ammo.

It also corrects Shots Left for empty chambers. Single-shot guns were still reporting one round in the gun even when all linked crates were empty and the chamber had already been cleared. The output now returns 0 whenever BulletData.Type == "Empty".

The fix intentionally avoids auto-calling LoadAmmo() from Think(). That preserves existing unload behavior, so using Unload can still leave the gun empty instead of immediately reloading from a linked crate once the timer expires.