### PR TITLE
Fix #248: fix legacy manufacturing cost for gun ammo crates

### DIFF
--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1918,10 +1918,10 @@ end
 function ACE_GetEntLegacyCost(ent, massOverride)
 	if not ACE_IsEnt(ent) then return 0 end
 
-	local points = ent.ACEPoints or 0
-	if points ~= 0 then return points end
-
 	local class = ent:GetClass()
+	local points = ent.ACEPoints or 0
+	if class ~= "acf_ammo" and points ~= 0 then return points end
+
 	local acf = ent.ACF or {}
 
 	-- Armor props: derive manufacturing cost from raw thickness (mm), then apply ductility scalar.


### PR DESCRIPTION
## Fixes #248.

Gun ammo crates now use their dedicated legacy manufacturing-cost calculation instead of sometimes falling back to the generic `ACEPoints` value. This restores proper manufacturing cost reporting for gun ammo, while leaving existing missile behavior intact.

## What Changed

- Updated `ACE_GetEntLegacyCost()` to avoid returning early from `ent.ACEPoints` for `acf_ammo`.
- Let ammo crates continue into the existing ammo-specific legacy cost path.
- Kept the current behavior unchanged for non-ammo entities.

## Why This Was Broken

Ammo crates already populate `ACEPoints`, and `ACE_GetEntLegacyCost()` was returning that value before it ever reached the ammo-specific manufacturing-cost logic. That meant gun ammo could report a generic legacy points value instead of its actual manufacturing cost.

Missiles still appeared correct because their path already aligned with the existing ammo handling.