### PR TITLE
ACE points simplification: direct walk + rack pre-load accounting

### DIFF
--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -4,9 +4,7 @@ include("acf/shared/sh_ace_functions.lua")
 include("acf/server/sv_pointshandling.lua")
 
 
-local ACE_ConVarHelp = ACE_ConVarHelp
 local IsEnt = ACE_IsEnt
-local ACE_GetPtsType = ACE_GetPtsType
 ACE.CacheVersion = ACE.CacheVersion or 1
 
 -- ------------------------------------------------------------
@@ -37,16 +35,17 @@ end
 function ACE_CheckLegalCont(con)
 	con.OTWarnings = con.OTWarnings or {}
 
-	if con.ACEArmorDirty then
-		ACE_NotifyContraptionModified(con)
+	if ACE_EnsureContraptionPoints then
+		ACE_EnsureContraptionPoints(con, nil, false)
 	end
 
-	if con.ACEPoints > ACF.PointsLimit and not con.OTWarnings.WarnedOverPoints then
+	local points = con.ACEPoints or 0
+	if points > ACF.PointsLimit and not con.OTWarnings.WarnedOverPoints then
 		local name  = ACE_GetOwnerName(ACE_GetContraptionOwner(con))
-		local above = con.ACEPoints - ACF.PointsLimit
+		local above = points - ACF.PointsLimit
 		chatMessageGlobal(
 			"[ACE] " .. name .. " has a vehicle [" .. math.ceil(above) .. "pts] over the limit costing [" ..
-				math.ceil(con.ACEPoints) .. "pts / " .. math.ceil(ACF.PointsLimit) .. "pts]",
+				math.ceil(points) .. "pts / " .. math.ceil(ACF.PointsLimit) .. "pts]",
 			Color(255, 234, 0)
 		)
 		con.OTWarnings.WarnedOverPoints = true
@@ -82,22 +81,12 @@ do
 
 		con.ACECacheVersion = ACE.CacheVersion
 
-		con.ACEArmorCachedData = nil
-		con.ACEArmorCacheKey = nil
 		con.ACEArmorCalculated = false
 		con.ACEArmorLastCalc = 0
 
+		con.ACEPointsDirty = true
 		con.ACENonArmorDirty = true
 		con.ACEAmmoCache = nil
-		con.ACESubsystemCache = {}
-		con.ACESubsystemDirty = {
-			Ammo = true,
-			Engines = true,
-			Firepower = true,
-			Crew = true,
-			Electronics = true
-		}
-		con.ACEDupeSubsystemKeys = nil
 		con.ACEPointsDetails = nil
 
 		return true
@@ -113,21 +102,13 @@ do
 		con.ACEPointsNonArmor = 0
 
 		con.ACEArmorPoints = 0
+		con.ACEPointsDirty = true
 		con.ACEArmorDirty = false
 		con.ACEArmorCalculated = false
 		con.ACEArmorLastCalc = 0
 
 		con.ACENonArmorDirty = true
 		con.ACEAmmoCache = nil
-		con.ACESubsystemCache = {}
-		con.ACESubsystemDirty = {
-			Ammo = true,
-			Engines = true,
-			Firepower = true,
-			Crew = true,
-			Electronics = true
-		}
-		con.ACEDupeSubsystemKeys = nil
 
 		con.ACEPointsPerType = {}
 		for _, k in ipairs({
@@ -136,9 +117,7 @@ do
 			"Firepower",
 			"Ammo",
 			"AmmoReady",
-			"AmmoBackup",
 			"AmmoReadyRounds",
-			"AmmoBackupRounds",
 			"Crew",
 			"Electronics"
 		}) do
@@ -146,23 +125,27 @@ do
 		end
 	end
 
-	-- Mark a subsystem as dirty and clear related caches.
-	function ACE_MarkSubsystemDirty(con, subsystem)
-		if not con or not subsystem then return end
+	-- Mark a contraption's derived point totals dirty.
+	function ACE_MarkContraptionPointsDirty(con, ent, armorDirty, nonArmorDirty)
+		if not con then return end
 
-		con.ACESubsystemDirty = con.ACESubsystemDirty or {}
-		con.ACESubsystemDirty[subsystem] = true
-		con.ACENonArmorDirty = true
-
-		if con.ACEDupeSubsystemKeys then
-			con.ACEDupeSubsystemKeys[subsystem] = nil
+		if ACE_ClearArmorPointCache and IsEnt(ent) then
+			ACE_ClearArmorPointCache(ent)
 		end
 
-		if con.ACESubsystemCache then
-			con.ACESubsystemCache[subsystem] = nil
+		if armorDirty == nil then armorDirty = true end
+		if nonArmorDirty == nil then nonArmorDirty = true end
+
+		con.ACEPointsDirty = true
+		con.ACEArmorDirty = con.ACEArmorDirty or armorDirty
+		con.ACENonArmorDirty = con.ACENonArmorDirty or nonArmorDirty
+
+		if armorDirty then
+			con.ACEArmorCalculated = false
+			con.ACEArmorLastCalc = 0
 		end
 
-		if subsystem == "Ammo" then
+		if nonArmorDirty then
 			con.ACEAmmoCache = nil
 		end
 	end
@@ -183,65 +166,14 @@ do
 	function ACE_AddPts(con, ent)
 		if not IsEnt(ent) then return end
 
-		local cls = ent:GetClass()
-		local eclass = ACE_GetPtsType(cls)
-
-		if eclass ~= "Ignore" and eclass ~= "Armor" then
-			ACE_MarkSubsystemDirty(con, eclass)
-		end
-
-		if cls == "acf_gun" or cls == "acf_rack" then
-			ACE_MarkSubsystemDirty(con, "Ammo")
-		end
-
-		local newPts = ACE_GetEntPoints(ent)
-		local oldPts = ent._AcePts or 0
-
-		if eclass == "Ignore" then
-			if ent._ACEPointsConRef and ent._ACEPointsConRef ~= con then
-				ACE_RemPts(ent._ACEPointsConRef, ent)
-			end
-
-			ent._ACEPointsConRef = con
-			ent._ACEPointsConKey = ACE_GetContraptionIndex and ACE_GetContraptionIndex(con) or nil
-			ent._AcePts = 0
-			return
-		end
-
-		if ent._ACEPointsConRef == con then
-			if eclass == "Armor" then
-				ACE_MarkArmorDirty(con, ent, "addpts-existing")
-			else
-				local delta = newPts - oldPts
-				if delta ~= 0 then
-					con.ACEPoints = (con.ACEPoints or 0) + delta
-					con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) + delta
-					con.ACEPointsPerType = con.ACEPointsPerType or {}
-					con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) + delta
-					ACE_NotifyContraptionModified(con)
-				end
-			end
-
-			ent._AcePts = newPts
-			return
-		end
-
 		if ent._ACEPointsConRef and ent._ACEPointsConRef ~= con then
 			ACE_RemPts(ent._ACEPointsConRef, ent)
 		end
 
 		ent._ACEPointsConRef = con
 		ent._ACEPointsConKey = ACE_GetContraptionIndex and ACE_GetContraptionIndex(con) or nil
-		ent._AcePts = newPts
 
-		if eclass == "Armor" then
-			ACE_MarkArmorDirty(con, ent, "addpts-new")
-		else
-			con.ACEPoints = (con.ACEPoints or 0) + newPts
-			con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) + newPts
-			con.ACEPointsPerType = con.ACEPointsPerType or {}
-			con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) + newPts
-		end
+		ACE_MarkContraptionPointsDirty(con, ent, true, true)
 	end
 
 	-- Handle entity removal and update point totals.
@@ -253,31 +185,7 @@ do
 		ent._ACEPointsConKey = nil
 		ent._ACEPointsConRef = nil
 
-		local cls = ent:GetClass()
-		local eclass = ACE_GetPtsType(cls)
-
-		if eclass ~= "Ignore" and eclass ~= "Armor" then
-			ACE_MarkSubsystemDirty(con, eclass)
-		end
-
-		if cls == "acf_gun" or cls == "acf_rack" then
-			ACE_MarkSubsystemDirty(con, "Ammo")
-		end
-
-		if eclass == "Ignore" then return end
-
-		if eclass == "Armor" then
-			ACE_MarkArmorDirty(con, ent, "rempts")
-			return
-		end
-
-		local pts = ent._AcePts or 0
-		con.ACEPoints = (con.ACEPoints or 0) - pts
-		con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) - pts
-		con.ACEPointsPerType = con.ACEPointsPerType or {}
-		con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) - pts
-
-		ACE_NotifyContraptionModified(con)
+		ACE_MarkContraptionPointsDirty(con, ent, true, true)
 	end
 
 	-- Track point totals when entities are added.
@@ -292,7 +200,7 @@ do
 end
 
 -- ------------------------------------------------------------
--- Hook PhysObj:SetMass (delegates armor marking to ARMOR wrapper)
+-- Hook PhysObj:SetMass so mass edits rebuild points on demand.
 -- ------------------------------------------------------------
 
 do
@@ -313,326 +221,21 @@ do
 			return OldSetMass(self, mass)
 		end
 
-		local oldPts = ent._AcePts or 0
-		ent._AcePts = ACE_GetEntPoints(ent)
-
 		OldSetMass(self, mass)
 
 		local con = ent.GetContraption and ent:CFW_GetContraption()
 		if not con then return end
 
-		local delta = (ent._AcePts or 0) - oldPts
-		local cls = ent:GetClass()
-		local eclass = ACE_GetPtsType(cls)
-
-		if eclass == "Ignore" then return end
-
-		if eclass == "Armor" then
-			if delta ~= 0 then
-				ACE_MarkArmorDirty(con, ent, "setmass")
-			end
-			return
-		end
-
-		if delta == 0 then return end
-
-		ACE_MarkSubsystemDirty(con, eclass)
-		if cls == "acf_gun" or cls == "acf_rack" then
-			ACE_MarkSubsystemDirty(con, "Ammo")
-		end
-
-		con.ACEPoints = (con.ACEPoints or 0) + delta
-		con.ACEPointsNonArmor = (con.ACEPointsNonArmor or 0) + delta
-		con.ACEPointsPerType = con.ACEPointsPerType or {}
-		con.ACEPointsPerType[eclass] = (con.ACEPointsPerType[eclass] or 0) + delta
-
-		ACE_NotifyContraptionModified(con)
+		ACE_MarkContraptionPointsDirty(con, ent, true, true)
 	end
 end
 
--- ============================================================
--- SECTION 2: ARMOR ONLY
--- Dirty tracking, dupe caching, scan scheduling, scan math use
--- ============================================================
-
 -- ------------------------------------------------------------
--- Simple ignore rules
--- Limited parent-chain logic
+-- Cache reset and armor dirty handling
 -- ------------------------------------------------------------
 
-
--- Ignore dirty events for safe/non-armor entities.
-local function ACE_ShouldIgnoreDirtyEnt(ent)
-	if not IsEnt(ent) then return true end
-
-	if ACE_IsMissileEntity(ent) then return true end
-
-	-- Walk a few levels up the parent chain to ignore missile attachments only
-	local p = ent:GetParent()
-	local depth = 0
-	while IsEnt(p) and depth < 4 do
-		if ACE_IsMissileEntity(p) then return true end
-
-		p = p:GetParent()
-		depth = depth + 1
-	end
-
-	return false
-end
-
--- ------------------------------------------------------------
--- Armor init and dirty rules
--- ------------------------------------------------------------
-
--- Check whether armor has been initialized.
-function ACE_HasArmorInit(con)
-	if not con then return false end
-	if con.ACEArmorCalculated then return true end
-	return (con.ACEArmorLastCalc or 0) > 0
-end
-
--- Dirty ignore check (stub before ARMOR section).
-function ACE_ShouldIgnoreDirty(con)
-	if not con then return true end
-	if con.ACERemoving then return true end
-	if not ACE_HasArmorInit(con) then return true end
-	return false
-end
-
--- ------------------------------------------------------------
--- Debug logging 
--- ------------------------------------------------------------
-
-ACE.ArmorDebugCvar = ACE.ArmorDebugCvar or CreateConVar("acf_armor_debug",
-	"0",
-	FCVAR_ARCHIVE,
-	ACE_ConVarHelp("Enable stored armor dirty logging (no live console spam).")
-)
-
-local armorDebugCvar = ACE.ArmorDebugCvar
-
-local armorDirtyLogLimit = CreateConVar("acf_armor_dirty_log_limit",
-	"120",
-	FCVAR_ARCHIVE,
-	ACE_ConVarHelp("How many stored dirty entries to keep.")
-)
-
-local armorDirtyLog = armorDirtyLog or {}
-
-
-local function ACE_ShortCacheKey(key)
-	if not key then return "nil" end
-	local hash = tostring(key):match(":([%x]+)$") or tostring(key)
-	if #hash > 8 then
-		return hash:sub(1, 8)
-	end
-	return hash
-end
-
--- Store a compact dirty-log entry.
-local function ACE_PushDirtyLog(entry)
-	local limit = math.max(10, armorDirtyLogLimit:GetInt() or 120)
-	armorDirtyLog[#armorDirtyLog + 1] = entry
-	while #armorDirtyLog > limit do
-		table.remove(armorDirtyLog, 1)
-	end
-end
-
--- Emit debug logs for armor dirty events.
-function ACE_DebugDirty(con, reason, ent, extra, action)
-	if not armorDebugCvar:GetBool() then return end
-	if not ACE_HasArmorInit(con) then return end
-
-	local conId = (ACE_GetContraptionIndex and ACE_GetContraptionIndex(con)) or tostring(con)
-	local entClass = IsEnt(ent) and ent:GetClass() or "?"
-	local entIndex = IsEnt(ent) and ent:EntIndex() or 0
-
-	local chain = ACE_GetEntChainSummary(ent, 5)
-	local entIsMissile = IsEnt(ent) and ACE_IsMissileEntity(ent) or false
-	local parent = IsEnt(ent) and ent:GetParent() or nil
-	local parentIsMissile = IsEnt(parent) and ACE_IsMissileEntity(parent) or false
-	local parentIsRack = IsEnt(parent) and (parent:GetClass() == "acf_rack" or parent:GetClass() == "acf_gun") or false
-	local parentIsWire = IsEnt(parent) and ACE_IsWireEntity(parent) or false
-
-	ACE_PushDirtyLog({
-		t = CurTime(),
-		reason = tostring(reason),
-		action = tostring(action or "?"),
-		conId = tostring(conId),
-		entClass = tostring(entClass),
-		entIndex = entIndex,
-		wasDirty = con and con.ACEArmorDirty or false,
-		extra = extra,
-		chain = chain,
-		entMissile = entIsMissile,
-		parentMissile = parentIsMissile,
-		parentRack = parentIsRack,
-		parentWire = parentIsWire
-	})
-
--- Emit debug logs for cache decisions.
-function ACE_DebugCache(con, reason, ent, extra, action)
-	if not armorDebugCvar:GetBool() then return end
-
-	local conId = (ACE_GetContraptionIndex and ACE_GetContraptionIndex(con)) or tostring(con)
-	local entClass = IsEnt(ent) and ent:GetClass() or "?"
-	local entIndex = IsEnt(ent) and ent:EntIndex() or 0
-
-	local chain = ACE_GetEntChainSummary(ent, 3)
-
-	ACE_PushDirtyLog({
-		t = CurTime(),
-		reason = tostring(reason),
-		action = tostring(action or "Cache"),
-		conId = tostring(conId),
-		entClass = tostring(entClass),
-		entIndex = entIndex,
-		wasDirty = con and con.ACEArmorDirty or false,
-		extra = extra,
-		chain = chain
-	})
-end
-
-end
-
-concommand.Add("ace_armor_dirty_log_dump", function(_, _, args)
-	if not armorDebugCvar:GetBool() then
-		print("[ACE] ace_armor_debug is 0")
-		return
-	end
-
-	local n = tonumber(args[1] or "") or 30
-	n = math.Clamp(n, 1, 200)
-
-	print(string.format("[ACE] Dumping last %d stored armor entries", n))
-
-	for i = math.max(1, #armorDirtyLog - n + 1), #armorDirtyLog do
-		local e = armorDirtyLog[i]
-		print(string.format(
-			"[ACE ArmorDirty] %s action=%s id=%s ent=%s idx=%s dirty=%s extra=%s chain=%s missile=%s parentMissile=%s parentRack=%s parentWire=%s",
-			tostring(e.reason),
-			tostring(e.action),
-			tostring(e.conId),
-			tostring(e.entClass),
-			tostring(e.entIndex),
-			tostring(e.wasDirty),
-			tostring(e.extra or ""),
-			tostring(e.chain or ""),
-			tostring(e.entMissile),
-			tostring(e.parentMissile),
-			tostring(e.parentRack),
-			tostring(e.parentWire)
-		))
-	end
-end)
-
-concommand.Add("ace_armor_dirty_log_clear", function()
-	armorDirtyLog = {}
-	print("[ACE] Cleared stored armor log")
-end)
-
--- ------------------------------------------------------------
--- Player warning when armor was made dirty after init
--- ------------------------------------------------------------
-
--- Broadcast the dirty notification to players.
-function ACE_NotifyContraptionModified(con)
-	if not ACE_HasArmorInit(con) then return end
-	if con.ACERemoving then return end
-	if not con.aceEntities then return end
-	if not con.ACEArmorDirty then return end
-
-	local base = con.GetACEBaseplate and con:GetACEBaseplate()
-	if not IsEnt(base) or (base.IsBeingRemoved and base:IsBeingRemoved()) then return end
-	if con.ents and next(con.ents) == nil then return end
-
-	con.OTWarnings = con.OTWarnings or {}
-	if con.OTWarnings.WarnedModified then return end
-
-	local name = ACE_GetOwnerName(ACE_GetContraptionOwner(con))
-	chatMessageGlobal(
-		"[ACE] " .. name .. " modified a vehicle after cost initialization. Armor cost marked dirty.",
-		Color(255, 200, 0)
-	)
-
-	con.OTWarnings.WarnedModified = true
-	ACE_DebugDirty(con, "notify-sent", base, nil, "Notify")
-end
-
--- ------------------------------------------------------------
--- Armor dirty wrapper
--- ------------------------------------------------------------
-
-local ArmorDirtyReasonPolicy = {
-	rempts = false,
-	setmass = true,
-	["addpts-existing"] = true,
-	["addpts-new"] = true
-}
-
--- Mark armor as dirty and capture context.
-function ACE_MarkArmorDirty(con, ent, reason)
-	if not con then return end
-	if ACE_ShouldIgnoreDirty(con) then return end
-	if ACE_ShouldIgnoreDirtyEnt(ent) then return end
-
-	local policy = ArmorDirtyReasonPolicy[reason]
-	if policy == false then
-		ACE_DebugDirty(con, "skip-reason:" .. tostring(reason), ent, nil, "MarkDirty")
-		return
-	end
-
-	local cls = IsEnt(ent) and ent:GetClass() or ""
-	if cls == "primitive_shape" and not ent.ACEArmorDirtySeen then
-		ent.ACEArmorDirtySeen = true
-		ACE_DebugDirty(con, "skip-first-primitive-shape", ent, nil, "MarkDirty")
-		return
-	end
-
-	if con.ACEArmorDirty then
-		return
-	end
-
-	con.ACEArmorDirty = true
-	ACE_DebugDirty(con, "mark-dirty:" .. tostring(reason or "unknown"), ent, nil, "MarkDirty")
-	ACE_NotifyContraptionModified(con)
-end
-
--- ============================================================
--- Dupe armor cache + AdvDupe trigger
--- ============================================================
-
-ACE.DupeArmorCache = ACE.DupeArmorCache or {}
-ACE.DupeSubsystemCache = ACE.DupeSubsystemCache or {}
-ACE.DupeArmorCacheVersion = ACE.DupeArmorCacheVersion or 1
-ACE.DupeArmorCacheLastClear = ACE.DupeArmorCacheLastClear or CurTime()
-ACE.DupeSubsystemCacheLastClear = ACE.DupeSubsystemCacheLastClear or CurTime()
-
-local DupeArmorCacheTtl = CreateConVar("acf_dupe_armor_cache_ttl",
-	"1800",
-	FCVAR_ARCHIVE,
-	ACE_ConVarHelp("Seconds between clearing the dupe armor cache (0 disables).")
-)
-
-timer.Create("ACE_DupeArmorCacheGC", 60, 0, function()
-	local ttl = DupeArmorCacheTtl:GetFloat()
-	if ttl <= 0 then return end
-
-	local now = CurTime()
-	local last = ACE.DupeArmorCacheLastClear or now
-	if now - last < ttl then return end
-
-	ACE.DupeArmorCache = {}
-	ACE.DupeSubsystemCache = {}
-	ACE.DupeArmorCacheLastClear = now
-	ACE.DupeSubsystemCacheLastClear = now
-end)
-
+-- Clear derived point caches globally; contraptions rebuild on demand.
 local function ACE_ClearAllCaches()
-	ACE.DupeArmorCache = {}
-	ACE.DupeSubsystemCache = {}
-	ACE.DupeArmorCacheLastClear = CurTime()
-	ACE.DupeSubsystemCacheLastClear = CurTime()
 	ACE.CacheVersion = (ACE.CacheVersion or 1) + 1
 end
 
@@ -640,82 +243,9 @@ concommand.Add("ace_cache_clear_all", function()
 	ACE_ClearAllCaches()
 end)
 
--- Initialize armor caches after AdvDupe paste.
-hook.Add("AdvDupe_FinishPasting", "ACE_ArmorInitOnDupePaste_Trimmed", function(...)
-	local dupe, created = ACE_ParseAdvDupeArgs(...)
-	if not istable(created) then return end
-
-	local baseKey = ACE_GetDupeSignature(dupe, created)
-
-	local cons = {}
-	local conEnts = {}
-	for _, ent in pairs(created) do
-		if IsValid(ent) then
-			local con = ACE_GetContraptionFromEntity(ent)
-			if con then
-				cons[con] = true
-				conEnts[con] = conEnts[con] or {}
-				conEnts[con][#conEnts[con] + 1] = ent
-			end
-		end
-	end
-
-	timer.Simple(0.05, function()
-		for con in pairs(cons) do
-			local baseEnt = con.GetACEBaseplate and con:GetACEBaseplate() or nil
-			local ents = conEnts[con]
-
-			local createdKey
-			local createdInfo
-			local cacheKey
-			if ents and ACE_GetCreatedSignature then
-				createdKey = ACE_GetCreatedSignature(ents, baseEnt)
-				cacheKey = createdKey
-			end
-			if not cacheKey then
-				cacheKey = baseKey
-			end
-
-			local cached = (cacheKey and ACE.DupeArmorCache and ACE.DupeArmorCache[cacheKey]) or nil
-			if ACE_DebugCache then
-				if ents and ACE_GetCreatedSignatureInfo then
-					local _, infoTable = ACE_GetCreatedSignatureInfo(ents, baseEnt)
-					createdInfo = infoTable
-				end
-
-				local info = string.format("base=%s created=%s chosen=%s hit=%s count=%s ref=%s",
-					ACE_ShortCacheKey(baseKey),
-					ACE_ShortCacheKey(createdKey),
-					ACE_ShortCacheKey(cacheKey),
-					tostring(cached ~= nil),
-					tostring(createdInfo and createdInfo.count or "?"),
-					createdInfo and tostring(createdInfo.ref or "") or ""
-				)
-				ACE_DebugCache(con, "cache-key", baseEnt or con, info, "CacheInit")
-			end
-
-			if cacheKey then con.ACEArmorCacheKey = cacheKey end
-			if cached then con.ACEArmorCachedData = cached end
-
-			if ents then
-				con.ACEDupeSubsystemKeys = ACE_GetSubsystemSignaturesFromEnts(ents)
-			end
-
-			ACE_EnsureArmor(con, baseEnt, true)
-		end
-	end)
-end)
-
-
--- Armor scan and rebuild logic live in sv_pointshandling.lua
-
-
-
-
-
-
-
-
-
-
+-- Mark armor points dirty for callers that know only armor changed.
+function ACE_MarkArmorDirty(con, ent)
+	if not con then return end
+	ACE_MarkContraptionPointsDirty(con, ent, true, false)
+end
 

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -109,10 +109,9 @@ end
 local function ACE_CalcAmmoSubsystem(ents, minDetailPts)
 	local totals = {
 		Ammo = 0,
+		Firepower = 0,
 		AmmoReady = 0,
-		AmmoBackup = 0,
-		AmmoReadyRounds = 0,
-		AmmoBackupRounds = 0
+		AmmoReadyRounds = 0
 	}
 
 	local detailItems = {}
@@ -125,48 +124,33 @@ local function ACE_CalcAmmoSubsystem(ents, minDetailPts)
 
 	for _, ent in ipairs(ents) do
 		if IsEnt(ent) and ent:GetClass() == "acf_ammo" then
-			local pts, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks, readyAlloc)
-			if pts > 0 then
-				totals.Ammo = totals.Ammo + pts
+			local _, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks, readyAlloc)
+			if detail then
+				local rawCost = detail.RawAmmoCost or 0
+				local dpsCost = detail.DPSCost or 0
+				if rawCost <= 0 and dpsCost <= 0 then continue end
 
-				if detail then
-					totals.AmmoReady = totals.AmmoReady + (detail.ReadyCost or 0)
-					totals.AmmoBackup = totals.AmmoBackup + (detail.StowCost or 0)
-					totals.AmmoReadyRounds = totals.AmmoReadyRounds + (detail.ReadyCount or 0)
-					totals.AmmoBackupRounds = totals.AmmoBackupRounds + (detail.StowCount or 0)
+				totals.Ammo = totals.Ammo + rawCost
+				totals.Firepower = totals.Firepower + dpsCost
 
-					local ammoType = detail.Type ~= "" and detail.Type or "Ammo"
-					local readyCount = math.floor((detail.ReadyCount or 0) + 0.5)
-					local stowCount = math.floor((detail.StowCount or 0) + 0.5)
-					local readyCost = detail.ReadyCost or 0
-					local stowCost = detail.StowCost or 0
+				totals.AmmoReady = totals.AmmoReady + rawCost
+				totals.AmmoReadyRounds = totals.AmmoReadyRounds + (detail.ReadyCount or 0)
 
-					if readyCount > 0 and readyCost > 0 then
-						ACE_AddDetailItem(
-							detailItems,
-							"Ammo",
-							string.format("Ready rack %s x%d", ammoType, readyCount),
-							readyCost,
-							ent,
-							minDetailPts
-						)
-					end
-					if stowCount > 0 and stowCost > 0 then
-						ACE_AddDetailItem(
-							detailItems,
-							"Ammo",
-							string.format("Backup ammo %s x%d", ammoType, stowCount),
-							stowCost,
-							ent,
-							minDetailPts
-						)
-					end
+				local ammoType = detail.Type ~= "" and detail.Type or "Ammo"
+				local readyCount = math.floor((detail.ReadyCount or 0) + 0.5)
 
-					ACE_AddAmmoLine(ammoLines, "READY", detail.Caliber, ammoType, readyCount, readyCost)
-					if stowCost > 0 then
-						ACE_AddAmmoLine(ammoLines, "BACKUP", detail.Caliber, ammoType, stowCount, stowCost)
-					end
+				if readyCount > 0 and rawCost > 0 then
+					ACE_AddDetailItem(
+						detailItems,
+						"Ammo",
+						string.format("%s x%d", ammoType, readyCount),
+						rawCost,
+						ent,
+						minDetailPts
+					)
 				end
+
+				ACE_AddAmmoLine(ammoLines, "READY", detail.Caliber, ammoType, readyCount, rawCost)
 			end
 		end
 	end
@@ -186,10 +170,8 @@ local function ACE_CalcNonAmmoSubsystem(ents, subsystem, minDetailPts)
 			if eclass == subsystem then
 				local pts
 				if subsystem == "Crew" then
-					pts = tonumber(ACE.CrewSeatPointCost)
-						or tonumber((ACE.PointCostConfig or {}).CrewSeatFlat)
-						or 250
-				elseif subsystem == "Firepower" and cls == "acf_gun" then
+					pts = ACE_GetCrewSeatPointCost(ent)
+				elseif subsystem == "Firepower" and (cls == "acf_gun" or cls == "acf_rack") then
 					pts = ACE_GetGunFirepowerPoints(ent)
 				else
 					pts = ACE_GetEntPoints(ent)
@@ -251,35 +233,18 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 	local roundPts = ACE_GetAmmoRoundPoints(bdata)
 	if roundPts <= 0 then return 0 end
 
-	local stowFactor = cfg.StowFactor or 1
-	local tailFactor = cfg.TailFactor or 0
-	local tailStartMul = cfg.TailStartMultiplier or 0
-
 	local readyCap = ACE_GetReadyRackCap(calMm)
 	local readyCount = rounds
-	local stowCount = 0
 
 	if readyCap > 0 then
 		readyCount = math.min(readyCap, rounds)
-		stowCount = math.max(rounds - readyCount, 0)
 	end
 
 	if readyAlloc and readyAlloc[crate] then
 		readyCount = math.min(readyAlloc[crate], rounds)
-		stowCount = math.max(rounds - readyCount, 0)
 	end
 
-	local readyCost = roundPts * readyCount * rpsFactor
-	local stowCost = roundPts * stowCount * stowFactor * rpsFactor
-
-	if readyCap > 0 and tailFactor > 0 and tailStartMul > 0 then
-		local tailStart = readyCap * tailStartMul
-		local tail = math.max(rounds - tailStart, 0)
-		if tail > 0 then
-			stowCost = stowCost - (roundPts * tail * tailFactor * rpsFactor)
-			if stowCost < 0 then stowCost = 0 end
-		end
-	end
+	local rawAmmoCost = roundPts * readyCount * rpsFactor
 
 	local name = ACF_GetGunValue(ammoId, "name") or tostring(ammoId)
 	local detail = {
@@ -292,25 +257,12 @@ function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
 		Rpm = rpsTotal * 60,
 		RofFactor = rpsFactor,
 		ReadyCount = readyCount,
-		StowCount = stowCount,
-		ReadyCost = readyCost,
-		StowCost = stowCost
+		RawAmmoCost = rawAmmoCost,
+		DPSCost = 0,
+		FirepowerCost = rawAmmoCost
 	}
 
-	return readyCost + stowCost, detail
-end
-
-
--- Sum legacy manufacturing cost for a contraption.
-function ACE_CalcContraptionLegacyCost(con, baseEnt)
-	local total = 0
-	local ents = ACE_GetContraptionEntities(con, baseEnt)
-	for _, ent in ipairs(ents) do
-		if IsEnt(ent) then
-			total = total + ACE_GetEntLegacyCost(ent)
-		end
-	end
-	return total
+	return rawAmmoCost, detail
 end
 
 
@@ -325,9 +277,7 @@ function ACE_CalcNonArmorPoints(con, baseEnt)
 		Firepower = 0,
 		Ammo = 0,
 		AmmoReady = 0,
-		AmmoBackup = 0,
 		AmmoReadyRounds = 0,
-		AmmoBackupRounds = 0,
 		Crew = 0,
 		Electronics = 0
 	}
@@ -350,10 +300,9 @@ function ACE_CalcNonArmorPoints(con, baseEnt)
 			local ammoTotals, ammoDetails, ammoLineMap, builtAmmoCache = ACE_CalcAmmoSubsystem(ents, MIN_DETAIL_PTS)
 
 			totals.Ammo = ammoTotals.Ammo or 0
+			totals.Firepower = (totals.Firepower or 0) + (ammoTotals.Firepower or 0)
 			totals.AmmoReady = ammoTotals.AmmoReady or 0
-			totals.AmmoBackup = ammoTotals.AmmoBackup or 0
 			totals.AmmoReadyRounds = ammoTotals.AmmoReadyRounds or 0
-			totals.AmmoBackupRounds = ammoTotals.AmmoBackupRounds or 0
 
 			ammoLines = ammoLineMap or {}
 			ammoCache = builtAmmoCache
@@ -371,6 +320,9 @@ function ACE_CalcNonArmorPoints(con, baseEnt)
 		end
 	end
 
+	totals.RawFirepower = totals.Firepower or 0
+	totals.Firepower = math.max((totals.RawFirepower or 0) - (totals.Ammo or 0), 0)
+
 	local nonArmor = (totals.Engines or 0)
 		+ (totals.Firepower or 0)
 		+ (totals.Ammo or 0)
@@ -383,909 +335,27 @@ function ACE_CalcNonArmorPoints(con, baseEnt)
 	return nonArmor, totals, { Items = trimmed, AmmoLines = ammoList }, ammoCache
 end
 
--- Recompute cached non-armor totals for a contraption.
-function ACE_RebuildNonArmorPoints(con, baseEnt)
-	if not con then return end
-
+-- Calculate armor points and per-entity readout lines.
+function ACE_CalcContraptionArmorPoints(con, baseEnt)
+	local total = 0
+	local details = {}
 	local ents = ACE_GetContraptionEntities(con, baseEnt)
-	local subsystems = ACE.PointSubsystems or {
-		"Engines",
-		"Firepower",
-		"Ammo",
-		"Crew",
-		"Electronics"
-	}
 
-	con.ACESubsystemCache = con.ACESubsystemCache or {}
-	con.ACESubsystemDirty = con.ACESubsystemDirty or {}
-	ACE.DupeSubsystemCache = ACE.DupeSubsystemCache or {}
-
-	local dupeKeys = con.ACEDupeSubsystemKeys
-	if not istable(dupeKeys) then
-		dupeKeys = {}
-	end
-
-	-- Resolve a cache key for the subsystem and update stored keys.
-	local function getSubsystemKey(subsystem)
-		local key = dupeKeys[subsystem]
-		if key then return key end
-
-		key = ACE_GetSubsystemSignatureFromEnts(subsystem, ents)
-		if key then
-			dupeKeys[subsystem] = key
-		end
-		return key
-	end
-
-	-- Load or compute cached data for a subsystem.
-	local function cacheSubsystem(subsystem)
-		local cached = con.ACESubsystemCache[subsystem]
-		if cached and not con.ACESubsystemDirty[subsystem] then
-			return cached
-		end
-
-		local key = getSubsystemKey(subsystem)
-		if key then
-			local shared = ACE.DupeSubsystemCache[key]
-			if shared then
-				if subsystem == "Ammo" then
-					local ammoCache = ACE_BuildAmmoCache(ents)
-					local data = {
-						Totals = shared.Totals or {},
-						Details = shared.Details or {},
-						AmmoLines = shared.AmmoLines or {},
-						AmmoCache = ammoCache
-					}
-					con.ACESubsystemCache[subsystem] = data
-					con.ACESubsystemDirty[subsystem] = false
-					return data
-				end
-
-				con.ACESubsystemCache[subsystem] = shared
-				con.ACESubsystemDirty[subsystem] = false
-				return shared
-			end
-		end
-
-		local data
-		if subsystem == "Ammo" then
-			local ammoTotals, ammoDetails, ammoLines, ammoCache = ACE_CalcAmmoSubsystem(ents, MIN_DETAIL_PTS)
-			data = {
-				Totals = ammoTotals,
-				Details = ammoDetails,
-				AmmoLines = ammoLines,
-				AmmoCache = ammoCache
-			}
-		else
-			local pts, items = ACE_CalcNonAmmoSubsystem(ents, subsystem, MIN_DETAIL_PTS)
-			data = {
-				Totals = { [subsystem] = pts or 0 },
-				Details = items
-			}
-		end
-
-		con.ACESubsystemCache[subsystem] = data
-		con.ACESubsystemDirty[subsystem] = false
-
-		if key then
-			if subsystem == "Ammo" then
-				ACE.DupeSubsystemCache[key] = {
-					Totals = data.Totals,
-					Details = data.Details,
-					AmmoLines = data.AmmoLines
-				}
-			else
-				ACE.DupeSubsystemCache[key] = data
-			end
-		end
-
-		return data
-	end
-
-	local totals = {
-		Engines = 0,
-		Firepower = 0,
-		Ammo = 0,
-		AmmoReady = 0,
-		AmmoBackup = 0,
-		AmmoReadyRounds = 0,
-		AmmoBackupRounds = 0,
-		Crew = 0,
-		Electronics = 0
-	}
-
-	local detailItems = {}
-	local ammoLines = {}
-
-	for _, subsystem in ipairs(subsystems) do
-		local data = cacheSubsystem(subsystem)
-		if data and data.Totals then
-			for k, v in pairs(data.Totals) do
-				totals[k] = (totals[k] or 0) + (v or 0)
-			end
-		end
-
-		if data and data.Details then
-			for _, item in ipairs(data.Details) do
-				detailItems[#detailItems + 1] = item
-			end
-		end
-
-		if subsystem == "Ammo" and data then
-			ammoLines = data.AmmoLines or {}
-			con.ACEAmmoCache = data.AmmoCache
-		end
-	end
-
-	local nonArmor = (totals.Engines or 0)
-		+ (totals.Firepower or 0)
-		+ (totals.Ammo or 0)
-		+ (totals.Crew or 0)
-		+ (totals.Electronics or 0)
-
-	con.ACEPointsNonArmor = nonArmor
-	con.ACEPointsPerType = con.ACEPointsPerType or {}
-
-	for k, v in pairs(totals) do
-		con.ACEPointsPerType[k] = v
-	end
-
-	con.ACEPointsDetails = {
-		Items = ACE_TrimDetailItems(detailItems, MIN_DETAIL_PTS),
-		AmmoLines = ACE_BuildAmmoLineList(ammoLines)
-	}
-
-	con.ACEDupeSubsystemKeys = next(dupeKeys) and dupeKeys or nil
-	con.ACENonArmorDirty = false
-end
-
-
--- ============================================================
--- Armor scan logic
--- ============================================================
-
-ACE_CalcContraptionArmor = function(ent)
-	if not IsEnt(ent) then return 0, 0 end
-
-	-- Resolve direction vectors and scan LOS armor samples.
-
-	local contraption = ent.GetContraption and ent:CFW_GetContraption() or nil
-	local contraptionId = contraption and ACE_GetContraptionIndex and ACE_GetContraptionIndex(contraption)
-		or (ent.ACF and ent.ACF.ContraptionId)
-
-	local contraptionEnts = {}
-
-	if contraption and contraption.ents then
-		for candidate in pairs(contraption.ents) do
-			if IsEnt(candidate) then contraptionEnts[#contraptionEnts + 1] = candidate end
-		end
-	elseif contraptionId then
-		for _, candidate in ipairs(ACE.contraptionEnts or {}) do
-			if IsEnt(candidate) then
-				local acf = candidate.ACF
-				if acf and acf.ContraptionId == contraptionId then
-					contraptionEnts[#contraptionEnts + 1] = candidate
-				end
-			end
-		end
-	end
-
-	if #contraptionEnts == 0 then contraptionEnts[1] = ent end
-	if #contraptionEnts > 1 then
-		table.sort(contraptionEnts, function(a, b) return a:EntIndex() < b:EntIndex() end)
-	end
-
-	local contraptionSet = {}
-	for _, comp in ipairs(contraptionEnts) do
-		contraptionSet[comp] = true
-	end
-
-	-- Normalize a vector or return nil.
-	local function normalizeOrNil(vec)
-		if not vec then return nil end
-		local len = vec:Length()
-		if len <= 1e-6 then return nil end
-		return vec / len
-	end
-
-	-- Project a vector onto a plane.
-	local function flattenToPlane(vec, up)
-		if not vec or not up then return nil end
-		return normalizeOrNil(vec - up * vec:Dot(up))
-	end
-
-	-- Resolve a world-up vector from gravity.
-	local function getWorldUp()
-		local gravity = physenv and physenv.GetGravity and physenv.GetGravity() or Vector(0, 0, -1)
-		if gravity:LengthSqr() <= 1e-6 then return Vector(0, 0, 1) end
-		return (-gravity):GetNormalized()
-	end
-
-	local function getWorldPlaneBasis(up)
-		local seedFront = flattenToPlane(Vector(1, 0, 0), up)
-			or flattenToPlane(Vector(0, 1, 0), up)
-			or Vector(1, 0, 0)
-		local seedSide = normalizeOrNil(up:Cross(seedFront)) or Vector(0, 1, 0)
-
-		return seedFront, seedSide
-	end
-
-	local origin = Vector(0, 0, 0)
-	local originCount = 0
-	for _, comp in ipairs(contraptionEnts) do
-		if not IsEnt(comp) then continue end
-		origin = origin + comp:WorldSpaceCenter()
-		originCount = originCount + 1
-	end
-	origin = originCount > 0 and (origin / originCount) or ent:WorldSpaceCenter()
-
-	-- Detect sphered wheel props.
-	local function isMakeSpherical(e)
-		local override = e and e.RenderOverride
-		return override and tostring(override):find("MakeSpherical") ~= nil
-	end
-
-	-- Compute world-space bounds for a prop.
-	local function getBoundsWorld(prop, scale)
-		local mins, maxs = prop:OBBMins(), prop:OBBMaxs()
-		scale = scale or 0.75
-		local corners = {
-			Vector(mins.x, mins.y, mins.z),
-			Vector(mins.x, mins.y, maxs.z),
-			Vector(mins.x, maxs.y, mins.z),
-			Vector(mins.x, maxs.y, maxs.z),
-			Vector(maxs.x, mins.y, mins.z),
-			Vector(maxs.x, mins.y, maxs.z),
-			Vector(maxs.x, maxs.y, mins.z),
-			Vector(maxs.x, maxs.y, maxs.z)
-		}
-		for i, v in ipairs(corners) do
-			corners[i] = prop:LocalToWorld(v * scale)
-		end
-		return corners
-	end
-
-	local function getShapeSampleWeight(comp)
-		local size = comp:OBBMaxs() - comp:OBBMins()
-		local volume = math.abs(size.x * size.y * size.z)
-
-		return math.max(volume ^ (1 / 3), 1)
-	end
-
-	local function addAligned(sum, vec, weight)
-		vec = normalizeOrNil(vec)
-		if not vec then return sum end
-
-		if sum:LengthSqr() > 1e-6 and vec:Dot(sum) < 0 then vec = -vec end
-
-		return sum + vec * (weight or 1)
-	end
-
-	-- Estimate left/right from wheel positions relative to their constrained bases.
-	local function getWheelBaseSide(ents, up)
-		if not constraint or not constraint.FindConstraints then return nil, 0 end
-
-		local sideSum = Vector(0, 0, 0)
-		local seenPairs = {}
-		local pairCount = 0
-
-		for _, base in ipairs(ents) do
-			if not IsEnt(base) then continue end
-			if isMakeSpherical(base) then continue end
-
-			local cons = constraint.FindConstraints(base, "Axis")
-			if not istable(cons) then continue end
-
-			for _, con in ipairs(cons) do
-				if not con or (con.Ent1 ~= base and con.Ent2 ~= base) then continue end
-
-				local other = (con.Ent1 == base) and con.Ent2 or con.Ent1
-				if not IsEnt(other) or not isMakeSpherical(other) then continue end
-
-				local pairKey = math.min(base:EntIndex(), other:EntIndex()) .. ":" .. math.max(base:EntIndex(), other:EntIndex())
-				if seenPairs[pairKey] then continue end
-				seenPairs[pairKey] = true
-
-				local rel = flattenToPlane(other:WorldSpaceCenter() - base:WorldSpaceCenter(), up)
-				if not rel then continue end
-				local relLen = rel:Length()
-				if relLen <= 1e-6 then continue end
-
-				sideSum = addAligned(sideSum, rel, relLen)
-				pairCount = pairCount + 1
-			end
-		end
-
-		return normalizeOrNil(sideSum), pairCount
-	end
-
-	-- Build a horizontal basis from the contraption footprint.
-	local function getShapeBasis(ents, up)
-		local seedFront, seedSide = getWorldPlaneBasis(up)
-		local points = {}
-		local totalWeight = 0
-		local sumX = 0
-		local sumY = 0
-
-		for _, comp in ipairs(ents) do
-			if not IsEnt(comp) or isMakeSpherical(comp) then continue end
-
-			local rel = comp:WorldSpaceCenter() - origin
-			local px = rel:Dot(seedFront)
-			local py = rel:Dot(seedSide)
-			local weight = getShapeSampleWeight(comp)
-
-			points[#points + 1] = { x = px, y = py, w = weight }
-			totalWeight = totalWeight + weight
-			sumX = sumX + px * weight
-			sumY = sumY + py * weight
-		end
-
-		if totalWeight <= 1e-6 then return nil, nil end
-
-		local meanX = sumX / totalWeight
-		local meanY = sumY / totalWeight
-		local covXX = 0
-		local covXY = 0
-		local covYY = 0
-
-		for _, point in ipairs(points) do
-			local dx = point.x - meanX
-			local dy = point.y - meanY
-			local weight = point.w or 1
-			covXX = covXX + dx * dx * weight
-			covXY = covXY + dx * dy * weight
-			covYY = covYY + dy * dy * weight
-		end
-
-		if covXX <= 1e-6 and covYY <= 1e-6 then return nil, nil end
-
-		local majorX, majorY
-		if math.abs(covXY) <= 1e-6 then
-			if covXX >= covYY then
-				majorX, majorY = 1, 0
-			else
-				majorX, majorY = 0, 1
-			end
-		else
-			local trace = covXX + covYY
-			local disc = math.sqrt(math.max((covXX - covYY) ^ 2 + 4 * covXY * covXY, 0))
-			local lambda = 0.5 * (trace + disc)
-			majorX = covXY
-			majorY = lambda - covXX
-		end
-
-		local majorAxis = normalizeOrNil(seedFront * majorX + seedSide * majorY)
-		local minorAxis = majorAxis and normalizeOrNil(up:Cross(majorAxis)) or nil
-		if not majorAxis or not minorAxis then return nil, nil end
-
-		return majorAxis, minorAxis
-	end
-
-	local function getEntOrientationWeight(comp)
-		local size = comp:OBBMaxs() - comp:OBBMins()
-		return math.max(size:Length(), 1)
-	end
-
-	local function getAxisSpan(ents, axis)
-		local minDot = math.huge
-		local maxDot = -math.huge
-
-		for _, comp in ipairs(ents) do
-			if not IsEnt(comp) then continue end
-
-			for _, corner in ipairs(getBoundsWorld(comp, 1)) do
-				local dot = corner:Dot(axis)
-				if dot < minDot then minDot = dot end
-				if dot > maxDot then maxDot = dot end
-			end
-		end
-
-		if minDot == math.huge or maxDot == -math.huge then return 0 end
-
-		return maxDot - minDot
-	end
-
-	-- Resolve which principal axis is forward/side using contraption-wide orientation agreement.
-	local function resolveBasisFromVotes(ents, up, axisA, axisB, wheelSide, wheelPairs)
-		if not axisA or not axisB then return nil, nil end
-
-		local spanA = getAxisSpan(ents, axisA)
-		local spanB = getAxisSpan(ents, axisB)
-		local abScore = spanA
-		local baScore = spanB
-		local abFrontSign = 0
-		local abSideSign = 0
-		local baFrontSign = 0
-		local baSideSign = 0
-
-		for _, comp in ipairs(ents) do
-			if not IsEnt(comp) or isMakeSpherical(comp) then continue end
-
-			local class = comp:GetClass()
-			local forward = flattenToPlane(comp:GetForward(), up)
-			local right = flattenToPlane(comp:GetRight(), up)
-			if not forward and not right then continue end
-
-			local weight = getEntOrientationWeight(comp)
-			local weaponWeight = (class == "acf_gun" or class == "acf_rack") and 1.5 or 1
-			local scoreAB = ((forward and math.abs(forward:Dot(axisA))) or 0) + ((right and math.abs(right:Dot(axisB))) or 0)
-			local scoreBA = ((forward and math.abs(forward:Dot(axisB))) or 0) + ((right and math.abs(right:Dot(axisA))) or 0)
-
-			abScore = abScore + scoreAB * weight
-			baScore = baScore + scoreBA * weight
-
-			if forward then
-				abFrontSign = abFrontSign + forward:Dot(axisA) * weight * weaponWeight
-				baFrontSign = baFrontSign + forward:Dot(axisB) * weight * weaponWeight
-			end
-			if right then
-				abSideSign = abSideSign + right:Dot(axisB) * weight
-				baSideSign = baSideSign + right:Dot(axisA) * weight
-			end
-		end
-
-		if wheelSide then
-			local wheelWeight = math.max(wheelPairs or 0, 1) * 2
-			abScore = abScore + math.abs(wheelSide:Dot(axisB)) * wheelWeight
-			baScore = baScore + math.abs(wheelSide:Dot(axisA)) * wheelWeight
-			abSideSign = abSideSign + wheelSide:Dot(axisB) * wheelWeight
-			baSideSign = baSideSign + wheelSide:Dot(axisA) * wheelWeight
-		end
-
-		local frontAxis, sideAxis, frontSign, sideSign
-		if abScore >= baScore then
-			frontAxis, sideAxis = axisA, axisB
-			frontSign, sideSign = abFrontSign, abSideSign
-		else
-			frontAxis, sideAxis = axisB, axisA
-			frontSign, sideSign = baFrontSign, baSideSign
-		end
-
-		if frontSign < 0 then
-			frontAxis = -frontAxis
-		end
-
-		local rightHandedSide = normalizeOrNil(up:Cross(frontAxis))
-		if sideSign < 0 or (math.abs(sideSign) <= 1e-6 and rightHandedSide and sideAxis:Dot(rightHandedSide) < 0) then
-			sideAxis = -sideAxis
-		end
-
-		return frontAxis, sideAxis
-	end
-
-	-- Build a stable basis: shape first, then wheel evidence, then simple entity-axis fallback.
-	local upDir = getWorldUp()
-	local wheelSide, wheelPairs = getWheelBaseSide(contraptionEnts, upDir)
-	local shapeMajor, shapeMinor = getShapeBasis(contraptionEnts, upDir)
-	local frontDir, sideDir = resolveBasisFromVotes(contraptionEnts, upDir, shapeMajor, shapeMinor, wheelSide, wheelPairs)
-	local worldFront = getWorldPlaneBasis(upDir)
-
-	frontDir = frontDir
-		or shapeMajor
-		or worldFront
-		or Vector(1, 0, 0)
-	sideDir = sideDir
-		or wheelSide
-		or normalizeOrNil(upDir:Cross(frontDir))
-		or Vector(0, 1, 0)
-
-	sideDir = normalizeOrNil(sideDir - frontDir * sideDir:Dot(frontDir)) or sideDir
-
-	local adjustedFront = normalizeOrNil(sideDir:Cross(upDir))
-	if adjustedFront and adjustedFront:Dot(frontDir) < 0 then adjustedFront = -adjustedFront end
-	frontDir = adjustedFront or frontDir
-
-	local debugDraw = ACE.ArmorDebugCvar and ACE.ArmorDebugCvar:GetBool() or false
-
-	-- Critical components are sampled for forward armor bias.
-	local function isEmptyAmmoCrate(ent)
-		if not IsEnt(ent) or ent:GetClass() ~= "acf_ammo" then return false end
-		return (tonumber(ent.Ammo) or 0) <= 0
-	end
-
-	local criticals = {}
-	local fallbackCriticals = {}
-	for _, cent in ipairs(contraptionEnts) do
-		if IsEnt(cent) then
-			local cls = cent:GetClass()
-			if cls == "acf_ammo" and isEmptyAmmoCrate(cent) then
-				continue
-			end
-
-			if cls == "acf_ammo" or cls == "acf_fueltank" or cls == "acf_engine"
-				or cls == "ace_crewseat_gunner" or cls == "ace_crewseat_loader" or cls == "ace_crewseat_driver" then
-				criticals[#criticals + 1] = cent
-			elseif cls == "acf_gun" or cls == "acf_rack" then
-				fallbackCriticals[#fallbackCriticals + 1] = cent
-			end
-		end
-	end
-
-	if #criticals == 0 and #fallbackCriticals > 0 then
-		criticals = fallbackCriticals
-	end
-
-	local ignoredArmor = table.Copy(ACF.TraceFilter or {})
-	table.Merge(ignoredArmor, {
-		acf_gun = false,
-		acf_rack = false,
-		ace_crewseat_gunner = true,
-		ace_crewseat_loader = true,
-		ace_crewseat_driver = true
-	})
-
-	-- Build an orthonormal basis from a direction.
-	local function basisFromDir(dir)
-		dir = dir:GetNormalized()
-		local upHint = (math.abs(dir.z) < 0.99) and Vector(0, 0, 1) or Vector(1, 0, 0)
-		local u = dir:Cross(upHint):GetNormalized()
-		local v = dir:Cross(u):GetNormalized()
-		return u, v
-	end
-
-	-- Calculate projected area and centroid.
-	local function projectedData(comp, dir)
-		local u, v = basisFromDir(dir)
-		local corners = getBoundsWorld(comp)
-
-		local minU, maxU = math.huge, -math.huge
-		local minV, maxV = math.huge, -math.huge
-
-		for _, wpos in ipairs(corners) do
-			local pu, pv = wpos:Dot(u), wpos:Dot(v)
-			if pu < minU then minU = pu end
-			if pu > maxU then maxU = pu end
-			if pv < minV then minV = pv end
-			if pv > maxV then maxV = pv end
-		end
-
-		local area = (maxU - minU) * (maxV - minV)
-		return area, (maxU - minU) * 0.5, (maxV - minV) * 0.5
-	end
-
-	-- Sample the actual world-space extent instead of component-local right/up axes.
-	local function getSamplePoints(comp)
-		local samples = getBoundsWorld(comp, 0.95)
-		samples[#samples + 1] = comp:WorldSpaceCenter()
-
-		return samples
-	end
-
-	local frontU, frontV = basisFromDir(frontDir)
-	local sideU, sideV = basisFromDir(sideDir)
-
-	local scanCfg = ACE.ArmorScanConfig or {}
-	local regionSnap = scanCfg.RegionSnap or 2
-	local tracePadding = scanCfg.TracePadding or 64
-
-	local function getProjectionRange(dir)
-		local minDot = math.huge
-		local maxDot = -math.huge
-
-		for _, comp in ipairs(contraptionEnts) do
-			if not IsEnt(comp) then continue end
-
-			for _, corner in ipairs(getBoundsWorld(comp, 1)) do
-				local dot = corner:Dot(dir)
-				if dot < minDot then minDot = dot end
-				if dot > maxDot then maxDot = dot end
-			end
-		end
-
-		if minDot == math.huge or maxDot == -math.huge then
-			local centerDot = origin:Dot(dir)
-			return centerDot, centerDot
-		end
-
-		return minDot, maxDot
-	end
-
-	local frontMin = getProjectionRange(frontDir)
-	local sideMin, sideMax = getProjectionRange(sideDir)
-
-	-- Build a region bucket key.
-	local function regionKey(pos, u, v)
-		if not pos then return nil end
-		local rel = pos - origin
-		local ku = math.floor(rel:Dot(u) / regionSnap + 0.5)
-		local kv = math.floor(rel:Dot(v) / regionSnap + 0.5)
-		return ku .. ":" .. kv
-	end
-
-	-- Accumulate armor region statistics.
-	local function updateRegion(regions, key, val, weight)
-		if not key or val <= 0 then return end
-		local cur = regions[key]
-		if not cur or val > cur.val then
-			regions[key] = { val = val, weight = weight }
-		end
-	end
-
-	local hullSize = scanCfg.TraceHullSize or 3
-	local TRACE_HULL_MINS = Vector(-hullSize, -hullSize, -hullSize)
-	local TRACE_HULL_MAXS = Vector(hullSize, hullSize, hullSize)
-	local TRACE_MAX_STEPS = scanCfg.TraceMaxSteps or 128
-
-	-- Calculate effective LOS armor at a trace impact point.
-	local function calcLosArmor(hitEnt, hitNormal, shotDir)
-		local acf = hitEnt.ACF
-		if not istable(acf) then return 0 end
-
-		local mat = acf.Material or "RHA"
-		local matData = ACE_GetMaterialData(mat)
-		local armor = acf.Armour or 0
-		if armor <= 0 then return 0 end
-
-		local armorData = hitEnt.acfPropArmorData and hitEnt:acfPropArmorData()
-		local effKE = (armorData and armorData.Effectiveness) or (matData and matData.effectiveness) or 1
-		local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
-			or (matData and (matData.HEATeffectiveness or matData.effectiveness))
-			or effKE
-
-		local eff = effKE * 0.8 + effCHEM * 0.2
-		local curve = (armorData and armorData.Curve) or 1
-		local ang = ACF_GetHitAngle(hitNormal, shotDir)
-
-		if ang >= 89 then
-			return (armor ^ curve) * eff
-		end
-
-		local cosAng = math.max(math.cos(math.rad(ang)), 0.01)
-		local los = (armor / (cosAng ^ ACF.SlopeEffectFactor)) ^ curve
-		return los * eff
-	end
-
-	-- Line-of-sight test with filter rules.
-	local function losFiltered(startPos, endPos, targetComp)
-		local filter = {}
-		local total = 0
-		local dir = (endPos - startPos):GetNormalized()
-		local hitTarget = false
-
-		for _ = 1, TRACE_MAX_STEPS do
-			-- Small hull keeps thin props from slipping through the trace.
-			local tr = util.TraceHull({
-				start = startPos,
-				endpos = endPos,
-				mins = TRACE_HULL_MINS,
-				maxs = TRACE_HULL_MAXS,
-				filter = filter,
-				mask = MASK_SOLID
-			})
-
-			if not tr.Hit then break end
-			local hitEnt = tr.Entity
-			if not IsEnt(hitEnt) then break end
-
-			if not contraptionSet[hitEnt] then
-				filter[#filter + 1] = hitEnt
-				startPos = tr.HitPos + dir * 0.1
-			else
-				local skip = false
-
-				if hitEnt.RenderOverride and tostring(hitEnt.RenderOverride):find("MakeSpherical") then
-					skip = true
-				end
-
-				if not skip and hitEnt == targetComp then
-					hitTarget = true
-					break
-				end
-
-				if not skip then
-					local cls = hitEnt:GetClass()
-					local skipArmor = ignoredArmor[cls] or not ACF_Check(hitEnt)
-					if not skipArmor and cls == "acf_ammo" and isEmptyAmmoCrate(hitEnt) then
-						skipArmor = true
-					end
-					if skipArmor then
-						skip = true
-					elseif ACF_CheckClips(hitEnt, tr.HitPos) then
-						skip = true
-					end
-				end
-
-				if skip then
-					filter[#filter + 1] = hitEnt
-					startPos = tr.HitPos + dir * 0.1
-				else
-					total = total + calcLosArmor(hitEnt, tr.HitNormal, dir)
-					filter[#filter + 1] = hitEnt
-					startPos = tr.HitPos + dir * 0.1
-				end
-			end
-		end
-
-		if not hitTarget then return 0 end
-		return total
-	end
-
-	-- Map a ratio to a debug color.
-	local function ACE_DebugColorRatio(r)
-		r = math.Clamp(r or 0, 0, 1)
-
-		-- red -> yellow -> green
-		local rr = math.floor(255 * (1 - r))
-		local gg = math.floor(255 * r)
-		local bb = 0
-
-		-- keep it readable when low
-		if r < 0.5 then
-			gg = math.floor(255 * (r * 2))
-			rr = 255
-		else
-			rr = math.floor(255 * (1 - (r - 0.5) * 2))
-			gg = 255
-		end
-
-		return Color(rr, gg, bb, 255)
-	end
-
-	local debugSamples = debugDraw and {} or nil
-	local debugMaxLOS = 0
-
-	local frontRegions, sideRegions = {}, {}
-	local compContrib = {}
-
-	for _, comp in ipairs(criticals) do
-		local frontArea = projectedData(comp, frontDir)
-		local sideArea = projectedData(comp, sideDir)
-		local compFrontMin = math.huge
-		local compSideMin = math.huge
-		local compSideMax = -math.huge
-
-		for _, corner in ipairs(getBoundsWorld(comp, 1)) do
-			local frontDot = corner:Dot(frontDir)
-			local sideDot = corner:Dot(sideDir)
-			if frontDot < compFrontMin then compFrontMin = frontDot end
-			if sideDot < compSideMin then compSideMin = sideDot end
-			if sideDot > compSideMax then compSideMax = sideDot end
-		end
-
-		local samples = getSamplePoints(comp)
-
-		local sampleCount = #samples
-		local weightF = (sampleCount > 0) and (frontArea / sampleCount) or 0
-		local weightS = (sampleCount > 0) and (sideArea / sampleCount) or 0
-		local compFrontWeight = 0
-		local compSideWeight = 0
-
-		for _, pt in ipairs(samples) do
-			local pointFrontDot = pt:Dot(frontDir)
-			local pointSideDot = pt:Dot(sideDir)
-			local frontDist = math.max(pointFrontDot - frontMin, pointFrontDot - compFrontMin, 0) + tracePadding
-			local sideNegDist = math.max(pointSideDot - sideMin, pointSideDot - compSideMin, 0) + tracePadding
-			local sidePosDist = math.max(sideMax - pointSideDot, compSideMax - pointSideDot, 0) + tracePadding
-
-			local frontVal = losFiltered(pt - frontDir * frontDist, pt, comp)
-			local sideValA = losFiltered(pt - sideDir * sideNegDist, pt, comp)
-			local sideValB = losFiltered(pt + sideDir * sidePosDist, pt, comp)
-
-			local sideVal = 0
-			if sideValA > 0 and (sideValB <= 0 or sideValA <= sideValB) then
-				sideVal = sideValA
-			elseif sideValB > 0 then
-				sideVal = sideValB
-			end
-
-			if debugSamples then
-				local best = math.max(frontVal or 0, sideVal or 0)
-				if best > debugMaxLOS then debugMaxLOS = best end
-				debugSamples[#debugSamples + 1] = {
-					pos = pt,
-					front = frontVal or 0,
-					side = sideVal or 0
-				}
-			end
-
-			if frontVal > 0 then
-				updateRegion(frontRegions, regionKey(pt, frontU, frontV), frontVal, weightF)
-				compFrontWeight = compFrontWeight + frontVal * weightF
-			end
-			if sideVal > 0 then
-				updateRegion(sideRegions, regionKey(pt, sideU, sideV), sideVal, weightS)
-				compSideWeight = compSideWeight + sideVal * weightS
-			end
-		end
-
-		local compWeight = compFrontWeight + compSideWeight * 2
-		if compWeight > 0 then
-			compContrib[#compContrib + 1] = {
-				Ent = comp,
-				Weight = compWeight
-			}
-		end
-	end
-
-	if debugSamples and debugMaxLOS > 0 then
-		for _, s in ipairs(debugSamples) do
-			local best = math.max(s.front or 0, s.side or 0)
-			local ratio = best / debugMaxLOS
-			local col = ACE_DebugColorRatio(ratio)
-
-			-- small square at each sample point
-			debugoverlay.Box(s.pos, Vector(-1, -1, -1), Vector(1, 1, 1), 30, col)
-
-			-- optional: label the best value
-			-- debugoverlay.Text(s.pos + Vector(0, 0, 2), string.format("%.0f", best), 30, true)
-		end
-	end
-
-	local accumFront, countFront = 0, 0
-	for _, e in pairs(frontRegions) do
-		accumFront = accumFront + e.val * e.weight
-		countFront = countFront + e.weight
-	end
-
-	local accumSide, countSide = 0, 0
-	for _, e in pairs(sideRegions) do
-		accumSide = accumSide + e.val * e.weight
-		countSide = countSide + e.weight
-	end
-
-	local frontAvg = countFront > 0 and (accumFront / countFront) or 0
-	local sideAvg = countSide > 0 and (accumSide / countSide) or 0
-
-	local quantStep = scanCfg.ResultQuantizeMm or 0
-	if quantStep > 0 then
-		frontAvg = math.Round(frontAvg / quantStep) * quantStep
-		sideAvg = math.Round(sideAvg / quantStep) * quantStep
-	end
-
-	local totalArmorPts = ACE_CalcArmorPoints(frontAvg, sideAvg)
-
-	-- Build per-entity armor detail weights.
-	-- Prefer trace-derived armor entities if available; otherwise fallback to armor prop projected area weighting.
-	local detailWeights = {}
-	local detailWeightTotal = 0
-	for _, row in ipairs(compContrib) do
-		local comp = row.Ent
-		if IsEnt(comp) then
-			local cls = comp:GetClass()
-			if ACE.ArmorClasses and ACE.ArmorClasses[cls] then
-				local w = tonumber(row.Weight) or 0
-				if w > 0 then
-					detailWeights[#detailWeights + 1] = { Ent = comp, Weight = w }
-					detailWeightTotal = detailWeightTotal + w
-				end
-			end
-		end
-	end
-
-	if detailWeightTotal <= 0 then
-		for _, ent in ipairs(contraptionEnts) do
-			if IsEnt(ent) then
-				local cls = ent:GetClass()
-				if ACE.ArmorClasses and ACE.ArmorClasses[cls] then
-					local w = projectedData(ent, frontDir) + projectedData(ent, sideDir) * 2
-					if w > 0 then
-						detailWeights[#detailWeights + 1] = { Ent = ent, Weight = w }
-						detailWeightTotal = detailWeightTotal + w
-					end
-				end
-			end
-		end
-	end
-
-	local armorDetails = {}
-	if totalArmorPts > 0 and detailWeightTotal > 0 then
-		for _, row in ipairs(detailWeights) do
-			local comp = row.Ent
-			if IsEnt(comp) then
-				local pts = totalArmorPts * (row.Weight / detailWeightTotal)
-				local label = ACE_FormatDetailLabel(comp)
-				armorDetails[#armorDetails + 1] = {
-					Label = label,
-					RawPoints = pts,
+	for _, ent in ipairs(ents) do
+		if IsEnt(ent) then
+			local pts = ACE_GetArmorPoints(ent)
+			if pts > 0 then
+				total = total + pts
+				details[#details + 1] = {
+					Label = ACE_FormatDetailLabel(ent),
 					Points = ACE_SafeRound1(pts),
-					EntIndex = comp:EntIndex()
+					EntIndex = ent:EntIndex()
 				}
 			end
 		end
 	end
 
-	table.sort(armorDetails, function(a, b)
+	table.sort(details, function(a, b)
 		if a.Points == b.Points then
 			if a.EntIndex == b.EntIndex then return tostring(a.Label) < tostring(b.Label) end
 			return a.EntIndex < b.EntIndex
@@ -1293,121 +363,68 @@ ACE_CalcContraptionArmor = function(ent)
 		return a.Points > b.Points
 	end)
 
-	-- Keep detail sum aligned with displayed armor total after rounding.
-	if #armorDetails > 0 then
-		local detailTotal = 0
-		for _, entry in ipairs(armorDetails) do
-			detailTotal = detailTotal + (entry.Points or 0)
-		end
-
-		local correction = ACE_SafeRound1(totalArmorPts - detailTotal)
-		if correction ~= 0 then
-			armorDetails[1].Points = ACE_SafeNonNegative((armorDetails[1].Points or 0) + correction)
-		end
-
-		for _, entry in ipairs(armorDetails) do
-			entry.RawPoints = nil
-		end
-	end
-
-	return frontAvg, sideAvg, armorDetails
+	return total, details
 end
 
-
--- Ensure armor data is initialized and cached.
-function ACE_EnsureArmor(con, baseEnt, force)
+-- Rebuild requested point totals for a contraption from entity state.
+function ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
 	if not con then return end
-
-	local cacheStale = ACE_EnsureCacheVersion and ACE_EnsureCacheVersion(con) or false
-	local needsInit = not con.ACEArmorCalculated or (con.ACEArmorLastCalc or 0) <= 0
-	if not force and not needsInit and not con.ACEArmorDirty and not cacheStale then return end
 
 	local base = baseEnt
 	if (not IsEnt(base)) and con.GetACEBaseplate then base = con:GetACEBaseplate() end
 
-	local front, side = 0, 0
-	local armorDetails = con.ACEArmorDetails or {}
-	local usedCache = false
+	local totals = con.ACEPointsPerType or {}
 
-	local cacheKey = con.ACEArmorCacheKey
-	local cached = con.ACEArmorCachedData
-	if ACE_DebugCache then
-		local info = string.format("key=%s cached=%s", tostring(cacheKey or "nil"), tostring(cached ~= nil))
-		ACE_DebugCache(con, "ensure-cache", base, info, "EnsureArmor")
-	end
-	if cached then
-		front = cached.Front or cached.front or 0
-		side = cached.Side or cached.side or 0
-		local cachedDetails = cached.Details or cached.details
-		local cacheVersion = cached.Version or cached.version or 1
-		local expectedVersion = ACE.ArmorCacheVersion or 1
+	if rebuildNonArmor then
+		local nonArmor, nonArmorTotals, details, ammoCache = ACE_CalcNonArmorPoints(con, base)
+		totals = nonArmorTotals or {}
 
-		if cacheVersion == expectedVersion and ACE_IsValidArmorResult(front, side) and ACE_IsValidArmorDetails(cachedDetails) then
-			con.ACEArmorFront = front
-			con.ACEArmorSide = side
-			armorDetails = cachedDetails or armorDetails
-			usedCache = true
-		else
-			front, side = 0, 0
-			usedCache = false
-		end
+		con.ACEPointsNonArmor = nonArmor or 0
+		con.ACEPointsDetails = details or { Items = {}, AmmoLines = {} }
+		con.ACEAmmoCache = ammoCache
+		con.ACENonArmorDirty = false
 	end
 
-	if not usedCache and IsEnt(base) then
-		front, side, armorDetails = ACE_CalcContraptionArmor(base)
-		con.ACEArmorFront = front
-		con.ACEArmorSide = side
+	if rebuildArmor then
+		local armorPts, armorDetails = ACE_CalcContraptionArmorPoints(con, base)
+
+		con.ACEArmorPoints = armorPts
+		con.ACEArmorFront = 0
+		con.ACEArmorSide = 0
+		con.ACEArmorDetails = armorDetails or {}
+		con.ACEArmorDirty = false
+		con.ACEArmorCalculated = true
+		con.ACEArmorLastCalc = CurTime()
 	end
 
-	if con.ACENonArmorDirty or not con.ACEPointsPerType then
-		ACE_RebuildNonArmorPoints(con, base)
-	end
+	local armorPts = con.ACEArmorPoints or totals.Armor or 0
+	totals.Armor = armorPts
+	con.ACEPointsPerType = totals
+	con.ACEPoints = (con.ACEPointsNonArmor or 0) + armorPts
+	con.ACEPointsDirty = con.ACEArmorDirty or con.ACENonArmorDirty or false
 
-	local newArmorPts = ACE_CalcArmorPoints(front, side)
-
-	con.ACEPointsPerType = con.ACEPointsPerType or {}
-	con.ACEPointsPerType.Armor = newArmorPts
-
-	con.ACEArmorPoints = newArmorPts
-	con.ACEArmorDetails = armorDetails or {}
-	con.ACEArmorDirty = false
-	con.ACEArmorCalculated = true
-	con.ACEArmorLastCalc = CurTime()
-
-	con.OTWarnings = con.OTWarnings or {}
-	con.OTWarnings.WarnedModified = false
-
-	local nonArmor = con.ACEPointsNonArmor or 0
-	con.ACEPoints = nonArmor + newArmorPts
-
-	local cacheKey = con.ACEArmorCacheKey
-	if cacheKey and not usedCache and ACE_IsValidArmorResult(front, side) then
-		ACE.DupeArmorCache = ACE.DupeArmorCache or {}
-		ACE.DupeArmorCache[cacheKey] = {
-			Version = ACE.ArmorCacheVersion or 1,
-			Front = front,
-			Side = side,
-			Details = armorDetails
-		}
-		if ACE_DebugCache then
-			local info = string.format("write key=%s", tostring(cacheKey))
-			ACE_DebugCache(con, "cache-write", base, info, "EnsureArmor")
-		end
-	elseif ACE_DebugCache then
-		local info = string.format("skip key=%s used=%s valid=%s", tostring(cacheKey), tostring(usedCache), tostring(ACE_IsValidArmorResult(front, side)))
-		ACE_DebugCache(con, "cache-skip", base, info, "EnsureArmor")
-	end
-
-	con.ACEArmorCacheKey = nil
-	con.ACEArmorCachedData = nil
-
-	if ACE_DebugDirty then
-		ACE_DebugDirty(con, "armor-scan-complete", base,
-			string.format("front=%.2f side=%.2f cache=%s", front or 0, side or 0, tostring(usedCache)),
-			"EnsureArmor"
-		)
+	if not con.ACEPointsDirty then
+		con.OTWarnings = con.OTWarnings or {}
+		con.OTWarnings.WarnedModified = false
 	end
 end
 
-_G.ACE_EnsureArmor = ACE_EnsureArmor
+-- Ensure point data is initialized and current.
+function ACE_EnsureContraptionPoints(con, baseEnt, force)
+	if not con then return end
+
+	local cacheStale = ACE_EnsureCacheVersion and ACE_EnsureCacheVersion(con) or false
+	local needsInit = not con.ACEArmorCalculated or (con.ACEArmorLastCalc or 0) <= 0
+	if not force and not needsInit and not con.ACEPointsDirty and not con.ACEArmorDirty
+		and not con.ACENonArmorDirty and not cacheStale then
+		return
+	end
+
+	local rebuildArmor = force or needsInit or con.ACEArmorDirty or cacheStale
+	local rebuildNonArmor = force or con.ACENonArmorDirty or cacheStale or not con.ACEPointsPerType
+
+	ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
+end
+
+_G.ACE_EnsureContraptionPoints = ACE_EnsureContraptionPoints
 

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -93,15 +93,19 @@ local function ACE_BuildAmmoLineList(ammoLines)
 end
 
 
--- Build per-contraption ammo cache inputs.
+-- Build per-contraption ammo cache inputs. Order matters: the ready-rack alloc
+-- weights each crate by its effective rounds, and "effective rounds" includes
+-- the rack pre-load reserve -- so build the reserve first, then feed it in.
 local function ACE_BuildAmmoCache(ents)
 	local gunRpsById, racks = ACE_BuildGunRpsAndRacks(ents)
-	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents)
+	local rackReserve = ACE_BuildRackReserveAlloc(ents, racks)
+	local readyAlloc  = ACE_BuildAmmoReadyAlloc(ents, rackReserve)
 
 	return {
-		GunRpsById = gunRpsById,
-		Racks = racks,
-		ReadyAlloc = readyAlloc
+		GunRpsById  = gunRpsById,
+		Racks       = racks,
+		ReadyAlloc  = readyAlloc,
+		RackReserve = rackReserve
 	}
 end
 
@@ -121,10 +125,11 @@ local function ACE_CalcAmmoSubsystem(ents, minDetailPts)
 	local gunRpsById = ammoCache.GunRpsById
 	local racks = ammoCache.Racks
 	local readyAlloc = ammoCache.ReadyAlloc
+	local rackReserve = ammoCache.RackReserve
 
 	for _, ent in ipairs(ents) do
 		if IsEnt(ent) and ent:GetClass() == "acf_ammo" then
-			local _, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks, readyAlloc)
+			local _, detail = ACE_CalcAmmoCratePoints(ent, gunRpsById, racks, readyAlloc, rackReserve)
 			if detail then
 				local rawCost = detail.RawAmmoCost or 0
 				local dpsCost = detail.DPSCost or 0
@@ -199,12 +204,20 @@ end
 -- ============================================================
 
 -- Calculate the points value for an ammo crate.
-function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
+function ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc, rackReserve)
 	if not IsEnt(crate) then return 0 end
 	local bdata = crate.BulletData
 	if not bdata then return 0 end
 
-	local rounds = crate.Capacity or 0
+	-- Effective rounds = loose rounds in this crate + missiles pre-loaded into
+	-- linked rack tubes that this crate could feed. The reserve portion comes
+	-- from ACE_BuildRackReserveAlloc, which distributes each rack's MaxMissile
+	-- across its compatible crates using the same rule that credits rack RPS
+	-- to a crate below. Without the reserve, an 8-tube rack primed from a
+	-- 2-round crate would price as if only those 2 loose rounds existed.
+	local crateCapacity = crate.Capacity or 0
+	local reserveRounds = (rackReserve and rackReserve[crate]) or 0
+	local rounds = crateCapacity + reserveRounds
 	if rounds <= 0 then return 0 end
 
 	local maxPen = ACE_GetAmmoMaxPen(bdata)

--- a/lua/acf/shared/missiles/missile_aam.lua
+++ b/lua/acf/shared/missiles/missile_aam.lua
@@ -66,7 +66,6 @@ ACF_defineGun("AIM-9 AAM", {								-- id
 		dragcoef			= 0.0005,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 415
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -142,7 +141,6 @@ ACF_defineGun("AIM-7 AAM", {							-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 1175
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -217,7 +215,6 @@ ACF_defineGun("AIM-120 AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -293,7 +290,6 @@ ACF_defineGun("AIM-54 AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.15,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -363,7 +359,6 @@ ACF_defineGun("SRAAM AAM", {								-- id
 		dragcoef			= 0.001,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 625
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -435,7 +430,6 @@ ACF_defineGun("Magic AAM", {								-- id
 		dragcoef			= 0.00075,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 415
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -511,7 +505,6 @@ ACF_defineGun("MICA AAM", {								-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 625
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -589,7 +582,6 @@ ACF_defineGun("Meteor AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -660,7 +652,6 @@ ACF_defineGun("R-60 AAM", {								-- id
 		dragcoef			= 0.0005,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 330
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -735,7 +726,6 @@ ACF_defineGun("R-73 AAM", {								-- id
 		dragcoef			= 0.001,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 625
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -811,7 +801,6 @@ ACF_defineGun("R-77 AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -887,7 +876,6 @@ ACF_defineGun("R-27 AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -960,7 +948,6 @@ ACF_defineGun("R-33 AAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 700
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_arty.lua
+++ b/lua/acf/shared/missiles/missile_arty.lua
@@ -69,7 +69,6 @@ ACF_defineGun("Type 63 RA", {							-- id
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333,
 
 
 
@@ -147,7 +146,6 @@ ACF_defineGun("SAKR-10 RA", {							-- id
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333,
 
 	},
 
@@ -225,7 +223,6 @@ ACF_defineGun("RW61 RA", {								-- id
 		predictiondelay		= 1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.4),						-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 667,
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -295,7 +292,6 @@ ACF_defineGun("M26 RA", {							-- id
 
 		dragcoef			= 0.00025,						-- percent speed loss per second
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 667,
 
 	},
 
@@ -366,7 +362,6 @@ ACF_defineGun("SS-40 RA", {								-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.2),					-- 139 HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 500,
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -438,7 +433,6 @@ ACF_defineGun("M31 RA", {							-- id
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333,
 
 	},
 
@@ -508,7 +502,6 @@ ACF_defineGun("ATACMS RA", {						-- id
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 833
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -584,7 +577,6 @@ ACF_defineGun("9M79-1", {						-- id
 		datalink			= false,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 4000
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_asm.lua
+++ b/lua/acf/shared/missiles/missile_asm.lua
@@ -67,7 +67,6 @@ ACF_defineGun("AGM-122 ASM", {						-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(0.4),				-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 714,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -141,7 +140,6 @@ ACF_defineGun("AGM-45 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(0.4),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 857
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -214,7 +212,6 @@ ACF_defineGun("AGM-88 ASM", {						-- id
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(0.6),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 1071
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -286,7 +283,6 @@ ACF_defineGun("KH-31 ASM", {						-- id
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 1071
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -358,7 +354,6 @@ ACF_defineGun("AGM-65 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 625
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -420,7 +415,6 @@ ACF_defineGun("AS-30 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 200,
 
 
 
@@ -486,7 +480,6 @@ ACF_defineGun("KH-23 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 100,
 
 
 
@@ -553,7 +546,6 @@ ACF_defineGun("KH-25 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 500,
 
 
 
@@ -627,7 +619,6 @@ ACF_defineGun("KH-29 ASM", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 800
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_atgm.lua
+++ b/lua/acf/shared/missiles/missile_atgm.lua
@@ -67,7 +67,6 @@ ACF_defineGun("BGM-71E ASM", {								-- id
 		calmul			= 0.3,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
 
-		pointcost			= 200
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -139,7 +138,6 @@ ACF_defineGun("9M113 ATGM", {									-- id
 		penmul			= math.sqrt(0.7),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.4,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 3,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 150
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -209,7 +207,6 @@ ACF_defineGun("9M133 ASM", {									-- id
 		calmul			= 0.5,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 4,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
 
-		pointcost			= 210
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -283,7 +280,6 @@ ACF_defineGun("AT-3 ASM", { --id
 		calmul			= 0.3,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 6,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
 
-		pointcost			= 50
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -357,7 +353,6 @@ ACF_defineGun("AT-2 ASM", { --id
 		penmul			= math.sqrt(1.55),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.3,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 5.25,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 100
 	},
 
 	ent				= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -429,7 +424,6 @@ ACF_defineGun("FGM-148 ASM", {
 		penmul			= math.sqrt(1.1),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.5,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 4,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 267
 	},
 
 	ent				= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -502,7 +496,6 @@ ACF_defineGun("Spike-LR ASM", {
 		penmul			= math.sqrt(2.5),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.5,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 7,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 400
 	},
 
 	ent				= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -579,7 +572,6 @@ ACF_defineGun("Kh-39 LMUR", {
 		penmul			= math.sqrt(1.35),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.2,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 4,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 700
 	},
 
 	ent				= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -655,7 +647,6 @@ ACF_defineGun("Ataka ASM", { --id
 		penmul			= math.sqrt(1.134),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.2,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 1.18,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 300
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -729,7 +720,6 @@ ACF_defineGun("AGM-114 ASM", {						--id
 		penmul				= math.sqrt(0.59),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 0.5,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 1.75,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 180
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -804,7 +794,6 @@ ACF_defineGun("Vikhr ASM", { --id
 		penmul			= math.sqrt(1.148),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.2,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 1,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 150
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -874,7 +863,6 @@ ACF_defineGun("MGM-166", { --id
 		penmul			= math.sqrt(0.1),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
 		calmul			= 0.000675,	--I guess it was a little too good at transfering energy. Increasing the velocitymul(energy limit) sent tanks to space
 		velmul			= 0.02,
-		pointcost			= 300
 	},
 
 	ent			= "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -944,7 +932,6 @@ ACF_defineGun("MIM-146", {										-- id
 
 
 		penmul			= math.sqrt(0.57),					-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)	--was 0.797
-		pointcost			= 353
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_bomb.lua
+++ b/lua/acf/shared/missiles/missile_bomb.lua
@@ -54,7 +54,6 @@ ACF_defineGun("50kgBOMB", {						-- id
 		penmul      = math.sqrt(0.05),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 50
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -111,7 +110,6 @@ ACF_defineGun("100kgBOMB", {						-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 100
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -167,7 +165,6 @@ ACF_defineGun("250kgBOMB", {						-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -223,7 +220,6 @@ ACF_defineGun("500kgBOMB", {						-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 750
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -276,7 +272,6 @@ ACF_defineGun("1000kgBOMB", {					-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 3000 --divided by 3 for unguided
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -328,7 +323,6 @@ ACF_defineGun("Mk82Bomb", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 333,
 
 
 
@@ -392,7 +386,6 @@ ACF_defineGun("Mk83Bomb", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 833,
 
 		penmul      = math.sqrt(0.15),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
@@ -451,7 +444,6 @@ ACF_defineGun("Mk84Bomb", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 1667,
 
 		penmul      = math.sqrt(0.2),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
@@ -512,7 +504,6 @@ ACF_defineGun("100kgGBOMB", {					-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 100
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.
@@ -570,7 +561,6 @@ ACF_defineGun("250kgGBOMB", {					-- id
 		penmul      = math.sqrt(0.3),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",			-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_gbu.lua
+++ b/lua/acf/shared/missiles/missile_gbu.lua
@@ -58,7 +58,6 @@ ACF_defineGun("GBU-39", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 100,
 
 
 
@@ -123,7 +122,6 @@ ACF_defineGun("FAB250-UPMP", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 400,
 
 
 
@@ -187,7 +185,6 @@ ACF_defineGun("227kgGBU", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 333,
 
 
 
@@ -250,7 +247,6 @@ ACF_defineGun("454kgGBU", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 833,
 
 		penmul      = math.sqrt(0.15),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
@@ -308,7 +304,6 @@ ACF_defineGun("909kgGBU", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 1667,
 
 		penmul      = math.sqrt(0.2),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
@@ -367,7 +362,6 @@ ACF_defineGun("WalleyeGBU", {						-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 1250,
 
 		penmul      = math.sqrt(0.5),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		calmul			= 1,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.

--- a/lua/acf/shared/missiles/missile_mininaval.lua
+++ b/lua/acf/shared/missiles/missile_mininaval.lua
@@ -71,7 +71,6 @@ ACF_defineGun("Scaled BGM-109 Tomahawk", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -155,7 +154,6 @@ ACF_defineGun("Scaled AGM-84 Harpoon", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 1000
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -239,7 +237,6 @@ ACF_defineGun("Scaled Storm Shadow ASM", {						-- id
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -322,7 +319,6 @@ ACF_defineGun("Scaled 3M-54 Kalibr", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -402,7 +398,6 @@ ACF_defineGun("Scaled Black Shark Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 1500,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -477,7 +472,6 @@ ACF_defineGun("Scaled G7a Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 1000,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -552,7 +546,6 @@ ACF_defineGun("Scaled Mk13 Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 750,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -627,7 +620,6 @@ ACF_defineGun("Scaled 9M317ME SAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -702,7 +694,6 @@ ACF_defineGun("Scaled 5V55 SAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 600
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_naval.lua
+++ b/lua/acf/shared/missiles/missile_naval.lua
@@ -71,7 +71,6 @@ ACF_defineGun("BGM-109 Tomahawk", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -155,7 +154,6 @@ ACF_defineGun("AGM-84 Harpoon", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 1000
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -239,7 +237,6 @@ ACF_defineGun("Storm Shadow ASM", {						-- id
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -322,7 +319,6 @@ ACF_defineGun("3M-54 Kalibr", {						-- id
 		predictiondelay		= 0.5,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		penmul            = math.sqrt(1),			-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
 		waterthrusttype 	= 1, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 250
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -405,7 +401,6 @@ ACF_defineGun("Black Shark Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 1500,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -486,7 +481,6 @@ ACF_defineGun("G7a Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 1000,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -562,7 +556,6 @@ ACF_defineGun("Mk13 Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 750,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -643,7 +636,6 @@ ACF_defineGun("Mk54 Torp", {						-- id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 		waterthrusttype 	= 4, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
 		buoyancy			= 1,
-		pointcost			= 750,
 	},
 
 	ent		= "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -720,7 +712,6 @@ ACF_defineGun("9M317ME SAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_pod.lua
+++ b/lua/acf/shared/missiles/missile_pod.lua
@@ -71,7 +71,6 @@ ACF_defineGun("40mmFFAR", { --id
 		penmul	= math.sqrt(0.5),
 
 		waterthrusttype = 0, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 50
 	},
 
 	ent		= "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
@@ -143,7 +142,6 @@ ACF_defineGun("70mmFFAR", { --id
 		velmul			= 4,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
 
 		waterthrusttype = 0, 	--0-stops underwater, 1-booster only underwater - DEFAULT, 2-works above and below, 3-underwater only, 4-booster all and under thrust only
-		pointcost			= 80
 	},
 
 	ent		= "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
@@ -212,7 +210,6 @@ ACF_defineGun("S8KO", { --id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul	= math.sqrt(0.65),	-- HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 80
 	},
 
 	ent        = "acf_missile_to_rack",
@@ -286,7 +283,6 @@ ACF_defineGun("Zuni ASR", { --id
 		calmul			= 0.4,	--Adjust this first. Used to balance the damage of kinetic missiles. Multiplier for the projectile caliber. Won't affect HEAT.
 		velmul			= 2,		--Used to balance the penetration of kinetic missiles. Multiplier for the velocity of the projectile on impact.
 
-		pointcost			= 200
 	},
 	ent        = "acf_missile_to_rack",
 	guidance   = {"Dumb"},

--- a/lua/acf/shared/missiles/missile_sam.lua
+++ b/lua/acf/shared/missiles/missile_sam.lua
@@ -64,7 +64,6 @@ ACF_defineGun("FIM-92 SAM", {								-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 83
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -137,7 +136,6 @@ ACF_defineGun("Mistral SAM", {								-- id
 		dragcoef			= 0.0015,						-- percent speed loss per second
 		inertialcapable		= true,						-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 83
 	},
 
 	ent        = "acf_missile_to_rack",						-- A workaround ent which spawns an appropriate rack for the missile.
@@ -211,7 +209,6 @@ ACF_defineGun("TY-90 AAM", {								-- id
 		dragcoef			= 0.002,						-- percent speed loss per second
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 415
 	},
 
 	ent        = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -287,7 +284,6 @@ ACF_defineGun("Strela-1 SAM", {								-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
-		pointcost			= 250
 	},
 
 	ent			= "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -358,7 +354,6 @@ ACF_defineGun("VT-1 SAM", {										-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 353
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -435,7 +430,6 @@ ACF_defineGun("9M311 SAM", {										-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 235
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -513,7 +507,6 @@ ACF_defineGun("9M331 SAM", {								-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 1.1,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 353
 	},
 
 	ent			= "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.
@@ -591,7 +584,6 @@ ACF_defineGun("9M38M1 SAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 333
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -666,7 +658,6 @@ ACF_defineGun("5V55 SAM", {							-- id
 		inertialcapable		= true,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.35,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 600
 	},
 
 	ent                = "acf_missile_to_rack",				-- A workaround ent which spawns an appropriate rack for the missile.
@@ -743,7 +734,6 @@ ACF_defineGun("StarstreakHVM", {										-- id
 		inertialcapable		= false,							-- Whether missile is capable of inertial guidance. Inertially guided missiles will follow their last track after losing the target. And can be fired offbore outside their seeker's viewcone.
 		datalink			= true,
 		predictiondelay		= 0.0,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
-		pointcost			= 235
 	},
 
 	ent        = "acf_missile_to_rack",					-- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/missiles/missile_uar.lua
+++ b/lua/acf/shared/missiles/missile_uar.lua
@@ -69,7 +69,6 @@ ACF_defineGun("SPG-9 ASR", { --id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.2),	-- 215.9 HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 50
 
 	},
 
@@ -138,7 +137,6 @@ ACF_defineGun("RS82 ASR", { --id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.3),	-- 215.9 HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 50
 	},
 
 	ent        = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
@@ -207,7 +205,6 @@ ACF_defineGun("HVAR ASR", { --id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.4),	-- 215.9 HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 65
 	},
 
 	ent        = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.
@@ -275,7 +272,6 @@ ACF_defineGun("S-24 ASR", { --id
 		predictiondelay		= 0.25,							-- Delay before enabling missile steering guidance. Missile will run straight at the aimpoint until this time. Done to cause missile to not self delete because it tries to steer its velocity at launch.
 
 		penmul            = math.sqrt(0.4),	-- 215.9 HEAT velocity multiplier. Squared relation to penetration (math.sqrt(2) means 2x pen)
-		pointcost			= 80
 	},
 
 	ent        = "acf_missile_to_rack", -- A workaround ent which spawns an appropriate rack for the missile.

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -816,39 +816,127 @@ function ACE_GetPtsType(className)
 	return ACE.ClassToType[className] or "Ignore"
 end
 
--- Validate armor scan results.
-function ACE_IsValidArmorResult(front, side)
-	if not front or not side then return false end
-	if front ~= front or side ~= side then return false end
-	if front <= 0 or side <= 0 then return false end
-	return true
+-- Resolve armor point tuning with conservative defaults.
+function ACE_GetArmorPointConfig()
+	local cfg = ACE.ArmorPointConfig or {}
+
+	return {
+		KEWeight = tonumber(cfg.KEWeight) or 0.8,
+		ChemWeight = tonumber(cfg.ChemWeight) or 0.2,
+		DamageReferenceMm = tonumber(cfg.DamageReferenceMm) or 50,
+		SurvivabilityScale = tonumber(cfg.SurvivabilityScale) or 100,
+		ArmorCostMultiplier = tonumber(cfg.ArmorCostMultiplier) or 1,
+		SurvivabilityArmorExponent = tonumber(cfg.SurvivabilityArmorExponent) or 1.15,
+		SurvivabilityHPExponent = tonumber(cfg.SurvivabilityHPExponent) or 0.45,
+		SurvivabilityHPReference = tonumber(cfg.SurvivabilityHPReference) or 100
+	}
 end
 
--- Convert front/side scan values to armor points.
-function ACE_CalcArmorPoints(front, side)
-	front = tonumber(front) or 0
-	side = tonumber(side) or 0
+-- Calculate material-adjusted armor thickness for one entity.
+function ACE_GetArmorEquivalentMm(ent)
+	if not ACE_IsEnt(ent) then return 0 end
 
-	local cfg = ACE.PointCostConfig or {}
-	local frontWeight = tonumber(cfg.ArmorFrontWeight) or 1
-	local sideWeight = tonumber(cfg.ArmorSideWeight) or 2.5
-	local armorScale = tonumber(cfg.ArmorScale) or 4
+	local acf = ent.ACF or {}
+	if not istable(acf) then return 0 end
 
-	return (front * frontWeight + side * sideWeight) * armorScale
-end
+	local mat = acf.Material or "RHA"
+	local matData = ACE_GetMaterialData and ACE_GetMaterialData(mat)
+	local armorData = ent.acfPropArmorData and ent:acfPropArmorData()
+	local armorMod = ACF.ArmorMod or 1
+	local armorMm = tonumber(acf.MaxArmour or acf.Armour) or 0
+	if armorMm <= 0 then return 0 end
 
--- Validate cached armor detail list structure.
-function ACE_IsValidArmorDetails(details)
-	if details == nil then return true end
-	if not istable(details) then return false end
+	local curve = (armorData and armorData.Curve) or 1
+	local effKE = (armorData and armorData.Effectiveness) or (matData and matData.effectiveness) or 1
+	local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
+		or (matData and (matData.HEATeffectiveness or matData.effectiveness))
+		or effKE
 
-	for _, row in ipairs(details) do
-		if not istable(row) then return false end
-		if not isnumber(row.Points) then return false end
+	local cfg = ACE_GetArmorPointConfig()
+	local weightedEff = effKE * cfg.KEWeight + effCHEM * cfg.ChemWeight
+
+	local effectiveMm = 0
+	if armorMm > 0 then
+		effectiveMm = (armorMm ^ curve) * weightedEff
 	end
 
-	return true
+	local rawMm = 0
+	if effectiveMm > 0 and armorMod > 0 then
+		rawMm = effectiveMm / armorMod
+	end
+
+	return rawMm
 end
+
+function ACE_GetSurvivabilityIndex(ent)
+	if not ACE_IsEnt(ent) then return 0 end
+
+	local armorMm = ACE_GetArmorEquivalentMm(ent)
+	if armorMm <= 0 then return 0 end
+
+	local acf = ent.ACF or {}
+	local hp = tonumber(acf.MaxHealth or acf.Health) or 0
+	if hp <= 0 then return 0 end
+
+	local cfg = ACE_GetArmorPointConfig()
+	local armorBase = math.max(cfg.DamageReferenceMm, 1)
+	local hpBase = math.max(cfg.SurvivabilityHPReference, 1)
+
+	return cfg.SurvivabilityScale
+		* ((armorMm / armorBase) ^ cfg.SurvivabilityArmorExponent)
+		* ((hp / hpBase) ^ cfg.SurvivabilityHPExponent)
+end
+
+function ACE_GetArmorPoints(ent)
+	if not ACE_IsEnt(ent) then return 0 end
+
+	if ACF_Check then
+		ACF_Check(ent)
+	end
+
+	local cacheKey = ent:EntIndex()
+	ACE.ArmorPointCache = ACE.ArmorPointCache or {}
+	if ACE.ArmorPointCache[cacheKey] ~= nil then
+		return ACE.ArmorPointCache[cacheKey]
+	end
+
+	local acf = ent.ACF or {}
+	if not istable(acf) then return 0 end
+
+	local armorMm = tonumber(acf.MaxArmour or acf.Armour) or 0
+	if armorMm <= 0 then return 0 end
+
+	local cfg = ACE_GetArmorPointConfig()
+	local points = math.max(ACE_GetSurvivabilityIndex(ent) * cfg.ArmorCostMultiplier, 0)
+	ACE.ArmorPointCache[cacheKey] = points
+
+	return points
+end
+
+-- Resolve crewseat point cost by role.
+function ACE_GetCrewSeatPointCost(ent)
+	if ACE_IsEnt(ent) and ent:GetClass() == "ace_crewseat_loader" then
+		return tonumber(ACE.LoaderSeatPointCost)
+			or tonumber((ACE.PointCostConfig or {}).LoaderSeatFlat)
+			or 300
+	end
+
+	return tonumber(ACE.CrewSeatPointCost)
+		or tonumber((ACE.PointCostConfig or {}).CrewSeatFlat)
+		or 100
+end
+
+function ACE_ClearArmorPointCache(ent)
+	if not ACE_IsEnt(ent) then return end
+	if ACE.ArmorPointCache then
+		ACE.ArmorPointCache[ent:EntIndex()] = nil
+	end
+end
+
+hook.Add("EntityRemoved", "ACE_ClearArmorPointCache", function(ent)
+	ACE_ClearArmorPointCache(ent)
+end)
+
 
 -- Safe helpers for point/readout math.
 function ACE_SafeNonNegative(value)
@@ -1081,31 +1169,27 @@ local function ACE_GetAmmoGuidancePenFactor(bdata)
 	return math.max(ACE_GetMissileGuidanceFactor(bdata.Data7), 1)
 end
 
--- Calculate per-missile legacy points (manufacturing-cost basis), including guidance.
-function ACE_CalcMissileLegacyRoundCost(bdata)
+-- Calculate per-missile base points, including guidance.
+function ACE_CalcMissileRoundPoints(bdata)
 	if not istable(bdata) then return 0 end
 
 	local ammoId = bdata.Id
 	local rackPointCost = ACF_GetRackValue and ACF_GetRackValue(bdata, "pointcost")
 	local gunPointCost = ACF_GetGunValue and ACF_GetGunValue(ammoId, "pointcost")
-	local legacyPts = tonumber(rackPointCost or 0) or tonumber(gunPointCost or 0) or 0
-	legacyPts = math.max(legacyPts, 0)
+	local configuredPts = tonumber(rackPointCost or 0) or tonumber(gunPointCost or 0) or 0
+	configuredPts = math.max(configuredPts, 0)
 
 	local factor = ACE_GetMissileGuidanceFactor(bdata.Data7)
-	local basePts = legacyPts
+	local basePts = configuredPts
 
 	if ACE_IsATGMCostAmmo(bdata) then
 		local cfg = ACE.ATGMCostConfig or {}
 		local perfPts = ACE_GetAmmoRoundPoints(bdata)
 		local perfMul = tonumber(cfg.PerformanceMul) or 1
-		local legacyWeight = math.Clamp(tonumber(cfg.LegacyWeight) or 0, 0, 1)
 		local minBase = tonumber(cfg.MinBase) or 25
 
 		if perfPts > 0 then
 			basePts = perfPts * perfMul
-			if legacyPts > 0 and legacyWeight > 0 then
-				basePts = basePts * (1 - legacyWeight) + legacyPts * legacyWeight
-			end
 		end
 
 		basePts = math.max(basePts, minBase)
@@ -1114,7 +1198,7 @@ function ACE_CalcMissileLegacyRoundCost(bdata)
 		return math.max(basePts, 0)
 	end
 
-	-- Non-ATGM missile racks still use legacy pointcost, so guidance is applied here.
+	-- Non-ATGM missiles use their configured rack/gun point value.
 	return math.max(basePts, 0) * factor
 end
 
@@ -1311,7 +1395,17 @@ function ACE_GetEntRps(ent)
 		return ACE_GetGunConfiguredRps(ent, ent.ROFLimit)
 	end
 
-	local reload = ent.ReloadTime
+	if ACE_IsEnt(ent) and ent:GetClass() == "acf_rack" then
+		local bdata = ent.BulletData or {}
+		local reload = (ACF_GetRackValue and ACF_GetRackValue(bdata, "reloadspeed"))
+			or (ACF_GetGunValue and ACF_GetGunValue(bdata.Id, "reloadspeed"))
+			or ent.ReloadTime
+
+		reload = tonumber(reload) or 0
+		if reload > 0 then return 1 / reload end
+	end
+
+	local reload = tonumber(ent.ReloadTime)
 	if reload and reload > 0 then return 1 / reload end
 
 	local rof = ent.RateOfFire
@@ -1320,13 +1414,22 @@ function ACE_GetEntRps(ent)
 	return 0
 end
 
--- Scale a gun's firepower points by its current ROF threat relative to its base ROF.
+-- Guns/racks keep ACEPoints at zero; firepower points are derived for readouts.
 function ACE_GetGunFirepowerPoints(ent)
-	if not ACE_IsEnt(ent) or ent:GetClass() ~= "acf_gun" then
-		return tonumber(ent and ent.ACEPoints) or 0
+	if not ACE_IsEnt(ent) then return 0 end
+
+	local class = ent:GetClass()
+	if class == "acf_rack" then
+		local maxMissile = tonumber(ent.MaxMissile) or 1
+		return 100 + math.max(maxMissile - 1, 0) * 50
 	end
 
-	local basePoints = tonumber(ent.ACEPoints) or 0
+	if class ~= "acf_gun" then
+		return 0
+	end
+
+	local basePoints = tonumber(ACF_GetGunValue and ACF_GetGunValue(ent.Id, "acepoints")) or 0.404
+	basePoints = basePoints * (tonumber(ACE.GunPointCostMultiplier) or 0.85)
 	if basePoints <= 0 then return 0 end
 
 	local currentRps = ACE_GetEntRps(ent)
@@ -1593,490 +1696,11 @@ function ACE_GetOwnerName(owner)
 	return ACE_IsEnt(owner) and owner:Nick() or "Unknown"
 end
 
--- Build a parent chain summary for debug logs.
-function ACE_GetEntChainSummary(ent, maxDepth)
-	if not ACE_IsEnt(ent) then return "?" end
-	local parts = {}
-	local cur = ent
-	local depth = 0
-	local limit = maxDepth or 4
-	while ACE_IsEnt(cur) and depth <= limit do
-		parts[#parts + 1] = string.format("%s(%d)", cur:GetClass(), cur:EntIndex())
-		cur = cur:GetParent()
-		depth = depth + 1
-	end
-	return table.concat(parts, " <- ")
-end
-
--- Format a position/angle tuple for dupe signatures.
-function ACE_FormatDupeTransform(pos, ang)
-	if pos and pos.x ~= nil and pos.y ~= nil and pos.z ~= nil then
-		pos = string.format("%.3f,%.3f,%.3f", pos.x, pos.y, pos.z)
-	end
-
-	if ang and ang.p ~= nil and ang.y ~= nil and ang.r ~= nil then
-		ang = string.format("%.2f,%.2f,%.2f", ang.p, ang.y, ang.r)
-	end
-
-	return tostring(pos or ""), tostring(ang or "")
-end
-
-function ACE_FormatArmorKey(material, ductility, armour, maxArmour, mass)
-	mass = mass or 0 -- shut up linter
-	-- Cache signatures should ignore runtime mass drift.
-	return string.format(
-		"mat=%s|duct=%.3f|arm=%.2f|max=%.2f",
-		tostring(material or ""),
-		tonumber(ductility) or 0,
-		tonumber(armour) or 0,
-		tonumber(maxArmour) or 0
-	)
-end
-
-local function ACE_ShouldIncludeArmorSignature(ent)
-	if not IsValid(ent) then return false end
-
-	local cls = ent:GetClass() or ""
-	if cls:find("gmod_wire_", 1, true) then return false end
-	if cls:find("starfall", 1, true) then return false end
-
-	if ent.RenderOverride and tostring(ent.RenderOverride):find("MakeSpherical") then
-		return false
-	end
-
-	if ACE_GetPtsType and ACE_GetPtsType(cls) == "Armor" then return true end
-
-	if cls == "prop_physics" or cls == "primitive_shape" then
-		local acf = ent.ACF
-		if acf and ((acf.Armour or acf.Armor) or (acf.MaxArmour or acf.MaxArmor)) then
-			return true
-		end
-	end
-
-	return false
-end
-
--- Build a signature for dupe cache lookups.
-function ACE_GetDupeSignature(dupe, created)
-	if not util or not util.SHA256 then return nil end
-
-	local entData = dupe and (dupe.Entities or dupe.Ents or dupe.EntityList or (dupe.Dupe and dupe.Dupe.Entities))
-	if istable(entData) then
-		local parts = {}
-
-		for _, data in pairs(entData) do
-			if istable(data) then
-				local class = data.Class or data.class or "unknown"
-				local model = data.Model or data.model or ""
-
-				local mods = data.EntityMods or data.entitymods
-				local acfSettings = mods and mods.acfsettings
-				local massMod = mods and mods.mass
-				local acf = data.ACF or data.acf
-
-				local material = (acfSettings and (acfSettings.Material or acfSettings.material)) or (acf and (acf.Material or acf.material))
-				local ductility = (acfSettings and (acfSettings.Ductility or acfSettings.ductility)) or (acf and (acf.Ductility or acf.ductility))
-				local armour = acf and (acf.Armour or acf.Armor)
-				local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
-				local mass = massMod and (massMod.Mass or massMod.mass)
-				local pos = data.Pos or data.pos
-				local ang = data.Angle or data.angle or data.Ang
-				local posKey, angKey = ACE_FormatDupeTransform(pos, ang)
-
-				parts[#parts + 1] = table.concat({
-					class,
-					model,
-					ACE_FormatArmorKey(material, ductility, armour, maxArmour, mass),
-					posKey,
-					angKey
-				}, "|")
-			end
-		end
-
-		table.sort(parts)
-		if #parts > 0 then
-			return tostring(ACE.DupeArmorCacheVersion) .. ":ents:" .. util.SHA256(table.concat(parts, ";"))
-		end
-	end
-
-	if istable(created) then
-		local parts = {}
-
-		local refEnt
-		for _, ent in pairs(created) do
-			if ACE_ShouldIncludeArmorSignature(ent) then
-				refEnt = ent
-				break
-			end
-		end
-
-		for _, ent in pairs(created) do
-			if ACE_ShouldIncludeArmorSignature(ent) then
-				local class = ent:GetClass() or "unknown"
-				local model = ent:GetModel() or ""
-
-				local acf = ent.ACF
-				local material = acf and acf.Material
-				local ductility = acf and acf.Ductility
-				local armour = acf and (acf.Armour or acf.Armor)
-				local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
-
-				local mass = 0
-				local phys = ent:GetPhysicsObject()
-				if IsValid(phys) then mass = phys:GetMass() end
-
-				local posKey, angKey = "", ""
-				if IsValid(refEnt) then
-					local relPos = refEnt:WorldToLocal(ent:GetPos())
-					local relAng = refEnt:WorldToLocalAngles(ent:GetAngles())
-					posKey, angKey = ACE_FormatDupeTransform(relPos, relAng)
-				end
-
-				parts[#parts + 1] = table.concat({
-					class,
-					model,
-					ACE_FormatArmorKey(material, ductility, armour, maxArmour, mass),
-					posKey,
-					angKey
-				}, "|")
-			end
-		end
-
-		table.sort(parts)
-		if #parts > 0 then
-			return tostring(ACE.DupeArmorCacheVersion) .. ":spawn:" .. util.SHA256(table.concat(parts, ";"))
-		end
-	end
-
-	return nil
-end
-
--- Build a signature for created entities using a fixed reference.
-local function ACE_BuildCreatedSignature(created, refEnt, wantInfo)
-	if not util or not util.SHA256 then return nil end
-	if not istable(created) then return nil end
-
-	refEnt = refEnt or nil
-	local parts = {}
-	local included = {}
-	local sum = Vector(0, 0, 0)
-	local count = 0
-
-	for _, ent in pairs(created) do
-		if ACE_ShouldIncludeArmorSignature(ent) then
-			included[#included + 1] = ent
-			sum = sum + ent:GetPos()
-			count = count + 1
-		end
-	end
-
-	if count == 0 then return nil end
-	local center = sum / count
-
-	local fallbackRef
-	local refToken = ""
-	if true then
-		local candidates = {}
-		for _, ent in ipairs(included) do
-			local class = ent:GetClass() or "unknown"
-			local model = ent:GetModel() or ""
-			local acf = ent.ACF
-			local material = acf and acf.Material
-			local ductility = acf and acf.Ductility
-			local armour = acf and (acf.Armour or acf.Armor)
-			local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
-			local dist = (ent:GetPos() - center):Length()
-
-			local token = table.concat({
-				class,
-				model,
-				ACE_FormatArmorKey(material, ductility, armour, maxArmour, 0),
-				string.format("%.1f", dist)
-			}, "|")
-			candidates[#candidates + 1] = { ent = ent, token = token }
-		end
-
-		if #candidates > 0 then
-			table.sort(candidates, function(a, b) return a.token < b.token end)
-			fallbackRef = candidates[1].ent
-			refToken = candidates[1].token
-		end
-	end
-
-	if not IsValid(fallbackRef) then return nil end
-
-	for _, ent in ipairs(included) do
-		local class = ent:GetClass() or "unknown"
-		local model = ent:GetModel() or ""
-
-		local acf = ent.ACF
-		local material = acf and acf.Material
-		local ductility = acf and acf.Ductility
-		local armour = acf and (acf.Armour or acf.Armor)
-		local maxArmour = acf and (acf.MaxArmour or acf.MaxArmor)
-
-		local posKey = ""
-
-		parts[#parts + 1] = table.concat({
-			class,
-			model,
-			ACE_FormatArmorKey(material, ductility, armour, maxArmour, 0),
-			posKey
-		}, "|")
-	end
-
-	table.sort(parts)
-	if #parts == 0 then return nil end
-
-	local hash = util.SHA256(table.concat(parts, ";"))
-	local key = tostring(ACE.DupeArmorCacheVersion) .. ":spawn:" .. hash
-	if wantInfo then
-		return key, {
-			count = count,
-			ref = refToken,
-			hash = hash,
-			first = parts[1],
-			last = parts[#parts]
-		}
-	end
-
-	return key
-end
-
--- Build a signature for created entities using a fixed reference.
-function ACE_GetCreatedSignature(created, refEnt)
-	return ACE_BuildCreatedSignature(created, refEnt, false)
-end
-
--- Build a signature plus debug info for created entities.
-function ACE_GetCreatedSignatureInfo(created, refEnt)
-	return ACE_BuildCreatedSignature(created, refEnt, true)
-end
-
-ACE.DupeSubsystemCacheVersion = ACE.DupeSubsystemCacheVersion or 1
-
--- Check if a class should participate in a subsystem signature.
-local function ACE_IsSubsystemClass(subsystem, className)
-	if subsystem == "Ammo" then
-		return className == "acf_ammo" or className == "acf_gun" or className == "acf_rack"
-	end
-
-	if subsystem == "Firepower" then
-		return className == "acf_gun" or className == "acf_rack"
-	end
-
-	return ACE_GetPtsType(className) == subsystem
-end
-
--- Build a signature token for a subsystem-relevant entity.
-local function ACE_GetSubsystemToken(ent, subsystem)
-	if not ACE_IsEnt(ent) then return nil end
-
-	local className = ent:GetClass() or ""
-	if subsystem == "Ammo" and className == "acf_ammo" then
-		local bdata = ent.BulletData
-		if not bdata then return nil end
-
-		local ammoId = bdata.Id or ""
-		local ammoType = bdata.Type or ""
-		local calMm = ACE_GetAmmoCaliberMm(bdata)
-		local maxPen = ACE_GetAmmoMaxPen(bdata)
-		local blastMass = ACE_GetAmmoBlastMass(bdata)
-		local rounds = ent.Capacity or 0
-
-		return table.concat({
-			className,
-			tostring(ammoId),
-			tostring(ammoType),
-			string.format("%.1f", calMm),
-			string.format("%.2f", maxPen),
-			string.format("%.3f", blastMass),
-			tostring(rounds)
-		}, "|")
-	end
-
-	if (subsystem == "Ammo" or subsystem == "Firepower") and (className == "acf_gun" or className == "acf_rack") then
-		local model = ent:GetModel() or ""
-		local rps = ACE_GetEntRps(ent)
-		local id = ent.Id or ""
-
-		return table.concat({
-			className,
-			tostring(id),
-			string.format("%.4f", rps),
-			model
-		}, "|")
-	end
-
-	local model = ent:GetModel() or ""
-	local pts = ACE_GetEntPoints(ent)
-
-	return table.concat({
-		className,
-		model,
-		string.format("%.2f", pts)
-	}, "|")
-end
-
--- Build a subsystem signature from a list of entities.
-function ACE_GetSubsystemSignatureFromEnts(subsystem, ents)
-	if not util or not util.SHA256 then return nil end
-	if not subsystem or not istable(ents) then return nil end
-
-	local parts = {}
-	for _, ent in pairs(ents) do
-		if ACE_IsEnt(ent) then
-			local className = ent:GetClass() or ""
-			if ACE_IsSubsystemClass(subsystem, className) then
-				local token = ACE_GetSubsystemToken(ent, subsystem)
-				if token then parts[#parts + 1] = token end
-			end
-		end
-	end
-
-	if #parts == 0 then return nil end
-	table.sort(parts)
-
-	return tostring(ACE.DupeSubsystemCacheVersion) .. ":" .. subsystem .. ":" .. util.SHA256(table.concat(parts, ";"))
-end
-
--- Build subsystem signatures for a list of entities.
-function ACE_GetSubsystemSignaturesFromEnts(ents)
-	if not istable(ents) then return nil end
-
-	local subsystems = ACE.PointSubsystems or {
-		"Engines",
-		"Firepower",
-		"Ammo",
-		"Crew",
-		"Electronics"
-	}
-
-	local keys = {}
-	for _, subsystem in ipairs(subsystems) do
-		local key = ACE_GetSubsystemSignatureFromEnts(subsystem, ents)
-		if key then keys[subsystem] = key end
-	end
-
-	return next(keys) and keys or nil
-end
-
--- Normalize AdvDupe2 hook arguments.
-function ACE_ParseAdvDupeArgs(...)
-	-- Supports both common patterns:
-	-- (ply, dupe, created) or (dupeInfoTable)
-	local a, b, c = ...
-
-	if istable(a) and (a.CreatedEntities or (a[1] and a[1].CreatedEntities)) then
-		local info = a
-		local dupe = info[1] or info.Dupe or info.dupe or info
-		local created = info.CreatedEntities or (dupe and dupe.CreatedEntities)
-		return dupe, created
-	end
-
-	if ACE_IsEnt(a) and a:IsPlayer() and istable(b) and istable(c) then
-		return b, c
-	end
-
-	if istable(a) and istable(b) then
-		return a, b
-	end
-
-	return nil, nil
-end
-
--- Legacy manufacturing cost indicator (original mass/material system).
-function ACE_GetEntLegacyCost(ent, massOverride)
-	if not ACE_IsEnt(ent) then return 0 end
-
-	local class = ent:GetClass()
-	local points = ent.ACEPoints or 0
-	if class ~= "acf_ammo" and points ~= 0 then return points end
-
-	local acf = ent.ACF or {}
-
-	-- Armor props: derive manufacturing cost from raw thickness (mm), then apply ductility scalar.
-	if ACE.ArmorClasses and ACE.ArmorClasses[class] then
-		local mat = acf.Material or "RHA"
-		local matData = ACE_GetMaterialData and ACE_GetMaterialData(mat)
-		local armorData = ent.acfPropArmorData and ent:acfPropArmorData()
-		local armorMod = ACF.ArmorMod or 1
-		local armorMm = tonumber(acf.MaxArmour or acf.Armour) or 0
-		local curve = (armorData and armorData.Curve) or 1
-
-		-- Match point-scan weighting: KE 80% + CHEM 20% effectiveness.
-		local effKE = (armorData and armorData.Effectiveness) or (matData and matData.effectiveness) or 1
-		local effCHEM = (armorData and (armorData.HEATeffectiveness or armorData.HEATEffectiveness))
-			or (matData and (matData.HEATeffectiveness or matData.effectiveness))
-			or effKE
-		local weightedEff = effKE * 0.8 + effCHEM * 0.2
-
-		local effectiveMm = 0
-		if armorMm > 0 then
-			effectiveMm = (armorMm ^ curve) * weightedEff
-		end
-
-		local rawMm = 0
-		if effectiveMm > 0 and armorMod > 0 then
-			rawMm = effectiveMm / armorMod
-		end
-
-		local rawHP = tonumber(acf.MaxHealth or acf.Health) or 1
-		rawHP = math.max(rawHP, 1)
-
-		-- Manufacturing scalar is now driven by raw HP, not ductility:
-		-- 1 HP => 0.2x (-80%), 100 HP => 1.2x (+20%), clamped for stability.
-		local hpCostMul = math.Clamp(0.2 + (rawHP - 1) * (1.0 / 99), 0.2, 1.2)
-		local perMm = ACE.LegacyRawMmCostPerProp or 1
-
-		return math.max(rawMm * perMm * hpCostMul, 0)
-	end
-
-	-- Ammo crates: derive manufacturing cost from per-round ammo pricing so
-	-- manufacturing scales with round performance and the amount stored.
-	if class == "acf_ammo" then
-		local bdata = ent.BulletData
-		if istable(bdata) then
-			local perRound
-			if ACE_IsAmmoMissileType(bdata) then
-				perRound = ACE_CalcMissileLegacyRoundCost(bdata)
-			else
-				perRound = ACE_GetAmmoRoundPoints(bdata)
-			end
-
-			if perRound > 0 then
-				local rounds = tonumber(ent.Capacity) or tonumber(ent.Ammo) or 0
-				rounds = math.max(rounds, 1)
-
-				return perRound * rounds * 10
-			end
-		end
-	end
-
-	local mass = massOverride
-	if mass == nil then
-		local phys = ent:GetPhysicsObject()
-		if IsValid(phys) then mass = phys:GetMass() end
-	end
-
-	mass = tonumber(mass) or 0
-	local pointsPerTon = ACF.LegacyManufacturingPointsPerTon or 0
-	if mass > 0 and pointsPerTon > 0 then
-		local matTable = ACE.LegacyMatCostTables or ACE.MatCostTables or {}
-		local mat = (ent.ACF and ent.ACF.Material) or "RHA"
-
-		points = (mass / 1000) * pointsPerTon * (matTable[mat] or 1)
-	end
-
-	return points
-end
-
 -- Cached wrapper for per-crate ammo points.
 function ACE_GetAmmoCratePointsForContraption(crate, con, fallbackEnt)
 	if not ACE_IsEnt(crate) then return 0 end
 
-	local ammoDirty = con and con.ACESubsystemDirty and con.ACESubsystemDirty.Ammo
-	if con and con.ACEAmmoCache and not ammoDirty then
+	if con and con.ACEAmmoCache then
 		local cache = con.ACEAmmoCache
 		return ACE_CalcAmmoCratePoints(crate, cache.GunRpsById or {}, cache.Racks or {}, cache.ReadyAlloc)
 	end
@@ -2110,29 +1734,6 @@ function ACE_GetEntPoints(ent)
 
 	return ent.ACEPoints or 0
 end
-
--- Run the armor scan for a contraption.
-function ACE_GetArmorScan(ent)
-	if not ACE_CalcContraptionArmor then return 0, 0 end
-	local front, side = ACE_CalcContraptionArmor(ent)
-	return front, side
-end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1791,6 +1791,20 @@ function ACE_BuildRackReserveAlloc(ents, racks)
 	return next(alloc) and alloc or nil
 end
 
+-- Public per-rack version of ACE_AllocateRackPreload, for callers (e.g. the
+-- armor tool popup) that have a single rack and want to see which crates
+-- fill its tubes. Returns {crate -> reserve_rounds} or nil.
+function ACE_GetRackPreloadAlloc(rack, con, fallbackEnt)
+	if not ACE_IsEnt(rack) or rack:GetClass() ~= "acf_rack" then return nil end
+	if not ACF_CanLinkRack then return nil end
+
+	local ents = ACE_GetContraptionEntities(con, fallbackEnt or rack)
+	local crates = ACE_CollectLoadedAmmoCrates(ents)
+	if #crates == 0 then return nil end
+
+	return ACE_AllocateRackPreload(rack, crates)
+end
+
 
 -- ============================================================
 -- ACE parsing/get helpers

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1166,8 +1166,14 @@ end
 -- factor directly keeps all three paths consistent: every missile with a
 -- MissileGuidanceFactors entry has that guidance factor into its cost.
 -- Non-missile ammo is unaffected.
+--
+-- GLATGM family rounds are explicitly excluded: they are launched from
+-- grenade launchers (gun-class ammo), not racks, and should be priced like
+-- any other gun ammo with their AmmoTypeFactor doing the work -- no
+-- missile-class guidance premium.
 local function ACE_GetAmmoGuidancePenFactor(bdata)
 	if not bdata or not ACE_IsAmmoMissileType(bdata) then return 1 end
+	if ACE_IsGLATGMAmmoType(bdata.Type) then return 1 end
 	return ACE_GetMissileGuidanceFactor(bdata.Data7)
 end
 
@@ -1285,8 +1291,11 @@ function ACE_GetAmmoRoundPoints(bdata)
 
 	-- Missiles get their own multiplier on top so MissileCostConfig is the one
 	-- knob that tunes missile pricing for both the ammo crate path
-	-- (ACE_CalcAmmoCratePoints) and the per-missile path (ACE_CalcMissileRoundPoints).
-	if ACE_IsAmmoMissileType(bdata) then
+	-- (ACE_CalcAmmoCratePoints) and the per-missile path
+	-- (ACE_CalcMissileRoundPoints). GLATGM family rounds opt out: they are
+	-- gun-class grenade-launcher ammo, not rack-fired missiles, and pay through
+	-- their AmmoTypeFactor (0.75) like any other gun round.
+	if ACE_IsAmmoMissileType(bdata) and not ACE_IsGLATGMAmmoType(bdata.Type) then
 		local mcfg = ACE.MissileCostConfig or {}
 		roundPts = roundPts * (tonumber(mcfg.PerformanceMul) or 1)
 	end

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1161,12 +1161,22 @@ function ACE_IsATGMCostAmmo(bdata)
 	return ACE_GetAmmoGunClass(bdata) == "ATGM"
 end
 
--- Resolve guidance scaling used by missile point/threat math.
+-- Resolve guidance scaling used by missile point/threat math. The factor from
+-- ACE.MissileGuidanceFactors maps directly onto the missile's pen multiplier:
+-- entries below 1 represent unreliable guidance that often misses and scale
+-- threat-per-round down, entries above 1 represent premium seekers that
+-- consistently land hits and scale threat up.
+--
+-- A previous version wrapped the return in math.max(factor, 1), which left
+-- the above-1 entries alone but neutered every below-1 entry to 1. That made
+-- the missile ammo crate path and the ATGM perf-points path disagree with
+-- the non-ATGM rack path, which multiplies by the raw factor. Applying the
+-- factor directly keeps all three paths consistent: every missile with a
+-- MissileGuidanceFactors entry has that guidance factor into its cost.
+-- Non-missile ammo is unaffected.
 local function ACE_GetAmmoGuidancePenFactor(bdata)
 	if not bdata or not ACE_IsAmmoMissileType(bdata) then return 1 end
-	-- Guidance should act as an upward threat modifier in pen-space, not make
-	-- missiles artificially cheap when using low-end guidance packages.
-	return math.max(ACE_GetMissileGuidanceFactor(bdata.Data7), 1)
+	return ACE_GetMissileGuidanceFactor(bdata.Data7)
 end
 
 -- Calculate per-missile base points, including guidance.

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1572,18 +1572,23 @@ function ACE_GetContraptionEntities(con, fallbackEnt)
 end
 
 -- Allocate ready-rack rounds across ammo crates.
-function ACE_BuildAmmoReadyAlloc(ents)
+function ACE_BuildAmmoReadyAlloc(ents, rackReserve)
 	local cfg = ACE.AmmoCostConfig or {}
 	if (cfg.ReadyRackBase or 0) <= 0 then return nil end
 
 	local groups = {}
-	-- Group ammo crates by caliber and weight by per-round cost.
+	-- Group ammo crates by caliber and weight each entry by its per-round cost.
+	-- A crate's "rounds" include any rack pre-load assigned to it by
+	-- ACE_BuildRackReserveAlloc, so the per-crate clamp (math.min later in this
+	-- function) won't strip the rack reserve back out -- and so the weighting
+	-- doesn't under-credit crates whose racks are primed full.
 
 	for _, ent in ipairs(ents) do
 		if ACE_IsEnt(ent) and ent:GetClass() == "acf_ammo" then
 			local bdata = ent.BulletData
 			if bdata then
-				local rounds = ent.Capacity or 0
+				local reserve = (rackReserve and rackReserve[ent]) or 0
+				local rounds = (ent.Capacity or 0) + reserve
 				if rounds > 0 then
 					local ammoId = bdata.Id
 					if ammoId then
@@ -1668,6 +1673,124 @@ function ACE_BuildAmmoReadyAlloc(ents)
 	return next(alloc) and alloc or nil
 end
 
+-- Collect every ammo crate in 'ents' that currently holds rounds. Rack
+-- reserve only flows from crates with positive Capacity (an empty crate
+-- couldn't have loaded the rack in the first place) and a valid BulletData Id.
+local function ACE_CollectLoadedAmmoCrates(ents)
+	local crates = {}
+	for _, ent in ipairs(ents) do
+		if ACE_IsEnt(ent) and ent:GetClass() == "acf_ammo" then
+			local bdata = ent.BulletData
+			if bdata and bdata.Id and (tonumber(ent.Capacity) or 0) > 0 then
+				crates[#crates + 1] = ent
+			end
+		end
+	end
+	return crates
+end
+
+-- For one rack, decide how its MaxMissile pre-load gets split across the
+-- crates it can feed from. Returns {crate -> share}, or nil if the rack has
+-- no slots, no Id, or no compatible crates.
+--
+-- Splits by ammo threat weight (high-pen / big-blast rounds get the larger
+-- share). If every candidate has zero threat the split is even. Uses
+-- largest-remainder rounding so shares stay integer; EntIndex tiebreaks so
+-- identical setups allocate identically across re-scans.
+local function ACE_AllocateRackPreload(rack, crates)
+	local maxMissile = tonumber(rack.MaxMissile) or 0
+	if maxMissile <= 0 or not rack.Id then return nil end
+
+	-- Gather candidate crates and their threat weights.
+	local candidates, totalWeight = {}, 0
+	for _, crate in ipairs(crates) do
+		local bdata = crate.BulletData
+		if ACF_CanLinkRack(rack.Id, bdata.Id, bdata, rack) then
+			local weight = math.max(ACE_GetAmmoThreatWeight(bdata), 0)
+			candidates[#candidates + 1] = { crate = crate, weight = weight }
+			totalWeight = totalWeight + weight
+		end
+	end
+	if #candidates == 0 then return nil end
+
+	-- Even split when no candidate carries any threat (e.g. all Refill).
+	if totalWeight <= 0 then
+		for _, entry in ipairs(candidates) do entry.weight = 1 end
+		totalWeight = #candidates
+	end
+
+	-- Each crate takes its whole share first; track the fractional remainder.
+	local remaining = maxMissile
+	for _, entry in ipairs(candidates) do
+		local raw        = maxMissile * entry.weight / totalWeight
+		entry.wholeShare = math.floor(raw)
+		entry.remainder  = raw - entry.wholeShare
+		remaining        = remaining - entry.wholeShare
+	end
+
+	-- Hand the leftover slots to whichever crates were closest to rounding up.
+	table.sort(candidates, function(a, b)
+		if a.remainder == b.remainder then
+			return a.crate:EntIndex() < b.crate:EntIndex()
+		end
+		return a.remainder > b.remainder
+	end)
+
+	for _, entry in ipairs(candidates) do
+		if remaining <= 0 then break end
+		entry.wholeShare = entry.wholeShare + 1
+		remaining = remaining - 1
+	end
+
+	local shares = {}
+	for _, entry in ipairs(candidates) do
+		if entry.wholeShare > 0 then
+			shares[entry.crate] = entry.wholeShare
+		end
+	end
+	return next(shares) and shares or nil
+end
+
+-- Spread each rack's MaxMissile pre-load across the ammo crates that could
+-- feed it, so the rounds sitting in rack tubes count toward the feeding
+-- crate's points. Without this, a 2-round crate would price for 2 even when
+-- its 8-tube rack is fully primed and ready to dump them.
+--
+-- "Could feed it" means ACF_CanLinkRack returns true -- the same compatibility
+-- rule ACE_CalcAmmoCratePoints uses to credit a rack's RPS to a crate. Keep
+-- the two checks in lockstep: if you change which crates a rack contributes
+-- RPS to, change which crates it contributes reserve to as well.
+--
+-- 'racks' is optional; pass the list from ACE_BuildGunRpsAndRacks to skip the
+-- re-scan. Returns {crate -> reserve_rounds}, or nil if nothing was allocated.
+function ACE_BuildRackReserveAlloc(ents, racks)
+	if not ACF_CanLinkRack then return nil end
+
+	if not racks then
+		racks = {}
+		for _, ent in ipairs(ents) do
+			if ACE_IsEnt(ent) and ent:GetClass() == "acf_rack" then
+				racks[#racks + 1] = ent
+			end
+		end
+	end
+	if #racks == 0 then return nil end
+
+	local crates = ACE_CollectLoadedAmmoCrates(ents)
+	if #crates == 0 then return nil end
+
+	local alloc = {}
+	for _, rack in ipairs(racks) do
+		local shares = ACE_AllocateRackPreload(rack, crates)
+		if shares then
+			for crate, count in pairs(shares) do
+				alloc[crate] = (alloc[crate] or 0) + count
+			end
+		end
+	end
+
+	return next(alloc) and alloc or nil
+end
 
 
 -- ============================================================
@@ -1702,18 +1825,24 @@ function ACE_GetAmmoCratePointsForContraption(crate, con, fallbackEnt)
 
 	if con and con.ACEAmmoCache then
 		local cache = con.ACEAmmoCache
-		return ACE_CalcAmmoCratePoints(crate, cache.GunRpsById or {}, cache.Racks or {}, cache.ReadyAlloc)
+		return ACE_CalcAmmoCratePoints(crate, cache.GunRpsById or {}, cache.Racks or {}, cache.ReadyAlloc, cache.RackReserve)
 	end
 
 	local ents = ACE_GetContraptionEntities(con, fallbackEnt or crate)
 
 	local gunRpsById, racks = ACE_BuildGunRpsAndRacks(ents)
 
-	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents)
-	local pts, detail = ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc)
+	local rackReserve = ACE_BuildRackReserveAlloc(ents, racks)
+	local readyAlloc = ACE_BuildAmmoReadyAlloc(ents, rackReserve)
+	local pts, detail = ACE_CalcAmmoCratePoints(crate, gunRpsById, racks, readyAlloc, rackReserve)
 
 	if con then
-		con.ACEAmmoCache = { GunRpsById = gunRpsById, Racks = racks, ReadyAlloc = readyAlloc }
+		con.ACEAmmoCache = {
+			GunRpsById = gunRpsById,
+			Racks = racks,
+			ReadyAlloc = readyAlloc,
+			RackReserve = rackReserve
+		}
 	end
 
 	return pts, detail

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1171,19 +1171,16 @@ local function ACE_GetAmmoGuidancePenFactor(bdata)
 	return ACE_GetMissileGuidanceFactor(bdata.Data7)
 end
 
--- Calculate per-missile points. Every missile type uses the same performance
--- model: penetration and blast threat from ACE_GetAmmoRoundPoints (which
--- already folds in guidance through the pen factor and ammo-type weighting),
--- scaled by MissileCostConfig.PerformanceMul, with MissileCostConfig.MinBase
--- as a floor so low-threat missiles still register a cost.
+-- Calculate per-missile points. Delegates to ACE_GetAmmoRoundPoints, which
+-- already applies MissileCostConfig.PerformanceMul for missile ammo; this
+-- function just adds the MinBase floor so low-threat missiles still register.
 function ACE_CalcMissileRoundPoints(bdata)
 	if not istable(bdata) then return 0 end
 
 	local cfg = ACE.MissileCostConfig or {}
-	local perfMul = tonumber(cfg.PerformanceMul) or 1
 	local minBase = tonumber(cfg.MinBase) or 1
 
-	return math.max(ACE_GetAmmoRoundPoints(bdata) * perfMul, minBase)
+	return math.max(ACE_GetAmmoRoundPoints(bdata), minBase)
 end
 
 -- Determine whether an ammo type should use HE utility scaling.
@@ -1284,8 +1281,17 @@ function ACE_GetAmmoRoundPoints(bdata)
 	end
 
 	local calFactor = calMm / refCal
+	local roundPts = baseRound * threatFactor * calFactor * typeFactor
 
-	return baseRound * threatFactor * calFactor * typeFactor
+	-- Missiles get their own multiplier on top so MissileCostConfig is the one
+	-- knob that tunes missile pricing for both the ammo crate path
+	-- (ACE_CalcAmmoCratePoints) and the per-missile path (ACE_CalcMissileRoundPoints).
+	if ACE_IsAmmoMissileType(bdata) then
+		local mcfg = ACE.MissileCostConfig or {}
+		roundPts = roundPts * (tonumber(mcfg.PerformanceMul) or 1)
+	end
+
+	return roundPts
 end
 
 -- Calculate threat weight for ready-rack allocation.

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1153,14 +1153,6 @@ function ACE_IsAmmoMissileType(bdata)
 	return classData and classData.type == "missile" or false
 end
 
--- Determine whether bullet data should use ATGM-style missile costing.
-function ACE_IsATGMCostAmmo(bdata)
-	if not bdata then return false end
-	if ACE_IsGLATGMAmmoType(bdata.Type) then return true end
-
-	return ACE_GetAmmoGunClass(bdata) == "ATGM"
-end
-
 -- Resolve guidance scaling used by missile point/threat math. The factor from
 -- ACE.MissileGuidanceFactors maps directly onto the missile's pen multiplier:
 -- entries below 1 represent unreliable guidance that often misses and scale
@@ -1179,37 +1171,19 @@ local function ACE_GetAmmoGuidancePenFactor(bdata)
 	return ACE_GetMissileGuidanceFactor(bdata.Data7)
 end
 
--- Calculate per-missile base points, including guidance.
+-- Calculate per-missile points. Every missile type uses the same performance
+-- model: penetration and blast threat from ACE_GetAmmoRoundPoints (which
+-- already folds in guidance through the pen factor and ammo-type weighting),
+-- scaled by MissileCostConfig.PerformanceMul, with MissileCostConfig.MinBase
+-- as a floor so low-threat missiles still register a cost.
 function ACE_CalcMissileRoundPoints(bdata)
 	if not istable(bdata) then return 0 end
 
-	local ammoId = bdata.Id
-	local rackPointCost = ACF_GetRackValue and ACF_GetRackValue(bdata, "pointcost")
-	local gunPointCost = ACF_GetGunValue and ACF_GetGunValue(ammoId, "pointcost")
-	local configuredPts = tonumber(rackPointCost or 0) or tonumber(gunPointCost or 0) or 0
-	configuredPts = math.max(configuredPts, 0)
+	local cfg = ACE.MissileCostConfig or {}
+	local perfMul = tonumber(cfg.PerformanceMul) or 1
+	local minBase = tonumber(cfg.MinBase) or 1
 
-	local factor = ACE_GetMissileGuidanceFactor(bdata.Data7)
-	local basePts = configuredPts
-
-	if ACE_IsATGMCostAmmo(bdata) then
-		local cfg = ACE.ATGMCostConfig or {}
-		local perfPts = ACE_GetAmmoRoundPoints(bdata)
-		local perfMul = tonumber(cfg.PerformanceMul) or 1
-		local minBase = tonumber(cfg.MinBase) or 25
-
-		if perfPts > 0 then
-			basePts = perfPts * perfMul
-		end
-
-		basePts = math.max(basePts, minBase)
-
-		-- Guidance is already applied in missile threat/penetration scaling for ATGM perf points.
-		return math.max(basePts, 0)
-	end
-
-	-- Non-ATGM missiles use their configured rack/gun point value.
-	return math.max(basePts, 0) * factor
+	return math.max(ACE_GetAmmoRoundPoints(bdata) * perfMul, minBase)
 end
 
 -- Determine whether an ammo type should use HE utility scaling.

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -134,69 +134,66 @@ ACF.PointsLimit = 10000 -- The maximum legal point value.
 ACF.MaxWeight   = 200000 -- The max weight in kg.
 
 ACE.PointCostConfig = ACE.PointCostConfig or {
-    ArmorFrontWeight = 1.0, -- Front armor contribution in armor points.
-    ArmorSideWeight  = 1.8, -- Side armor contribution in armor points.
-    ArmorScale       = 4.0, -- Final armor points multiplier.
-    CrewSeatFlat     = 250, -- Flat point cost per crew seat entity.
+    CrewSeatFlat     = 100, -- Flat point cost for driver and gunner seats.
+    LoaderSeatFlat   = 300, -- Flat point cost per loader seat.
     MinDetailPoints  = 300 -- Minimum points to list an entry in armor tool breakdown.
 }
 
-ACE.GunPointCostMultiplier    = tonumber(ACE.GunPointCostMultiplier) or tonumber(ACE.CannonPointMul) or 0.85 -- Multiplier for gun/cannon point cost.
 ACE.EnginePointCostMultiplier = tonumber(ACE.EnginePointCostMultiplier) or tonumber(ACE.EnginePointMul) or 0.69 -- Multiplier for engine point cost.
-ACF.LegacyManufacturingPointsPerTon = tonumber(ACF.LegacyManufacturingPointsPerTon) or tonumber(ACF.PointsPerTon) or 42 -- Legacy manufacturing cost coefficient per ton.
-ACE.LegacyAmmoPointsPerTon    = tonumber(ACE.LegacyAmmoPointsPerTon) or tonumber(ACE.AmmoPerTon) or 100 -- Legacy non-missile ammo points per ton.
+ACE.GunPointCostMultiplier    = tonumber(ACE.GunPointCostMultiplier) or tonumber(ACE.CannonPointMul) or 0.85 -- Multiplier for gun/cannon point cost.
+ACE.AmmoPointsPerTon          = tonumber(ACE.AmmoPointsPerTon) or 100 -- Non-missile ammo crate points per ton.
 ACE.CrewSeatPointCost         = tonumber(ACE.CrewSeatPointCost)
     or tonumber(ACE.CrewSeatCostFlat)
     or tonumber(ACE.PointCostConfig and ACE.PointCostConfig.CrewSeatFlat)
-    or 250 -- Flat point cost per crew seat.
+    or 100 -- Flat point cost for driver and gunner seats.
+ACE.LoaderSeatPointCost       = tonumber(ACE.LoaderSeatPointCost)
+    or tonumber(ACE.PointCostConfig and ACE.PointCostConfig.LoaderSeatFlat)
+    or 300 -- Flat point cost per loader seat.
+ACE.ArmorPointConfig = ACE.ArmorPointConfig or {
+    KEWeight = 0.7, -- Share of KE effectiveness in normalized armor thickness.
+    ChemWeight = 0.3, -- Share of chemical effectiveness in normalized armor thickness.
+    DamageReferenceMm = 50, -- Armor point reference thickness.
+    SurvivabilityScale = 100, -- Armor points per 50mm/100HP survivability unit.
+    ArmorCostMultiplier = 0.2, -- Final armor cost multiplier.
+    SurvivabilityArmorExponent = 1.4, -- Armor thickness contribution to armor points.
+    SurvivabilityHPExponent = 0.45, -- HP contribution to armor points.
+    SurvivabilityHPReference = 75 -- HP baseline for armor points.
+}
 
 -- Backward-compatible aliases (deprecated names).
-ACE.CannonPointMul = ACE.GunPointCostMultiplier
 ACE.EnginePointMul = ACE.EnginePointCostMultiplier
-ACF.PointsPerTon = ACF.LegacyManufacturingPointsPerTon
-ACE.AmmoPerTon = ACE.LegacyAmmoPointsPerTon
+ACE.CannonPointMul = ACE.GunPointCostMultiplier
 ACE.CrewSeatCostFlat = ACE.CrewSeatPointCost
 
--- Deprecated: armor mass-based cost has been replaced by LOS armor scan.
---
 -- Ammo cost scoring config for the ACE legality system.
 ACE.AmmoTypeFactors = {
-    AP = 0.5,
-    APHE = 0.6,
-    APDS = 1.0,
-    APFSDS = 1.05,
-    HVAP = 0.7,
-    HEAT = 0.75,
+    AP = 1,
+    APHE = 1.1,
+    APDS = 0.9,
+    APFSDS = 0.9,
+    HVAP = 0.8,
+    HEAT = 0.7,
     HEATFS = 0.8,
-    THEAT = 0.95,
+    THEAT = 0.9,
     THEATFS = 1.0,
-    HESH = 0.4,
+    HESH = 1,
     HE = 0.66,
     HEFS = 0.715,
-    HP = 0.1,
-    CAP = 0.6,
+    HP = 1,
+    CAP = 1,
     CHEAT = 0.8,
     CHE = 0.25,
     CHF = 1,
     SM = 1,
     FLR = 1,
-    FL = 0.3,
+    FL = 1,
     GLATGM = 0.75,
-    ["GLATGM-HE"] = 0.25,
+    ["GLATGM-HE"] = 0.75,
     Refill = 0
 }
 
-ACE.LegacyMatCostTables = ACE.LegacyMatCostTables or {
-    Alum = 1.2 * (0.221 / 0.34), -- 20% cost increase for ~25% weight reduction.
-    CHA = 0.8 * (0.98 / 1.25), -- 25% heavier for ~20% cost reduction.
-    Cer = 1.4 * (2.05 / 1.4), -- 50% more protection/kg for ~40% cost increase.
-    ERA = 2.0 * (2.5 / 2.0),
-    Rub = 1.5 * (0.05 / 0.2),
-    Texto = 1.4 * (0.5 / 0.35),
-    RHA = 1
-}
 ACE.AmmoCostConfig = {
-    BaseRoundPts = 340, -- Base per-round scaling before penetration, caliber, ammo type, and RoF threat are applied.
+    BaseRoundPts = 320, -- Base per-round scaling before penetration, caliber, ammo type, and RoF threat are applied.
     RefPen = 700, -- Reference penetration (mm) for pen scaling.
     RefCaliber = 100, -- Reference caliber (mm) for caliber scaling.
     RofKneeRpm = 22, -- RoF knee for saturation: RoF/(RoF+k), using RPM.
@@ -208,17 +205,12 @@ ACE.AmmoCostConfig = {
     HeUtilExp = 0.5, -- HE utility exponent for filler per caliber.
     ReadyRackBase = 3000, -- Ready rack baseline: base / caliber(mm).
     ReadyRackPivot = 60, -- Caliber (mm) where low-caliber boost stops.
-    ReadyRackLowBoost = 1.5, -- Low-caliber boost (20mm hits 300 at base 3000).
-    StowFactor = 0.0, -- Cost multiplier for stowed rounds.
-    TailFactor = 0, -- Extra discount per round beyond tail start (0 disables).
-    TailStartMultiplier = 2 -- Tail start = readyCap * multiplier.
+    ReadyRackLowBoost = 1.5 -- Low-caliber boost (20mm hits 300 at base 3000).
 }
 
--- ATGM rack/ammo pricing blend.
--- Performance uses the same ammo threat model as guns; legacy keeps continuity with existing per-missile pointcost.
+-- ATGM rack/ammo pricing.
 ACE.ATGMCostConfig = {
     PerformanceMul = 1.0, -- Multiplier for performance-derived base points.
-    LegacyWeight = 0.2, -- 0 = pure performance, 1 = pure legacy pointcost.
     MinBase = 1 -- Safety floor before guidance multiplier.
 }
 
@@ -240,19 +232,6 @@ ACE.MissileGuidanceFactors = {
     Infrared = 2.7,
     Top_Attack_IR = 3,
     Radar = 1.2
-}
-
--- Armor tool UX timing.
-ACE.ArmorPreviewTapWindow = ACE.ArmorPreviewTapWindow or 0.35 -- Seconds between reload taps to trigger preview.
-ACE.ArmorPreviewCooldown = ACE.ArmorPreviewCooldown or 5 -- Seconds between preview requests per player.
-
--- Armor scan tuning values for LOS trace consistency.
-ACE.ArmorScanConfig = ACE.ArmorScanConfig or {
-    RegionSnap = 2,
-    TraceHullSize = 3,
-    TraceMaxSteps = 128,
-    TracePadding = 64,
-    ResultQuantizeMm = 1.0 -- Quantize scan outputs to reduce tiny trace jitter.
 }
 
 ---------------------------------- Misc & other ----------------------------------
@@ -310,7 +289,7 @@ ACE.DustMaterialColor = {
     Dirt       = Color(93,80,56,150),
     Sand       = Color(225,202,130,150),
     Glass      = Color(255,255,255,50),
-    Snow      = Color(255,255,255,50),
+    Snow       = Color(255,255,255,50),
     Wood       = Color(117,101,70,150)
 }
 
@@ -430,13 +409,13 @@ if SERVER then
         end
     end
 
-    cvars.AddChangeCallback("acf_healthmod", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_armormod", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_ammomod", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_spalling", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_spalling_multipler", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_gunfire", ACF_CVarChangeCallback)
-    cvars.AddChangeCallback("acf_debris_lifetime", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_healthmod", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_armormod", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_ammomod", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_spalling", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_spalling_multipler", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_gunfire", ACF_CVarChangeCallback)
+cvars.AddChangeCallback("acf_debris_lifetime", ACF_CVarChangeCallback)
 cvars.AddChangeCallback("acf_debris_children", ACF_CVarChangeCallback)
 cvars.AddChangeCallback("acf_explosions_scaled_he_max", ACF_CVarChangeCallback)
 cvars.AddChangeCallback("acf_explosions_scaled_ents_max", ACF_CVarChangeCallback)
@@ -484,7 +463,6 @@ elseif CLIENT then
     CreateClientConVar( "acf_sens_scopes", 0.2, true, false, "Reduce mouse sensitivity by this amount when zoomed in with scopes on ACE SWEPs.", 0.01, 1)
     CreateClientConVar( "acf_tinnitus", 1, true, false, "Allows the ear tinnitus effect to be applied when an explosive was detonated too close to your position, improving the inmersion during combat.", 0, 1 )
     CreateClientConVar( "acf_sound_volume", 100, true, false, "Adjusts the volume of explosions and gunshots.", 0, 100 )
-    CreateClientConVar( "acf_armor_readout_full", 0, true, false, "Show full armor readout in the ACF armor tool.", 0, 1 )
 
 end
 
@@ -709,7 +687,3 @@ AddCSLuaFile("autorun/acf_missile/folder.lua")
 include("autorun/acf_missile/folder.lua")
 
 print("[ACE | INFO]- Done!")
-
-
-
-

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -210,7 +210,11 @@ ACE.AmmoCostConfig = {
 
 -- Per-missile pricing. Applies to every missile type -- the cost model is
 -- unified on performance points (pen + blast + caliber + ammo type, with
--- guidance folded in via the pen factor).
+-- guidance folded in via the pen factor). Tune via PerformanceMul / MinBase
+-- here, or adjust the bullet data on the missile itself; do NOT re-add the
+-- legacy per-missile `pointcost` fields that used to live in each missile
+-- definition under lua/acf/shared/missiles/ -- those were hand-tuned static
+-- values that disagreed with the performance model and have been removed.
 ACE.MissileCostConfig = {
     PerformanceMul = 1.0, -- Multiplier on ACE_GetAmmoRoundPoints output.
     MinBase = 1 -- Floor so low-threat missiles still register a cost.

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -216,22 +216,22 @@ ACE.ATGMCostConfig = {
 
 -- Guidance multipliers applied on top of missile base cost.
 ACE.MissileGuidanceFactors = {
-    Dumb = 0.3,
-    Straight_Running = 0.45,
-    GPS = 0.6,
+    Dumb = 0.5,
+    Straight_Running = 0.6,
     Antimissile = 1,
-    AntiRadiation = 0.7,
-    Beam_Riding = 0.7,
-    GPS_TerrainAvoidant = 0.8,
-    SACLOS = 0.75,
-    Semiactive = 0.85,
-    Wire = 1.0,
-    Acoustic_Straight = 1.0,
-    Acoustic_Helical = 1.0,
-    Laser = 1.2,
-    Infrared = 2.7,
-    Top_Attack_IR = 3,
-    Radar = 1.2
+    Radar = 1.4,
+    Semiactive = 1.4,
+    AntiRadiation = 1,
+    Wire = 1,
+    Laser = 1,
+    SACLOS = 1,
+    Beam_Riding = 1,
+    Infrared = 1.5,
+    Top_Attack_IR = 1.8,
+    GPS = 0.8,
+    GPS_TerrainAvoidant = 0.9,
+    Acoustic_Straight = 1,
+    Acoustic_Helical = 1
 }
 
 ---------------------------------- Misc & other ----------------------------------

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -188,7 +188,7 @@ ACE.AmmoTypeFactors = {
     FLR = 1,
     FL = 1,
     GLATGM = 0.75,
-    ["GLATGM-HE"] = 0.75,
+    ["GLATGM-HE"] = 0.495,
     Refill = 0
 }
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -208,10 +208,12 @@ ACE.AmmoCostConfig = {
     ReadyRackLowBoost = 1.5 -- Low-caliber boost (20mm hits 300 at base 3000).
 }
 
--- ATGM rack/ammo pricing.
-ACE.ATGMCostConfig = {
-    PerformanceMul = 1.0, -- Multiplier for performance-derived base points.
-    MinBase = 1 -- Safety floor before guidance multiplier.
+-- Per-missile pricing. Applies to every missile type -- the cost model is
+-- unified on performance points (pen + blast + caliber + ammo type, with
+-- guidance folded in via the pen factor).
+ACE.MissileCostConfig = {
+    PerformanceMul = 1.0, -- Multiplier on ACE_GetAmmoRoundPoints output.
+    MinBase = 1 -- Floor so low-threat missiles still register a cost.
 }
 
 -- Guidance multipliers applied on top of missile base cost.
@@ -238,7 +240,7 @@ ACE.MissileGuidanceFactors = {
 
 ACF.LargeCaliber        = 10 --Gun caliber in CM to be considered a large caliber gun, 10cm = 100mm
 
-ACF.SpallDamageMult        = 0.01
+ACF.SpallDamageMult     = 0.01
 ACF.APDamageMult        = 2                        -- AP Damage Multipler            -1.1
 ACF.APHEDamageMult      = 1.75                    -- APHE Damage Multipler
 ACF.APDSDamageMult      = 3                    -- APDS Damage Multipler

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -210,13 +210,18 @@ ACE.AmmoCostConfig = {
 
 -- Per-missile pricing. Applies to every missile type -- the cost model is
 -- unified on performance points (pen + blast + caliber + ammo type, with
--- guidance folded in via the pen factor). Tune via PerformanceMul / MinBase
--- here, or adjust the bullet data on the missile itself; do NOT re-add the
--- legacy per-missile `pointcost` fields that used to live in each missile
--- definition under lua/acf/shared/missiles/ -- those were hand-tuned static
--- values that disagreed with the performance model and have been removed.
+-- guidance folded in via the pen factor). PerformanceMul is applied inside
+-- ACE_GetAmmoRoundPoints for missile-type ammo, so it reaches BOTH the
+-- ammo crate path (ACE_CalcAmmoCratePoints) and the per-missile path
+-- (ACE_CalcMissileRoundPoints) -- this is the single knob for "how much
+-- should missiles cost relative to gun ammo of equivalent threat".
+-- Tune via PerformanceMul / MinBase here, or adjust the bullet data on
+-- the missile itself; do NOT re-add the legacy per-missile `pointcost`
+-- fields that used to live in each missile definition under
+-- lua/acf/shared/missiles/ -- those were hand-tuned static values that
+-- disagreed with the performance model and have been removed.
 ACE.MissileCostConfig = {
-    PerformanceMul = 1.0, -- Multiplier on ACE_GetAmmoRoundPoints output.
+    PerformanceMul = 3.0, -- Multiplier on missile ACE_GetAmmoRoundPoints output.
     MinBase = 1 -- Floor so low-threat missiles still register a cost.
 }
 

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -715,7 +715,7 @@ do
 			debugoverlay.Text(self:GetPos() + Vector(0,0,10), "Total Ammo Mass: " .. self.AmmoMassMax .. "kgs", 20 )
 
 			if WeaponType ~= "missile" then
-				self.ACEPoints = math.ceil(self.AmmoMassMax / 1000 * ACE.LegacyAmmoPointsPerTon)
+				self.ACEPoints = math.ceil(self.AmmoMassMax / 1000 * ACE.AmmoPointsPerTon)
 			else
 				local MissileCost = CalculateMissileCost(self.BulletData)
 				self.ACEPoints = Capacity * MissileCost

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -12,13 +12,12 @@ local CrewLinkDistBase = 200
 local AmmoLinkDistBase = 512
 
 local function MarkGunPointStateDirty(Gun)
-	if not ACE_MarkSubsystemDirty then return end
+	if not ACE_MarkContraptionPointsDirty then return end
 
 	local Contraption = Gun.GetContraption and Gun:GetContraption() or nil
 	if not Contraption then return end
 
-	ACE_MarkSubsystemDirty(Contraption, "Firepower")
-	ACE_MarkSubsystemDirty(Contraption, "Ammo")
+	ACE_MarkContraptionPointsDirty(Contraption, Gun, false, true)
 end
 
 function ENT:Initialize()
@@ -182,7 +181,7 @@ do
 		Gun.Class           = Lookup.gunclass
 		Gun.Heat            = ACE.AmbientTemp
 		Gun.LinkRangeMul    = math.max(Gun.Caliber / 10,1) ^ 1.2
-		Gun.ACEPoints		= (Lookup.acepoints or 0.404) * ACE.GunPointCostMultiplier
+		Gun.ACEPoints		= 0
 		Gun.RequiresGunner	= false
 		local GunnerExcluded	= Lookup.gunnerexception or false
 

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -165,8 +165,7 @@ function MakeACF_Rack(Owner, Pos, Angle, Id)
 
 	Rack.MaxMissile = table.Count(gundef.mountpoints) or 1
 	Rack.ReloadTime = gundef.magreload or 1 --Replace with fixed time delay rather than multiplier
-	Rack.ACEPoints	= (100 + (Rack.MaxMissile-1) * 50)
-	--Rack.ACEPoints	= 200
+	Rack.ACEPoints	= 0
 
 	local gunclass = RackClasses[Rack.Class] or ErrorNoHalt("Couldn't find the " .. tostring(Rack.Class) .. " gun-class!")
 
@@ -1295,8 +1294,8 @@ end
 
 do
 	-- Calculates per-missile points for rack/ammo entities.
-	-- ATGMs use the same performance model as gun ammo, blended with legacy pointcost for continuity.
+	-- ATGMs use the same performance model as gun ammo.
 	function CalculateMissileCost(BulletData)
-		return ACE_CalcMissileLegacyRoundCost(BulletData)
+		return ACE_CalcMissileRoundPoints(BulletData)
 	end
 end

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -14,10 +14,12 @@ if CLIENT then
 	TOOL.Information = {
 		{ name = "left" },
 		{ name = "right" },
-		{ name = "reloadhint" }
+		{ name = "reloadhint" },
+		{ name = "reloadfull" }
 	}
 
-	language.Add("tool.acfarmorprop.reloadhint", "Get information about contraption (double-tap R for preview values)")
+	language.Add("tool.acfarmorprop.reloadhint", "Reload: Get information about contraption")
+	language.Add("tool.acfarmorprop.reloadfull", "Shift + Reload: Get full point readout")
 end
 
 -- Shared panel state used across panel rebuilds to keep UI controls stable.
@@ -69,6 +71,10 @@ local function ApplySettings( _, ent, data )
 		ent.ACF = ent.ACF or {}
 		ent.ACF.Material = data.Material
 		duplicator.StoreEntityModifier( ent, "acfsettings", { Material = data.Material } )
+	end
+
+	if ACE_ClearArmorPointCache then
+		ACE_ClearArmorPointCache(ent)
 	end
 
 	if con then ACE_AddPts(con, ent) end
@@ -148,13 +154,6 @@ function TOOL:Reload( trace )
 	if not IsValid( ent ) or ent:IsPlayer() then return false end
 	if CLIENT then return true end
 
-	local ply = self:GetOwner()
-	local now = CurTime()
-	local lastReload = ply.ACE_ArmorReloadLast or 0
-	local doubleTapWindow = ACE.ArmorPreviewTapWindow or 0.35
-	local doubleTap = (now - lastReload) <= doubleTapWindow
-	ply.ACE_ArmorReloadLast = now
-
 	-- Coerce numeric values and guard NaN/inf.
 	local function safeNumber(value)
 		value = tonumber(value) or 0
@@ -164,17 +163,8 @@ function TOOL:Reload( trace )
 		return value
 	end
 
-	local function normalizePointDetails(rawDetails)
-		local source = istable(rawDetails) and rawDetails or {}
-		local details = {
-			Items = istable(source.Items) and source.Items or {},
-			AmmoLines = {},
-			ArmorLines = {}
-		}
-
-		return details
-	end
-
+	local ply = self:GetOwner()
+	local fullReadout = ply:KeyDown(IN_SPEED)
 	local data		= ACF_CalcMassRatio(ent, true) or {}
 
 	local total		= tonumber(ent.acftotal) or 0
@@ -185,27 +175,19 @@ function TOOL:Reload( trace )
 	local power		= tonumber(data.Power) or 0
 
 	local Contraption = ent:CFW_GetContraption() or nil
-	local details = Contraption and Contraption.ACEPointsDetails or nil
+	if Contraption and ACE_EnsureContraptionPoints then
+		ACE_EnsureContraptionPoints(Contraption, ent, false)
+	end
+
 	local PointVal		= 0
 
 	local PtsArmor = 0
 	local PtsEngine = 0
 	local PtsFirepower = 0
 	local PtsAmmo = 0
-	local PtsAmmoReady = 0
-	local PtsAmmoBackup = 0
-	local AmmoReadyRounds = 0
-	local AmmoBackupRounds = 0
 	local PtsCrew = 0
 	local PtsElectronics = 0
-	local ArmorDirty = false
 	local ArmorInitMissing = false
-	local HypoUsed = false
-	local HypoFront = 0
-	local HypoSide = 0
-	local HypoPts = 0
-	local HypoRequested = doubleTap
-	local LegacyCost = 0
 
 	if Contraption ~= nil then
 		local pointsPerType = Contraption.ACEPointsPerType or {}
@@ -214,80 +196,14 @@ function TOOL:Reload( trace )
 		PtsEngine = safeNumber(pointsPerType.Engines)
 		PtsFirepower = safeNumber(pointsPerType.Firepower)
 		PtsAmmo = safeNumber(pointsPerType.Ammo)
-		PtsAmmoReady = safeNumber(pointsPerType.AmmoReady)
-		PtsAmmoBackup = safeNumber(pointsPerType.AmmoBackup)
-		AmmoReadyRounds = safeNumber(pointsPerType.AmmoReadyRounds)
-		AmmoBackupRounds = safeNumber(pointsPerType.AmmoBackupRounds)
 		PtsCrew = safeNumber(pointsPerType.Crew)
 		PtsElectronics = safeNumber(pointsPerType.Electronics)
-		ArmorDirty = Contraption.ACEArmorDirty and Contraption.ACEArmorCalculated
 		ArmorInitMissing = not Contraption.ACEArmorCalculated
 	else
 		PointVal = safeNumber(ACE_GetEntPoints(ent))
 	end
 
-	if Contraption ~= nil then
-		LegacyCost = safeNumber(ACE_CalcContraptionLegacyCost and ACE_CalcContraptionLegacyCost(Contraption, ent) or 0)
-	else
-		LegacyCost = safeNumber(ACE_GetEntLegacyCost and ACE_GetEntLegacyCost(ent) or 0)
-	end
-
-	local frontArm, sideArm = 0, 0
-	if Contraption ~= nil and Contraption.ACEArmorCalculated then
-		frontArm = safeNumber(Contraption.ACEArmorFront)
-		sideArm = safeNumber(Contraption.ACEArmorSide)
-	elseif Contraption == nil and ACE_GetArmorScan then
-		frontArm, sideArm = ACE_GetArmorScan(ent)
-		frontArm = safeNumber(frontArm)
-		sideArm = safeNumber(sideArm)
-	end
-
-	if doubleTap and ACE_GetArmorScan then
-		local nextAllowed = ply.ACE_ArmorHypoNext or 0
-		if now < nextAllowed then
-			local wait = math.max(0, nextAllowed - now)
-			ply:ChatPrint(string.format("[ACE] Armor preview is on cooldown (%.1fs).", wait))
-		else
-			local scanEnt = ent
-			if Contraption and Contraption.GetACEBaseplate then
-				local base = Contraption:GetACEBaseplate()
-				if IsValid(base) then
-					scanEnt = base
-				end
-			end
-			HypoFront, HypoSide = ACE_GetArmorScan(scanEnt)
-			HypoFront = safeNumber(HypoFront)
-			HypoSide = safeNumber(HypoSide)
-			HypoPts = safeNumber(ACE_CalcArmorPoints(HypoFront, HypoSide))
-			HypoUsed = true
-			if ACE_CalcNonArmorPoints and Contraption then
-				local nonArmor, totals, hypoDetails = ACE_CalcNonArmorPoints(Contraption, scanEnt)
-				PointVal = safeNumber(nonArmor + HypoPts)
-				PtsArmor = safeNumber(HypoPts)
-				PtsEngine = safeNumber(totals.Engines)
-				PtsFirepower = safeNumber(totals.Firepower)
-				PtsAmmo = safeNumber(totals.Ammo)
-				PtsAmmoReady = safeNumber(totals.AmmoReady)
-				PtsAmmoBackup = safeNumber(totals.AmmoBackup)
-				AmmoReadyRounds = safeNumber(totals.AmmoReadyRounds)
-				AmmoBackupRounds = safeNumber(totals.AmmoBackupRounds)
-				PtsCrew = safeNumber(totals.Crew)
-				PtsElectronics = safeNumber(totals.Electronics)
-				details = hypoDetails
-			end
-			local cooldown = ACE.ArmorPreviewCooldown or 5
-			ply.ACE_ArmorHypoNext = now + cooldown
-		end
-	end
-
-	if HypoUsed then
-		frontArm = HypoFront
-		sideArm = HypoSide
-	end
-
-	local netDetails = normalizePointDetails(details)
-
-	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {}, netDetails }
+	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {} }
 	local ToJSON		= util.TableToJSON( GeneralTb )
 	local Compressed	= util.Compress(ToJSON) or ""
 
@@ -297,32 +213,20 @@ function TOOL:Reload( trace )
 		net.WriteFloat(parenttotal)
 		net.WriteFloat(physratio)
 		net.WriteFloat(power)
-		net.WriteFloat(LegacyCost)
 		net.WriteFloat(PointVal)
 		net.WriteFloat(PtsArmor)
+		net.WriteBool(ArmorInitMissing)
+		net.WriteBool(fullReadout)
 		net.WriteFloat(PtsEngine)
 		net.WriteFloat(PtsFirepower)
 		net.WriteFloat(PtsAmmo)
-		net.WriteFloat(PtsAmmoReady)
-		net.WriteFloat(PtsAmmoBackup)
-		net.WriteFloat(AmmoReadyRounds)
-		net.WriteFloat(AmmoBackupRounds)
 		net.WriteFloat(PtsCrew)
 		net.WriteFloat(PtsElectronics)
-		net.WriteFloat(frontArm)
-		net.WriteFloat(sideArm)
-		net.WriteBool(ArmorDirty)
-		net.WriteBool(ArmorInitMissing)
-		net.WriteBool(HypoRequested)
-		net.WriteBool(HypoUsed)
-		net.WriteFloat(HypoFront)
-		net.WriteFloat(HypoSide)
-		net.WriteFloat(HypoPts)
 
 		net.WriteUInt(#Compressed, 16)
 		net.WriteData(Compressed, #Compressed)
 
-	net.Send(self:GetOwner())
+	net.Send(ply)
 
 end
 
@@ -361,74 +265,110 @@ local PointClassToType = {
 	ace_wind_sensor = "Electronics"
 }
 
--- Resolve ammo caliber in millimeters.
-local function ACE_GetAmmoCaliberMm(bdata)
-	if not bdata then return 0 end
+local function ACE_GetDPSCostByTypeForGun(con, gun)
+	local breakdown = {}
+	if not con or not con.ents or not IsValid(gun) then return breakdown end
 
-	local best = math.max(
-		bdata.Caliber or 0,
-		bdata.SlugCaliber or 0,
-		bdata.SlugCaliber2 or 0,
-		bdata.JetCaliber or 0
-	)
+	local totalFirepower = ACE_GetGunFirepowerPoints and ACE_GetGunFirepowerPoints(gun) or 0
+	if totalFirepower <= 0 then return breakdown end
 
-	if best <= 0 and bdata.Id then
-		best = ACF_GetGunValue(bdata.Id, "caliber") or 0
-	end
-
-	return best * 10
-end
-
--- Resolve gun caliber in millimeters.
-local function ACE_GetGunCaliberMm(ent)
-	if not IsValid(ent) then return 0 end
-
-	local cal = ent.Caliber or 0
-	if cal <= 0 and ent.Id then
-		cal = ACF_GetGunValue(ent.Id, "caliber") or 0
-	end
-
-	return cal * 10
-end
-
--- Sum ammo points for a given caliber.
-local function ACE_GetAmmoCostForCaliber(con, caliberMm)
-	if not con or not con.ents or caliberMm <= 0 then return 0 end
-
-	local target = math.floor(caliberMm + 0.5)
-	local total = 0
-	-- Sum ammo crate points that match the gun caliber.
-
+	local weights = {}
+	local totalWeight = 0
 	for ent in pairs(con.ents) do
 		if IsValid(ent) and ent:GetClass() == "acf_ammo" then
-			local cal = ACE_GetAmmoCaliberMm(ent.BulletData)
-			if cal > 0 and math.floor(cal + 0.5) == target then
-				total = total + (ACE_GetAmmoCratePointsForContraption(ent, con, ent) or 0)
+			local bdata = ent.BulletData
+			if istable(bdata) and bdata.Id == gun.Id then
+				local _, detail = ACE_GetAmmoCratePointsForContraption(ent, con, ent)
+				local weight = (detail and detail.RawAmmoCost) or 0
+				local ammoType = (bdata and bdata.Type) or "Ammo"
+				ammoType = ammoType ~= "" and ammoType or "Ammo"
+				if weight > 0 then
+					weights[ammoType] = (weights[ammoType] or 0) + weight
+					totalWeight = totalWeight + weight
+				end
 			end
 		end
 	end
 
-	return total
+	if totalWeight <= 0 then return breakdown end
+
+	local totalDPS = math.max(totalFirepower - totalWeight, 0)
+	if totalDPS <= 0 then return breakdown end
+
+	for ammoType, weight in pairs(weights) do
+		breakdown[ammoType] = totalDPS * (weight / totalWeight)
+	end
+
+	return breakdown
 end
 
--- Sum ammo points for crates compatible with a rack.
-local function ACE_GetAmmoCostForRack(con, rack)
-	if not con or not con.ents or not IsValid(rack) then return 0 end
-	if not ACF_CanLinkRack or not rack.Id then return 0 end
+local function ACE_GetAmmoCostByTypeForRack(con, rack)
+	local breakdown = {}
+	if not con or not con.ents or not IsValid(rack) then return breakdown end
+	if not ACF_CanLinkRack or not rack.Id then return breakdown end
 
-	local total = 0
+	local totalFirepower = ACE_GetGunFirepowerPoints and ACE_GetGunFirepowerPoints(rack) or 0
+	if totalFirepower <= 0 then return breakdown end
 
+	local weights = {}
+	local totalWeight = 0
 	for ent in pairs(con.ents) do
 		if IsValid(ent) and ent:GetClass() == "acf_ammo" then
 			local bdata = ent.BulletData
 			if istable(bdata) and ACF_CanLinkRack(rack.Id, bdata.Id, bdata, rack) then
-				total = total + (ACE_GetAmmoCratePointsForContraption(ent, con, ent) or 0)
+				local _, detail = ACE_GetAmmoCratePointsForContraption(ent, con, ent)
+				local weight = (detail and detail.RawAmmoCost) or 0
+				local ammoType = bdata.Type or "Ammo"
+				ammoType = ammoType ~= "" and ammoType or "Ammo"
+				if weight > 0 then
+					weights[ammoType] = (weights[ammoType] or 0) + weight
+					totalWeight = totalWeight + weight
+				end
 			end
 		end
 	end
 
-	return total
+	if totalWeight <= 0 then return breakdown end
+
+	local totalDPS = math.max(totalFirepower - totalWeight, 0)
+	if totalDPS <= 0 then return breakdown end
+
+	for ammoType, weight in pairs(weights) do
+		breakdown[ammoType] = totalDPS * (weight / totalWeight)
+	end
+
+	return breakdown
 end
+
+local function ACE_FormatPoints(points)
+	points = math.Round(tonumber(points) or 0, 1)
+	local whole = math.floor(points)
+	local frac = math.floor((points - whole) * 10 + 0.5)
+	local text = string.Comma(whole)
+	if frac > 0 then text = text .. "." .. frac end
+	return text .. "pts"
+end
+
+local function ACE_FormatTypeBreakdown(breakdown)
+	local entries = {}
+
+	for ammoType, points in pairs(breakdown or {}) do
+		if points > 0 then
+			entries[#entries + 1] = tostring(ammoType) .. " " .. ACE_FormatPoints(points)
+		end
+	end
+
+	table.sort(entries)
+	return table.concat(entries, ", ")
+end
+
+local CostLabelByCategory = {
+	Engines = "Mobility Cost",
+	Firepower = "DPS Cost",
+	Ammo = "Raw Ammo Cost",
+	Crew = "Crew Cost",
+	Electronics = "Electronics Cost"
+}
 
 -- Resolve point category for a class.
 local function ACE_GetPointsCategory(ent)
@@ -462,82 +402,71 @@ local function ACE_DebugArmorPopup(ply, ent, con, matchedRow)
 end
 
 local function ACE_GetPopupPoints(ent, ply)
-	if not IsValid(ent) then return 0, "Entity Cost" end
+	if not IsValid(ent) then return 0, "Entity Cost", "" end
 
 	local cls = ent:GetClass()
-	local points = 0
-
-	if cls == "acf_ammo" and ACE_GetAmmoCratePointsForContraption then
-		local con = ent:CFW_GetContraption()
-		points = ACE_GetAmmoCratePointsForContraption(ent, con, ent) or 0
-	elseif ACE_GetEntPoints then
-		points = ACE_GetEntPoints(ent) or 0
-	end
-
-	local label = "Entity Cost"
-	if points ~= 0 then return points, label end
-
 	local con = ent:CFW_GetContraption()
+	local armorPoints = ACE_GetArmorPoints and ACE_GetArmorPoints(ent) or 0
+	local componentPoints = 0
+	local lines = {}
 
-	-- Guns fall back to the ammo cost for their own caliber.
-	if cls == "acf_gun" then
-		local gunCal = ACE_GetGunCaliberMm(ent)
-		local ammoCost = ACE_GetAmmoCostForCaliber(con, gunCal)
-		if ammoCost > 0 then
-			points = ammoCost
-			if gunCal > 0 then
-				label = string.format("Total Ammo Cost (%dmm)", math.floor(gunCal + 0.5))
-			else
-				label = "Total Ammo Cost"
-			end
+	if armorPoints > 0 then
+		lines[#lines + 1] = "Armor Cost: " .. ACE_FormatPoints(armorPoints)
+	end
 
-			return points, label
+	if cls == "acf_engine" or cls == "acf_gearbox" then
+		componentPoints = ACE_GetEntPoints and ACE_GetEntPoints(ent) or 0
+		if componentPoints > 0 then
+			lines[#lines + 1] = CostLabelByCategory.Engines .. ": " .. ACE_FormatPoints(componentPoints)
+		end
+	elseif cls == "acf_gun" then
+		local ammoByType = ACE_GetDPSCostByTypeForGun(con, ent)
+		local text = ACE_FormatTypeBreakdown(ammoByType)
+
+		for _, points in pairs(ammoByType) do
+			componentPoints = componentPoints + points
+		end
+
+		if text ~= "" then
+			lines[#lines + 1] = CostLabelByCategory.Firepower .. ": " .. text
+		end
+	elseif cls == "acf_rack" then
+		local ammoByType = ACE_GetAmmoCostByTypeForRack(con, ent)
+		local text = ACE_FormatTypeBreakdown(ammoByType)
+
+		for _, points in pairs(ammoByType) do
+			componentPoints = componentPoints + points
+		end
+
+		if text ~= "" then
+			lines[#lines + 1] = CostLabelByCategory.Firepower .. ": " .. text
+		end
+	elseif cls == "acf_ammo" and ACE_GetAmmoCratePointsForContraption then
+		local _, detail = ACE_GetAmmoCratePointsForContraption(ent, con, ent)
+		componentPoints = (detail and detail.RawAmmoCost) or 0
+		if componentPoints > 0 then
+			lines[#lines + 1] = CostLabelByCategory.Ammo .. ": " .. ACE_FormatPoints(componentPoints)
+		end
+	else
+		local category = ACE_GetPointsCategory(ent)
+		if category == "Crew" and ACE_GetCrewSeatPointCost then
+			componentPoints = ACE_GetCrewSeatPointCost(ent)
+		else
+			componentPoints = ACE_GetEntPoints and ACE_GetEntPoints(ent) or 0
+		end
+		if componentPoints > 0 and category and category ~= "Armor" and category ~= "Ignore" then
+			local label = CostLabelByCategory[category] or (category .. " Cost")
+			lines[#lines + 1] = label .. ": " .. ACE_FormatPoints(componentPoints)
 		end
 	end
 
-	-- Racks fall back to the ammo cost of crates compatible with this rack.
-	if cls == "acf_rack" then
-		local ammoCost = ACE_GetAmmoCostForRack(con, ent)
-		if ammoCost > 0 then
-			return ammoCost, "Total Rack Ammo Cost"
-		end
+	local total = armorPoints + componentPoints
+	if total <= 0 then
+		return 0, "Entity Cost", ""
 	end
 
-	if con and ACE_EnsureArmor then
-		ACE_EnsureArmor(con, ent, false)
-	end
-
-	local pointsPerType = con and con.ACEPointsPerType or nil
-	local category = pointsPerType and ACE_GetPointsCategory(ent) or nil
-
-	-- Armor props should use only their per-entity contribution from the armor detail table.
-	if category == "Armor" then
-		local matchedRow = nil
-		if con and istable(con.ACEArmorDetails) then
-			local idx = ent:EntIndex()
-			for _, row in ipairs(con.ACEArmorDetails) do
-				if istable(row) and row.EntIndex == idx then
-					matchedRow = row
-					local armorPts = tonumber(row.Points) or 0
-					ACE_DebugArmorPopup(ply, ent, con, matchedRow)
-					return armorPts, "Entity Armor Cost"
-				end
-			end
-		end
-
-		ACE_DebugArmorPopup(ply, ent, con, matchedRow)
-		-- Never fall back armor entities to total armor category in popup.
-		return 0, "Entity Armor Cost"
-	end
-
-	local categoryPts = category and pointsPerType[category] or 0
-	categoryPts = tonumber(categoryPts) or 0
-	if categoryPts > 0 then
-		points = categoryPts
-		label = "Total " .. category .. " Cost"
-	end
-
-	return points, label
+	ACE_DebugArmorPopup(ply, ent, con, nil)
+	return total, "Entity Cost", table.concat(lines, "\n")
 end
 
 -- Update hover popup data for the active tool.
@@ -558,7 +487,7 @@ function TOOL:Think()
 
 		local Mat = ent.ACF.Material or "RHA"
 		local MatData = ACE_GetMaterialData( Mat )
-		local AcePts, pointsLabel = ACE_GetPopupPoints(ent, ply)
+		local AcePts, pointsLabel, pointBreakdown = ACE_GetPopupPoints(ent, ply)
 
 		if not MatData then return end
 
@@ -571,7 +500,7 @@ function TOOL:Think()
 		self.Weapon:SetNWString( "Material", MatData.sname or "RHA")
 		self.Weapon:SetNWString( "PointCostLabel", pointsLabel )
 		self.Weapon:SetNWFloat( "PointCost", AcePts )
-		self.Weapon:SetNWFloat( "CostValue", ACE_GetEntLegacyCost and ACE_GetEntLegacyCost(ent) or 0 )
+		self.Weapon:SetNWString( "PointCostBreakdown", pointBreakdown or "" )
 
 	else
 
@@ -584,7 +513,7 @@ function TOOL:Think()
 		self.Weapon:SetNWString( "Material", "RHA" )
 		self.Weapon:SetNWString( "PointCostLabel", "Entity Cost" )
 		self.Weapon:SetNWFloat( "PointCost", 0 )
-		self.Weapon:SetNWFloat( "CostValue", 0 )
+		self.Weapon:SetNWString( "PointCostBreakdown", "" )
 	end
 
 	self.AimEntity = ent
@@ -596,35 +525,25 @@ if CLIENT then
 
 	local getPhrase = language.GetPhrase
 
-	-- Normalize legacy material values stored in client convars.
-	local function ACE_MaterialCheck( Material )
+	-- Estimate the selected armor settings with the same formula used for armor cost.
+	local function ACE_GetArmorPointPreview(armor, health, matData)
+		if not matData or not ACE_GetArmorPointConfig then return 0 end
 
-		-- Map legacy numeric ids to string ids.
-		local BackCompMat = {
-			"RHA",
-			"CHA",
-			"Cer",
-			"Rub",
-			"ERA",
-			"Alum",
-			"Texto"
-		}
+		local cfg = ACE_GetArmorPointConfig()
+		local curve = tonumber(matData.curve) or 1
+		local effKE = tonumber(matData.effectiveness) or 1
+		local effCHEM = tonumber(matData.HEATeffectiveness or matData.effectiveness) or effKE
+		local weightedEff = effKE * cfg.KEWeight + effCHEM * cfg.ChemWeight
+		local armorMod = ACF.ArmorMod or 1
+		local effectiveMm = ((tonumber(armor) or 0) ^ curve) * weightedEff / math.max(armorMod, 0.001)
+		local hp = tonumber(health) or 0
 
-		-- If the convar holds a legacy id, replace it with the modern id.
-		if isnumber(tonumber(Material)) then
+		if effectiveMm <= 0 or hp <= 0 then return 0 end
 
-			local Mat_ID = math.Clamp(Material + 1, 1,7)
-			Material = BackCompMat[Mat_ID]
-
-			-- Write back the normalized material id.
-			RunConsoleCommand( "acfarmorprop_material", Material )
-		end
+		return cfg.SurvivabilityScale * cfg.ArmorCostMultiplier
+			* ((effectiveMm / math.max(cfg.DamageReferenceMm, 1)) ^ cfg.SurvivabilityArmorExponent)
+			* ((hp / math.max(cfg.SurvivabilityHPReference, 1)) ^ cfg.SurvivabilityHPExponent)
 	end
-
-	-- Delay normalization to allow client convars to initialize.
-	timer.Simple(0.1, function()
-		ACE_MaterialCheck( GetConVar("acfarmorprop_material"):GetString() )
-	end )
 
 	-- Helper to add centered help text; mirrors PANEL:CPanelText for this file.
 	local function ArmorPanelText( name, panel, desc, font )
@@ -715,9 +634,6 @@ if CLIENT then
 
 		panel:NumSlider( "#tool.acfarmorprop.ductility", "acfarmorprop_ductility", -80, 80 )
 		panel:ControlHelp( "#tool.acfarmorprop.ductilitydesc" )
-
-		panel:CheckBox( "Show full points readout", "acf_armor_readout_full" )
-		panel:ControlHelp( "Toggle the extended points readout shown on reload." )
 
 		MaterialTable(panel)
 
@@ -812,347 +728,106 @@ if CLIENT then
 		local Color3 = Color(255,255,100)
 		local Color4 = Color(255,191,0)
 
-		local total		= math.Round( net.ReadFloat(), 1 )
-		local phystotal	= math.Round( net.ReadFloat(), 1 )
-		local parenttotal	= math.Round( net.ReadFloat(), 1 )
-		local physratio	= math.Round( net.ReadFloat(), 1 )
-		local power		= net.ReadFloat() -- Preserve precision for hp/ton calculation.
-		local LegacyCost	= math.Round( net.ReadFloat(), 1 )
-		local CostDisplay	= math.Round( LegacyCost * 100, 0 )
-		local CostDisplayText = string.Comma(math.max(math.floor(CostDisplay), 0))
-
-
-		local hpton		= math.Round( power / (total / 1000), 1 )
+		local total = math.Round( net.ReadFloat(), 1 )
+		local phystotal = math.Round( net.ReadFloat(), 1 )
+		local parenttotal = math.Round( net.ReadFloat(), 1 )
+		local physratio = math.Round( net.ReadFloat(), 1 )
+		local power = net.ReadFloat() -- Preserve precision for hp/ton calculation.
 
 		local PointVal	= math.Round( net.ReadFloat(), 1 )
 		local PtsArmor = math.Round( net.ReadFloat(), 1 )
+
+		local ArmorInitMissing = net.ReadBool()
+		local FullReadout = net.ReadBool()
 		local PtsEngine = math.Round( net.ReadFloat(), 1 )
 		local PtsFirepower = math.Round( net.ReadFloat(), 1 )
 		local PtsAmmo = math.Round( net.ReadFloat(), 1 )
-		local PtsAmmoReady = math.Round( net.ReadFloat(), 1 )
-		local PtsAmmoBackup = math.Round( net.ReadFloat(), 1 )
-		net.ReadFloat()
-		local _ = math.Round( net.ReadFloat(), 0 )
 		local PtsCrew = math.Round( net.ReadFloat(), 1 )
 		local PtsElectronics = math.Round( net.ReadFloat(), 1 )
-
-		local quantStep = (ACE and ACE.ArmorScanConfig and ACE.ArmorScanConfig.ResultQuantizeMm) or 0
-		local armDigits = 2
-		if quantStep >= 1 then
-			armDigits = 0
-		elseif quantStep >= 0.1 then
-			armDigits = 1
-		end
-
-		local FrontArm = math.Round( net.ReadFloat(), armDigits )
-		local SideArm = math.Round( net.ReadFloat(), armDigits )
-		local ArmorDirty = net.ReadBool()
-		local ArmorInitMissing = net.ReadBool()
-		local HypoRequested = net.ReadBool()
-		local HypoUsed = net.ReadBool()
-		net.ReadFloat()
-		net.ReadFloat()
-		net.ReadFloat()
 
 		local compressedLen = net.ReadUInt(16)
 		local Compressed = compressedLen > 0 and net.ReadData(compressedLen) or nil
 		local Decompress = Compressed and util.Decompress(Compressed) or nil
 		local FromJSON = Decompress and util.JSONToTable(Decompress) or nil
+		FromJSON = istable(FromJSON) and FromJSON or { {}, {} }
 
 	local Sep = "\n"
 
 	local Tabletxt	= {}
+	local hpton = total > 0 and math.Round(power / (total / 1000), 1) or 0
 
-	-- Format ammo line items for the readout.
-	local function formatAmmoLines(lines)
-		if not istable(lines) then return {} end
-
-		local hideBackup = false
-		if ACE and ACE.AmmoCostConfig then
-			hideBackup = (tonumber(ACE.AmmoCostConfig.StowFactor) or 0) == 0
-		end
-
-		local entries = {}
-		for _, entry in ipairs(lines) do
-			local count = tonumber(entry.Count or entry.count or 0) or 0
-			local state = tostring(entry.State or entry.state or "")
-			if not (hideBackup and state == "BACKUP") and count > 0 then
-				entries[#entries + 1] = {
-					count = math.floor(count + 0.5),
-					caliber = tonumber(entry.Caliber or entry.caliber or 0) or 0,
-					atype = tostring(entry.Type or entry.type or "Ammo"),
-					state = state,
-				points = tonumber(entry.Points or entry.points or 0) or 0
-				}
-			end
-		end
-
-		table.sort(entries, function(a, b)
-			if a.points == b.points then
-				if a.caliber == b.caliber then
-					if a.atype == b.atype then
-						if a.state == b.state then
-							return a.count > b.count
-						end
-						return a.state == "READY"
-					end
-					return a.atype < b.atype
-				end
-				return a.caliber > b.caliber
-			end
-			return a.points > b.points
-		end)
-
-		local formatted = {}
-		for _, entry in ipairs(entries) do
-			local calText = entry.caliber > 0 and string.format("%dmm", entry.caliber) or "0mm"
-			local stateLabel = entry.state
-			if hideBackup and entry.state == "READY" then
-				stateLabel = ""
-			end
-
-			local costText = ""
-			if entry.state == "READY" and entry.points > 0 then
-				costText = string.format(" - %.1fpts", entry.points)
-			end
-
-			formatted[#formatted + 1] = string.format("%dx%s %s%s%s", entry.count, calText, entry.atype, stateLabel ~= "" and " " .. stateLabel or "", costText)
-		end
-
-		return formatted
+	local function addPointsLine(label, points)
+		if points <= 0 then return end
+		table.Add(Tabletxt, { Color4, label .. ": ", Color3, points .. "pts" .. Sep })
 	end
 
-	-- Percent helper for readout lines.
-	local function pct(part, total)
-		if total <= 0 then return 0 end
-		return math.Round(part / total * 100, 0)
-	end
-
-	local function getMaxReadoutLines()
-		return 3
-	end
-
-	-- Prebuild readout labels and summary rows.
-	local PTBreakdownHeader = { Color2, "<|", Color1, "|============|", Color2, "[- Cost Breakdown -]", Color1, "|============|", Color2, "|>" .. Sep }
-
-	local Title = { Color2, "<|", Color1, "|============|", Color2, "[- Contraption Summary -]", Color1, "|============|", Color2, "|>" .. Sep }
-	local SummaryPoints
-	if PointVal > ACF.PointsLimit then
-		local OverPoints = PointVal - ACF.PointsLimit
-		SummaryPoints = { Color4, "-Points Cost: ", Color1, "" .. PointVal .. "pts", Color2, "  -  ", Color1, OverPoints .. " pts over" .. Sep }
+	if FullReadout then
+		table.Add(Tabletxt, { Color2, "<|", Color1, "|============|", Color2, "[- Cost Breakdown -]", Color1, "|============|", Color2, "|>" .. Sep })
+		addPointsLine("Points", PointVal)
+		addPointsLine("Armor Cost", PtsArmor)
+		addPointsLine("Mobility Cost", PtsEngine)
+		addPointsLine("Raw Ammo Cost", PtsAmmo)
+		addPointsLine("DPS Cost", PtsFirepower)
+		addPointsLine("Crew Cost", PtsCrew)
+		addPointsLine("Electronics Cost", PtsElectronics)
+		table.Add(Tabletxt, { Color2, "<|", Color1, "|==========================================|", Color2, "|>" .. Sep })
 	else
-		SummaryPoints = { Color4, "-Points Cost: ", Color3, "" .. PointVal .. "pts" .. Sep }
-	end
-
-	local SummaryCost = { Color4, "-Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep }
-	local TMass2 = {
-		Color4, "-Mass Ratio: ", Color3, "" .. phystotal .. "kg",
-		Color4, " physical, ", Color3, "" .. parenttotal .. "kg",
-		Color4, " parented / ", Color3, physratio .. "%", Color4, " physical )" .. Sep
-	}
-
-	local Engine = {
-		Color4, "-Total Power: ", Color3, "" .. math.Round(power, 1),
-		Color4, " hp -> ", Color3, "" .. hpton, Color4, " hp/ton" .. Sep
-	}
-
-	local function formatArmorLines(lines)
-		if not istable(lines) then return {} end
-
-		local entries = {}
-		for _, entry in ipairs(lines) do
-			if istable(entry) then
-				entries[#entries + 1] = {
-					label = tostring(entry.Label or entry.label or "Armor Segment"),
-					points = tonumber(entry.Points or entry.points) or 0,
-				}
-			end
-		end
-
-		table.sort(entries, function(a, b)
-			if a.points == b.points then
-				return a.label < b.label
-			end
-			return a.points > b.points
-		end)
-
-		local formatted = {}
-		for _, entry in ipairs(entries) do
-			formatted[#formatted + 1] = string.format("%s: %.1f pts", entry.label, entry.points)
-		end
-
-		return formatted
-	end
-
-	local function normalizeDecodedDetails(raw)
-		if not istable(raw) then
-			return { Items = {}, AmmoLines = {}, ArmorLines = {} }
-		end
-		return {
-			Items = istable(raw.Items) and raw.Items or {},
-			AmmoLines = istable(raw.AmmoLines) and raw.AmmoLines or {},
-			ArmorLines = istable(raw.ArmorLines) and raw.ArmorLines or {}
-		}
-	end
-
-	local Details = normalizeDecodedDetails(FromJSON and FromJSON[3] or nil)
-	local ammoLines = formatAmmoLines(Details.AmmoLines)
-	local armorLines = formatArmorLines(Details.ArmorLines)
-
-	-- Full readout is optional; collapsed mode only shows warnings and cost.
-	local showBreakdown = not (ArmorInitMissing and not HypoUsed)
-	local fullReadout = true
-	local fullReadoutCvar = GetConVar( "acf_armor_readout_full" )
-	if fullReadoutCvar then
-		fullReadout = fullReadoutCvar:GetBool()
-	end
-
-	if not fullReadout then
-		showBreakdown = false
-	end
-	-- Condensed mode shows warnings and core totals only.
-	if not showBreakdown then
-		if ArmorDirty then
-			table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
-		elseif ArmorInitMissing and not HypoUsed and not HypoRequested then
-			table.Add(Tabletxt, {
-				Color1,
-				"[!] ARMOR COST NOT INITIALIZED. ",
-				Color2,
-				"Something terrible has happened. Please forward this to the devs. Frankly I don't even know how you got here." .. Sep
-			})
-		end
-		if not ArmorInitMissing and fullReadout then
-			table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep })
-		end
-	else
-		Tabletxt = table.Add(Tabletxt, PTBreakdownHeader)
-		if HypoUsed then
-			table.Add(Tabletxt, { Color2, "[i] Preview mode (no points applied). Respawn to apply." .. Sep })
-		end
-
-		local TPoints = {}
-		local totalLabel = HypoUsed and "Points Cost (preview): " or "Points Cost: "
-		if PointVal > ACF.PointsLimit then
-			local OverPoints = PointVal - ACF.PointsLimit
-			TPoints = {
-				Color4, totalLabel, Color1, "" .. PointVal .. "pts",
-				Color2, "  -  ", Color1, OverPoints .. " pts over" .. Sep
-			}
-		else
-			TPoints = { Color4, totalLabel, Color3, "" .. PointVal .. "pts" .. Sep }
-		end
-		table.Add(Tabletxt, TPoints)
-		table.Add(Tabletxt, { Color4, "Manufacturing Cost: ", Color3, "$" .. CostDisplayText .. Sep })
-		if ArmorDirty then
-			table.Add(Tabletxt, { Color1, "[!] Armor cost dirty; respawn to recalc." .. Sep })
-		elseif ArmorInitMissing and not HypoUsed then
-			table.Add(Tabletxt, { Color1, "[!] ARMOR COST NOT INITIALIZED. ", Color2, "Unfreeze or enter vehicle." .. Sep })
-		end
-
-		local FractionalPts = "/" .. PointVal
-		local armFmt = string.format("front=%%.%dfmm  side=%%.%dfmm", armDigits, armDigits)
+		table.Add(Tabletxt, { Color2, "<|", Color1, "|============|", Color2, "[- Contraption Summary -]", Color1, "|============|", Color2, "|>" .. Sep })
 		table.Add(Tabletxt, {
-			Color4, "Armor scan: ", Color3, string.format(armFmt, FrontArm, SideArm) .. Sep
+			Color4, "-Mass Ratio: ", Color3, "" .. phystotal .. "kg",
+			Color4, " physical, ", Color3, "" .. parenttotal .. "kg",
+			Color4, " parented / ", Color3, physratio .. "%", Color4, " physical )" .. Sep
 		})
-		table.Add(Tabletxt, { Color4, "Armor: ", Color3, "(" .. pct(PtsArmor, PointVal) .. "%) - ", PtsArmor .. FractionalPts .. Sep })
-		if #armorLines > 0 then
-			local maxArmorLines = getMaxReadoutLines()
-			for i, line in ipairs(armorLines) do
-				if i > maxArmorLines then
-					table.Add(Tabletxt, { Color3, "    ..." .. (#armorLines - maxArmorLines) .. " more" .. Sep })
-					break
-				end
-				table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
-			end
-		end
-		table.Add(Tabletxt, { Color4, "Engines: ", Color3, "(" .. pct(PtsEngine, PointVal) .. "%) - ", PtsEngine .. FractionalPts .. Sep })
-		if PtsFirepower > 0 then
-			table.Add(Tabletxt, {
-				Color4, "Firepower: ", Color3,
-				"(" .. pct(PtsFirepower, PointVal) .. "%) - ", PtsFirepower .. FractionalPts .. Sep
-			})
-		end
-		if PtsAmmo > 0 or #ammoLines > 0 or PtsAmmoReady > 0 or PtsAmmoBackup > 0 then
-			table.Add(Tabletxt, { Color4, "Ammo: ", Color3, "(" .. pct(PtsAmmo, PointVal) .. "%) - ", PtsAmmo .. FractionalPts .. Sep })
-			if #ammoLines > 0 then
-				local maxAmmoLines = getMaxReadoutLines()
-				for i, line in ipairs(ammoLines) do
-					if i > maxAmmoLines then
-						table.Add(Tabletxt, { Color3, "    ..." .. (#ammoLines - maxAmmoLines) .. " more" .. Sep })
-						break
-					end
-					table.Add(Tabletxt, { Color3, "    " .. line .. Sep })
-				end
-			end
-		end
-		table.Add(Tabletxt, { Color4, "Crew: ", Color3, "(" .. pct(PtsCrew, PointVal) .. "%) - ", PtsCrew .. FractionalPts .. Sep })
-		table.Add(Tabletxt, {
-			Color4, "Electronics: ", Color3,
-			"(" .. pct(PtsElectronics, PointVal) .. "%) - ", PtsElectronics .. FractionalPts .. Sep
-		})
-	end
 
-	Tabletxt = table.Add(Tabletxt, Title)
-	if not fullReadout then
-		Tabletxt = table.Add(Tabletxt, SummaryPoints)
-		Tabletxt = table.Add(Tabletxt, SummaryCost)
-	end
-	Tabletxt = table.Add(Tabletxt, TMass2)
-
-
-	local Count = 0
-	for material, _ in pairs(FromJSON[1]) do
-		local Percent = math.Round(FromJSON[2][material] * 100, 1)
-		local MatText = material .. ": "
-		local MassText = math.Round(Percent, 0) .. "%  "
-
-		Count = Count + 1
-			if Count > 7 then
-				Count = 0
-				table.Add(Tabletxt,{ Color4, MatText})
-				table.Add(Tabletxt,{ Color3, MassText .. Sep})
-			else
-				table.Add(Tabletxt,{ Color4, MatText})
-				table.Add(Tabletxt,{ Color3, MassText})
-			end
-
+		local count = 0
+		for material, _ in pairs(FromJSON[1]) do
+			local percent = math.Round((FromJSON[2][material] or 0) * 100, 1)
+			count = count + 1
+			table.Add(Tabletxt, { Color4, material .. ": ", Color3, math.Round(percent, 0) .. "%  " .. (count > 7 and Sep or "") })
+			if count > 7 then count = 0 end
 		end
 
-		table.Add(Tabletxt,{ Color4, Sep})
+		table.Add(Tabletxt, { Color4, Sep })
 
-		Count = 0
-		for material, mass in pairs( FromJSON[1] ) do
-			local MatText = material .. ": "
-			local MassText = math.Round(mass,1) .. "kg  "
-
-			Count = Count + 1
-			if Count >= 3 then
-				Count = 0
-				table.Add(Tabletxt,{ Color4, MatText})
-				table.Add(Tabletxt,{ Color3, MassText .. Sep})
-			else
-				table.Add(Tabletxt,{ Color4, MatText})
-				table.Add(Tabletxt,{ Color3, MassText})
-			end
-
+		count = 0
+		for material, mass in pairs(FromJSON[1]) do
+			count = count + 1
+			table.Add(Tabletxt, { Color4, material .. ": ", Color3, math.Round(mass, 1) .. "kg  " .. (count >= 3 and Sep or "") })
+			if count >= 3 then count = 0 end
 		end
 
+		table.Add(Tabletxt, { Color3, Sep })
 
-		table.Add(Tabletxt,{Color3,Sep})
-
-		Tabletxt = table.Add(Tabletxt,TbStr)
-
-		local TMass = {}
 		if total > ACF.MaxWeight then
-			local OverTons = total - ACF.MaxWeight
-			TMass		= { Color4, "-Total Mass: ", Color1, "" .. math.Truncate(total / 1000,1) .. " tons", Color4, " / ", Color1, "" .. total .. "kg", Color2, "  -  ", Color1, OverTons .. " kg over" .. Sep }
+			table.Add(Tabletxt, {
+				Color4, "-Total Mass: ", Color1, "" .. math.Truncate(total / 1000, 1) .. " tons",
+				Color4, " / ", Color1, "" .. total .. "kg",
+				Color2, "  -  ", Color1, math.Round(total - ACF.MaxWeight, 1) .. " kg over" .. Sep
+			})
 		else
-			TMass		= { Color4, "-Total Mass: ", Color3, "" .. math.Truncate(total / 1000,1) .. " tons", Color4, " / ", Color3, "" .. total .. "kg" .. Sep }
+			table.Add(Tabletxt, {
+				Color4, "-Total Mass: ", Color3, "" .. math.Truncate(total / 1000, 1) .. " tons",
+				Color4, " / ", Color3, "" .. total .. "kg" .. Sep
+			})
 		end
 
-		Tabletxt = table.Add(Tabletxt,TMass)
-		Tabletxt = table.Add(Tabletxt,Engine)
+		table.Add(Tabletxt, {
+			Color4, "-Total Power: ", Color3, "" .. math.Round(power, 1),
+			Color4, " hp -> ", Color3, "" .. hpton, Color4, " hp/ton" .. Sep
+		})
+
+		local pointsColor = PointVal > ACF.PointsLimit and Color1 or Color3
+		table.Add(Tabletxt, { Color4, "-Total Point Cost: ", pointsColor, PointVal .. "pts" })
+		if PointVal > ACF.PointsLimit then
+			table.Add(Tabletxt, { Color2, "  -  ", Color1, math.Round(PointVal - ACF.PointsLimit, 1) .. " pts over" })
+		end
+
+		table.Add(Tabletxt, { Color2, "\n<|", Color1, "|===============================================|", Color2, "|>" .. Sep })
+	end
+
+	if ArmorInitMissing then
+		table.Add(Tabletxt, { Color1, Sep .. "[!] ARMOR POINTS NOT INITIALIZED. ", Color2, "Unfreeze or enter vehicle." })
+	end
 
 		chat.AddText(unpack(Tabletxt))
 
@@ -1167,9 +842,9 @@ if CLIENT then
 		getPhrase("tool.acfarmorprop.mass") .. ": %s\n" ..
 		getPhrase("tool.acfarmorprop.armor") .. ": %s\n" ..
 		getPhrase("tool.acfarmorprop.health") .. ": %s\n" ..
-		getPhrase("tool.acfarmorprop.material") .. ": %s\n\n" ..
-		"%s" ..
-		"Manufacturing Cost: $%s"
+		getPhrase("tool.acfarmorprop.material") .. ": %s\n" ..
+		"Entity Cost: %s\n\n" ..
+		"%s"
 
 	-- Draw the hover tooltip and popup text.
 	function TOOL:DrawHUD()
@@ -1182,7 +857,7 @@ if CLIENT then
 		local material	= self.Weapon:GetNWString( "Material" )
 		local pointLabel		= self.Weapon:GetNWString( "PointCostLabel", "Entity Cost" )
 		local acepointcost	= self.Weapon:GetNWFloat( "PointCost" )
-		local acecost		= self.Weapon:GetNWFloat( "CostValue", 0 )
+		local pointBreakdown = self.Weapon:GetNWString( "PointCostBreakdown", "" )
 
 		local area		= GetConVar( "acfarmorprop_area" ):GetFloat()
 		local ductility	= GetConVar( "acfarmorprop_ductility" ):GetFloat()
@@ -1193,20 +868,15 @@ if CLIENT then
 
 		local mass, armor, health = CalcArmor( area, ductility / 100, thickness , mat)
 		mass = math.min( mass, 50000 )
+		local afterCost = ACE_GetArmorPointPreview(armor, health, MatData)
 
 		local pointLine = ""
 		if acepointcost > 0 then
-			local roundedPoints = math.Round(acepointcost, 1)
-			local whole = math.floor(roundedPoints)
-			local frac = math.floor((roundedPoints - whole) * 10 + 0.5)
-			local pointText = string.Comma(whole)
-			if frac > 0 then
-				pointText = pointText .. "." .. frac
+			pointLine = string.format("%s: %s\n", pointLabel, ACE_FormatPoints(acepointcost))
+			if pointBreakdown ~= "" then
+				pointLine = pointLine .. pointBreakdown .. "\n"
 			end
-			pointLine = string.format("%s: %spts\n", pointLabel, pointText)
 		end
-
-		local costText = string.Comma(math.max(math.Round(acecost * 100, 0), 0))
 
 		local text = string.format(overlayTextFormat,
 			math.Round(curmass, 2),
@@ -1217,8 +887,8 @@ if CLIENT then
 			math.Round(armor, 2),
 			math.Round(health, 2),
 			MatData.sname,
-			pointLine,
-			costText
+			ACE_FormatPoints(afterCost),
+			pointLine
 		)
 
 		local pos = ent:WorldSpaceCenter()

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -302,6 +302,39 @@ local function ACE_GetDPSCostByTypeForGun(con, gun)
 	return breakdown
 end
 
+-- Cost of the missiles currently sitting in this rack's tubes, broken down by
+-- ammo type. The cost itself is already paid through the feeding crate's
+-- RawAmmoCost (rack reserve adds rounds to readyCount in ACE_BuildRackReserveAlloc),
+-- so this is purely informational for the rack popup -- it tells the user
+-- "your rack carries X pts of Y missiles in its tubes" without re-summing into
+-- the rack's own componentPoints, which would double-count against the crate.
+local function ACE_GetRackReserveCostByType(con, rack)
+	local breakdown = {}
+	if not con or not IsValid(rack) then return breakdown end
+	if not ACE_GetRackPreloadAlloc or not ACE_GetAmmoCratePointsForContraption then return breakdown end
+
+	local alloc = ACE_GetRackPreloadAlloc(rack, con, rack)
+	if not alloc then return breakdown end
+
+	for crate, share in pairs(alloc) do
+		if IsValid(crate) and share > 0 then
+			local _, detail = ACE_GetAmmoCratePointsForContraption(crate, con, crate)
+			if detail then
+				local readyCount = detail.ReadyCount or 0
+				local cost = detail.RawAmmoCost or 0
+				if readyCount > 0 and cost > 0 then
+					local perMissile = cost / readyCount
+					local ammoType = detail.Type
+					ammoType = (ammoType and ammoType ~= "") and ammoType or "Ammo"
+					breakdown[ammoType] = (breakdown[ammoType] or 0) + perMissile * share
+				end
+			end
+		end
+	end
+
+	return breakdown
+end
+
 local function ACE_GetAmmoCostByTypeForRack(con, rack)
 	local breakdown = {}
 	if not con or not con.ents or not IsValid(rack) then return breakdown end
@@ -441,6 +474,14 @@ local function ACE_GetPopupPoints(ent, ply)
 		if text ~= "" then
 			lines[#lines + 1] = CostLabelByCategory.Firepower .. ": " .. text
 		end
+
+		local reserveByType = ACE_GetRackReserveCostByType(con, ent)
+		local reserveText = ACE_FormatTypeBreakdown(reserveByType)
+		if reserveText ~= "" then
+			-- Informational: the cost shown here is already paid through the
+			-- linked crate's RawAmmoCost, so it is NOT added to componentPoints.
+			lines[#lines + 1] = "Loaded Missiles (on crates): " .. reserveText
+		end
 	elseif cls == "acf_ammo" and ACE_GetAmmoCratePointsForContraption then
 		local _, detail = ACE_GetAmmoCratePointsForContraption(ent, con, ent)
 		componentPoints = (detail and detail.RawAmmoCost) or 0
@@ -462,11 +503,14 @@ local function ACE_GetPopupPoints(ent, ply)
 
 	local total = armorPoints + componentPoints
 	if total <= 0 then
-		return 0, "Entity Cost", ""
+		return 0, "Entity Cost", "", 0
 	end
 
 	ACE_DebugArmorPopup(ply, ent, con, nil)
-	return total, "Entity Cost", table.concat(lines, "\n")
+	-- 4th return is the non-armor component cost; the HUD adds it to the
+	-- armor preview so the "after change" estimate reflects what the entity
+	-- will actually cost (e.g. ammo + new armor), not just the new armor.
+	return total, "Entity Cost", table.concat(lines, "\n"), componentPoints
 end
 
 -- Update hover popup data for the active tool.
@@ -487,7 +531,7 @@ function TOOL:Think()
 
 		local Mat = ent.ACF.Material or "RHA"
 		local MatData = ACE_GetMaterialData( Mat )
-		local AcePts, pointsLabel, pointBreakdown = ACE_GetPopupPoints(ent, ply)
+		local AcePts, pointsLabel, pointBreakdown, componentCost = ACE_GetPopupPoints(ent, ply)
 
 		if not MatData then return end
 
@@ -500,6 +544,7 @@ function TOOL:Think()
 		self.Weapon:SetNWString( "Material", MatData.sname or "RHA")
 		self.Weapon:SetNWString( "PointCostLabel", pointsLabel )
 		self.Weapon:SetNWFloat( "PointCost", AcePts )
+		self.Weapon:SetNWFloat( "PointCostNonArmor", componentCost or 0 )
 		self.Weapon:SetNWString( "PointCostBreakdown", pointBreakdown or "" )
 
 	else
@@ -513,6 +558,7 @@ function TOOL:Think()
 		self.Weapon:SetNWString( "Material", "RHA" )
 		self.Weapon:SetNWString( "PointCostLabel", "Entity Cost" )
 		self.Weapon:SetNWFloat( "PointCost", 0 )
+		self.Weapon:SetNWFloat( "PointCostNonArmor", 0 )
 		self.Weapon:SetNWString( "PointCostBreakdown", "" )
 	end
 
@@ -857,6 +903,7 @@ if CLIENT then
 		local material	= self.Weapon:GetNWString( "Material" )
 		local pointLabel		= self.Weapon:GetNWString( "PointCostLabel", "Entity Cost" )
 		local acepointcost	= self.Weapon:GetNWFloat( "PointCost" )
+		local nonArmorCost	= self.Weapon:GetNWFloat( "PointCostNonArmor", 0 )
 		local pointBreakdown = self.Weapon:GetNWString( "PointCostBreakdown", "" )
 
 		local area		= GetConVar( "acfarmorprop_area" ):GetFloat()
@@ -868,7 +915,11 @@ if CLIENT then
 
 		local mass, armor, health = CalcArmor( area, ductility / 100, thickness , mat)
 		mass = math.min( mass, 50000 )
-		local afterCost = ACE_GetArmorPointPreview(armor, health, MatData)
+		-- Future entity cost is the new armor preview plus whatever the entity
+		-- already pays for non-armor reasons (ammo cost on a crate, firepower
+		-- contribution on a gun/rack, crew flat, etc.). Without this, ammo
+		-- crates and racks would preview their new cost as armor-only.
+		local afterCost = ACE_GetArmorPointPreview(armor, health, MatData) + nonArmorCost
 
 		local pointLine = ""
 		if acepointcost > 0 then


### PR DESCRIPTION
## Summary
Ten-commit branch rewriting how ACE point totals get built for contraption legality.

### 1. Drop the trace-based scan (`f4de9c5`)
Replaces the directional trace system with direct entity-walking logic closer to the original legacy approach. Loses directional accuracy on armor but gains stability on edge-case geometries (rocket tanks, APS-equipped contraptions that broke the trace direction scan). Point output is tuned to land at or below the prior numbers.

### 2. Account for rack pre-load when pricing ammo (`48de4af`)
Missile racks can be primed to their `MaxMissile` capacity from a linked crate, so effective ready firepower is `rack.MaxMissile + crate.Capacity`, not just the crate's loose rounds. `ACE_BuildRackReserveAlloc` distributes each rack's `MaxMissile` across the crates it could feed (`ACF_CanLinkRack` -- same rule that credits a rack's RPS to a crate), weighted by ammo threat with an even-share fallback, largest-remainder rounding, `EntIndex` tiebreak. `ACE_BuildAmmoReadyAlloc` and `ACE_CalcAmmoCratePoints` both add the reserve to a crate's effective round count before the readyCap clamps.

### 3. Apply guidance to missile ammo cost (`d88cc33`)
`ACE_GetAmmoGuidancePenFactor` previously wrapped its return in `math.max(factor, 1)`, neutering every below-1 entry to 1 while letting above-1 entries pass. The non-ATGM rack path was using the raw factor, so the two sides disagreed. Drops the clamp so guidance scales pen across every cost path.

### 4. Retune `MissileGuidanceFactors` (`8a85fb8`)
With guidance applied as a pen multiplier across all paths, the old 0.3-to-3.0 spread was too aggressive. Compresses to roughly 0.5-1.8 with Wire/SACLOS/Laser near 1.0 as the neutral baseline.

### 5. Unify missile pricing on the performance model (`fec7af2`)
`ACE_CalcMissileRoundPoints` used to branch on `ACE_IsATGMCostAmmo`: ATGMs took the dynamic performance cost, every other missile type took a static configured `pointcost` multiplied by the raw guidance factor. Drops the branch; every missile uses the performance model. Config renamed `ATGMCostConfig` -> `MissileCostConfig`, `ACE_IsATGMCostAmmo` removed.

### 6. Drop legacy per-missile `pointcost` fields (`f46e81e`)
Strips all 95 hand-tuned `pointcost` fields from the 11 missile definition files under `lua/acf/shared/missiles/`. Dead weight after commit 5 and an attractive nuisance for future tuning.

### 7. Wire `MissileCostConfig.PerformanceMul` into the crate path + bump to 3.0 (`9f27d89`)
`PerformanceMul` only reached `missile.ACEPoints` (a display value, never summed into a contraption total because `ace_missile` is mapped to `"Ignore"` in `ACE.ClassToType`). Moves the multiplier into `ACE_GetAmmoRoundPoints` gated on `ACE_IsAmmoMissileType` so it actually tunes crate-side missile pricing. Default bumped `1.0` -> `3.0` because at `1.0` a THEAT Spike LR with `Top_Attack_IR` priced ~415 raw ammo points despite being able to one-shot most armor.

### 8. Exclude GLATGM rounds from missile-class pricing (`77b45a8`)
`GLATGM` and `GLATGM-HE` are launched from grenade launchers (gun-class), not racks. `ACE_IsAmmoMissileType` returns true for them so the missile-physics display path in `sh_acfm_roundinject` works -- but that predicate was also gating the guidance multiplier and `PerformanceMul`. Adds explicit GLATGM opt-outs at both pricing call sites; the physics path is untouched.

### 9. Retune `GLATGM-HE` AmmoTypeFactor (`f394a3a`)
Drops `GLATGM-HE` from `0.75` -> `0.495` so HE-warhead grenade-launcher ATGMs sit lower than their kinetic-warhead siblings, matching observed performance.

### 10. Fix armor tool: preview cost includes non-armor component + rack reserve listing (`e77750c`)
Two related armor-tool popup fixes:

- **Future entity cost was armor-only.** For an ammo crate or any entity with a non-armor cost (gun firepower, rack firepower, crew flat), the "after" estimate showed only the new armor cost while the actual future cost would still include the existing ammo/firepower/crew portion. `ACE_GetPopupPoints` now returns `componentPoints` as a 4th value; `Think` pushes it via a `PointCostNonArmor` NWFloat; `DrawHUD` adds it to the armor preview.
- **Racks didn't surface their on-board missile cost.** After commit 2 those missiles are priced through the linked crate, but a player looking at a rack couldn't see what its tubes were worth. Adds an "On-board Missiles (on crates): TYPE X pts" breakdown line on the rack popup using a new public `ACE_GetRackPreloadAlloc` wrapper around the existing per-rack allocator. The line is labelled "(on crates)" and is purely informational -- not added to the rack's `componentPoints` because that would double-count the crate's `RawAmmoCost`.

## Test plan
- [ ] Compare point totals on a representative set of builds against `dev`; confirm typical builds land at or below the prior trace-based values *except* for missile-heavy builds, which should be ~3x more expensive per missile.
- [ ] Verify previously-problematic geometries (rocket tanks, APS contraptions) report points without errors or direction-scan failures.
- [ ] Spawn a missile rack (e.g. 8-tube) linked to a low-capacity ATGM crate; confirm ammo points scale with rack capacity.
- [ ] Re-scan an unchanged contraption multiple times; confirm output is identical each time.
- [ ] Spawn the same warhead under different guidance packages; confirm crate cost scales with guidance quality across the new 0.5-1.8 range.
- [ ] Spawn a THEAT Spike LR with `Top_Attack_IR`; confirm raw ammo cost is ~3x what it was on commit 6.
- [ ] Sweep one missile from each rack-fired family (AAM, SAM, ATGM, ASM, ARTY, GBU, NAVAL, MININAVAL, BOMB, POD, UAR) and confirm sensible cost. Tune `PerformanceMul` if a family is out of line; adjust bullet data if a specific missile is off.
- [ ] Spawn a GLATGM and a GLATGM-HE crate; confirm they price as gun ammo (no missile premium, no `Top_Attack_IR` bump) -- only `AmmoTypeFactor` and the standard pen/blast/caliber math apply. GLATGM-HE should sit notably below GLATGM after the retune.
- [ ] Hover the armor tool on an ammo crate, change armor/health/material; confirm the "after" estimate now includes the ammo cost (not just the new armor value).
- [ ] Hover the armor tool on a rack with missiles linked; confirm the popup shows a "Loaded Missiles (on crates): ..." line with per-ammo-type cost. Verify the value is sensible (close to the crate's `RawAmmoCost / readyCount * MaxMissile`).