### PR TITLE
Fixes weapon_base and sweps

### DIFF
--- a/lua/entities/ace_grenade/init.lua
+++ b/lua/entities/ace_grenade/init.lua
@@ -43,12 +43,13 @@ function ENT:Think()
 
 		self:Remove()
 		--Originally 4
-		local HEWeight =  4
+		local HEWeight =  0.5
 		local Radius = HEWeight ^ 0.33 * 8 * 39.37
 
 		--print(Radius/39.37)
 
 		ACF_HE( self:GetPos() + Vector(0,0,8) , Vector(0,0,1) , HEWeight , HEWeight * 0.5 , self.DamageOwner, nil, self) --0.5 is standard antipersonal mine
+
 
 		local Flash = EffectData()
 		Flash:SetOrigin( self:GetPos() + Vector(0,0,8) )

--- a/lua/weapons/weapon_ace_at4/shared.lua
+++ b/lua/weapons/weapon_ace_at4/shared.lua
@@ -12,7 +12,7 @@ SWEP.SlotPos = 3 --Priority in which the weapon appears, 1 tries to put it at th
 SWEP.FireRate = 0.2 --Rounds per second
 
 SWEP.Primary.ClipSize = 1
-SWEP.Primary.DefaultClip = 10
+SWEP.Primary.DefaultClip = 1
 SWEP.Primary.Automatic = false
 SWEP.Primary.Ammo = "RPG_Round"
 SWEP.Primary.Sound = "ace_weapons/sweps/multi_sound/at4_multi.mp3"

--- a/lua/weapons/weapon_ace_at4t/shared.lua
+++ b/lua/weapons/weapon_ace_at4t/shared.lua
@@ -12,7 +12,7 @@ SWEP.SlotPos = 3 --Priority in which the weapon appears, 1 tries to put it at th
 SWEP.FireRate = 0.1 --Rounds per second
 
 SWEP.Primary.ClipSize = 1
-SWEP.Primary.DefaultClip = 8
+SWEP.Primary.DefaultClip = 1
 SWEP.Primary.Automatic = false
 SWEP.Primary.Ammo = "RPG_Round"
 SWEP.Primary.Sound = "ace_weapons/sweps/multi_sound/at4p_multi.mp3"

--- a/lua/weapons/weapon_ace_base/cl_init.lua
+++ b/lua/weapons/weapon_ace_base/cl_init.lua
@@ -64,7 +64,7 @@ function SWEP:DoDrawCrosshair(x, y)
 
 
 	if self.HasScope then
-		local OuterReticleSize = 120 * degrees
+		local OuterReticleSize = 120 * (degrees / 3)
 		if Zoom then
 			surface.SetDrawColor(Color(0, 0, 0, 255))
 				if self.HasScope then
@@ -84,7 +84,7 @@ function SWEP:DoDrawCrosshair(x, y)
 	end
 
 	local ReticuleBarSize = self.ReticuleSize
-	local OffsetDist = 40 * degrees
+	local OffsetDist = 40 * (degrees / 3 )
 
 	surface.SetDrawColor(0, 0, 0, 255)
 	surface.DrawRect(x - 2, y - ReticuleBarSize - OffsetDist - 2, 4, ReticuleBarSize + 4)

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -464,7 +464,37 @@ function SWEP:Think()
 
 	self:HandleRecoil()
 	self:OnThink()
+
+--DEEPSEEKDEEPSEEKDEEPSEEKDEEPSEEKDEEPSEEK
+
+	-- Force speed on both sides
+	local zoom = self:GetZoomState()
+	local owner = self:GetOwner()
+	if IsValid(owner) and owner:IsPlayer() then
+		local mul = self.CarrySpeedMul or 1
+		local baseWalk = self.NormalPlayerWalkSpeed or 250
+		local baseRun = self.NormalPlayerRunSpeed or 500
+		local targetWalk, targetRun
+		if zoom then
+			targetWalk = baseWalk * 0.5 * mul
+			targetRun = baseRun * 0.5 * mul
+		else
+			targetWalk = baseWalk * mul
+			targetRun = baseRun * mul
+		end
+		-- Let's limit the maximum base speed (as in the original)
+		targetWalk = math.min(targetWalk, baseWalk)
+		targetRun = math.min(targetRun, baseRun)
+
+		if owner:GetWalkSpeed() ~= targetWalk then
+			owner:SetWalkSpeed(targetWalk)
+		end
+		if owner:GetRunSpeed() ~= targetRun then
+			owner:SetRunSpeed(targetRun)
+		end
+	end
 end
+
 
 function SWEP:OnReload()
 end
@@ -519,6 +549,10 @@ function SWEP:Deploy()
 	local owner = self:GetOwner()
 	if not owner:IsPlayer() then
 		owner:SetMaxLookDistance( 10000 )
+
+	if SERVER then
+    self:SetOwnerZoomSpeed(self:GetZoomState())
+    end
 	end
 end
 
@@ -531,11 +565,11 @@ function SWEP:SetOwnerZoomSpeed(setSpeed)
 
 	if IsValid(owner) and owner:IsPlayer() then
 		if setSpeed then
-			owner:SetWalkSpeed(math.min(self.NormalPlayerWalkSpeed * 0.5 * self.CarrySpeedMul, self.NormalPlayerWalkSpeed))
-			owner:SetRunSpeed(math.min(self.NormalPlayerRunSpeed * 0.5 * self.CarrySpeedMul, self.NormalPlayerRunSpeed))
+			owner:SetWalkSpeed((self.NormalPlayerWalkSpeed * 0.5 * self.CarrySpeedMul))
+			owner:SetRunSpeed((self.NormalPlayerRunSpeed * 0.5 * self.CarrySpeedMul))
 		elseif self.NormalPlayerWalkSpeed and self.NormalPlayerRunSpeed then
-			owner:SetWalkSpeed(math.min(self.NormalPlayerWalkSpeed * self.CarrySpeedMul, self.NormalPlayerWalkSpeed))
-			owner:SetRunSpeed(math.min(self.NormalPlayerRunSpeed * self.CarrySpeedMul, self.NormalPlayerRunSpeed))
+			owner:SetWalkSpeed(( self.NormalPlayerWalkSpeed * self.CarrySpeedMul))
+			owner:SetRunSpeed(( self.NormalPlayerRunSpeed * self.CarrySpeedMul))
 		end
 	end
 end

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -550,9 +550,9 @@ function SWEP:Deploy()
 	if not owner:IsPlayer() then
 		owner:SetMaxLookDistance( 10000 )
 
-	if SERVER then
-    self:SetOwnerZoomSpeed(self:GetZoomState())
-    end
+if SERVER then
+self:SetOwnerZoomSpeed(self:GetZoomState())
+end
 	end
 end
 
@@ -565,11 +565,11 @@ function SWEP:SetOwnerZoomSpeed(setSpeed)
 
 	if IsValid(owner) and owner:IsPlayer() then
 		if setSpeed then
-			owner:SetWalkSpeed((self.NormalPlayerWalkSpeed * 0.5 * self.CarrySpeedMul))
-			owner:SetRunSpeed((self.NormalPlayerRunSpeed * 0.5 * self.CarrySpeedMul))
+			owner:SetWalkSpeed( self.NormalPlayerWalkSpeed * 0.5 * self.CarrySpeedMul )
+			owner:SetRunSpeed( self.NormalPlayerRunSpeed * 0.5 * self.CarrySpeedMul )
 		elseif self.NormalPlayerWalkSpeed and self.NormalPlayerRunSpeed then
-			owner:SetWalkSpeed(( self.NormalPlayerWalkSpeed * self.CarrySpeedMul))
-			owner:SetRunSpeed(( self.NormalPlayerRunSpeed * self.CarrySpeedMul))
+			owner:SetWalkSpeed( self.NormalPlayerWalkSpeed * self.CarrySpeedMul )
+			owner:SetRunSpeed( self.NormalPlayerRunSpeed * self.CarrySpeedMul )
 		end
 	end
 end

--- a/lua/weapons/weapon_ace_elite/shared.lua
+++ b/lua/weapons/weapon_ace_elite/shared.lua
@@ -87,8 +87,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_elite/shared.lua
+++ b/lua/weapons/weapon_ace_elite/shared.lua
@@ -88,7 +88,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_fiveseven/shared.lua
+++ b/lua/weapons/weapon_ace_fiveseven/shared.lua
@@ -87,8 +87,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.005 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_fiveseven/shared.lua
+++ b/lua/weapons/weapon_ace_fiveseven/shared.lua
@@ -88,7 +88,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_galil/shared.lua
+++ b/lua/weapons/weapon_ace_galil/shared.lua
@@ -77,7 +77,7 @@ function SWEP:InitBulletData()
 	self.BulletData.Data8 = 0
 	self.BulletData.Data9 = 0
 	self.BulletData.Data10 = 1 -- Tracer
-	self.BulletData.Colour = Color(255, 0, 0)
+	self.BulletData.Colour = Color(0, 255, 0)
 	--
 	self.BulletData.Data13 = 0 --THEAT ConeAng2
 	self.BulletData.Data14 = 0 --THEAT HE Allocation

--- a/lua/weapons/weapon_ace_glock/shared.lua
+++ b/lua/weapons/weapon_ace_glock/shared.lua
@@ -87,8 +87,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_glock/shared.lua
+++ b/lua/weapons/weapon_ace_glock/shared.lua
@@ -88,7 +88,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_grenade/init.lua
+++ b/lua/weapons/weapon_ace_grenade/init.lua
@@ -10,7 +10,7 @@ function SWEP:DoAmmoStatDisplay()
 
 	local sendInfo = string.format( "Frag Grenade")
 
-			sendInfo = sendInfo .. string.format(", %.1fm blast", 4 ^ 0.33 * 8) --4 taken from mine entity
+			sendInfo = sendInfo .. string.format(", %.1fm blast", 0.5 ^ 0.33 * 8) --4 taken from mine entity
 
 
 

--- a/lua/weapons/weapon_ace_grenade/shared.lua
+++ b/lua/weapons/weapon_ace_grenade/shared.lua
@@ -4,7 +4,7 @@ SWEP.Category = "ACE Weapons"
 SWEP.SubCategory = "Grenades/Mines"
 
 if CLIENT then
-	SWEP.PrintName		= "Frag Grenade"
+	SWEP.PrintName		= "HE Grenade"
 	SWEP.Slot			= 4
 	SWEP.SlotPos		= 3
 end
@@ -31,7 +31,7 @@ SWEP.Primary.Sound			= "weapons/slam/throw.wav"
 SWEP.Primary.NumShots		= 1
 SWEP.Primary.Delay			= 2
 SWEP.Primary.ClipSize		= 1
-SWEP.Primary.DefaultClip	= 20
+SWEP.Primary.DefaultClip	= 5
 SWEP.Primary.Automatic		= false
 SWEP.Primary.Ammo		= "Grenade"
 
@@ -78,7 +78,7 @@ function SWEP:ThrowNade(power, heightoffset)
 			power = 0
 		end
 
-		local aim = owner:GetAimVector() + Vector(0,0,0.1)
+		local aim = owner:GetAimVector() * 9 + Vector(0,0,0.1)
 
 		local ent = ents.Create("ace_grenade")
 		ent:SetPos(owner:GetShootPos() + Vector(0, 0, heightoffset))
@@ -104,7 +104,7 @@ function SWEP:PrimaryAttack()
 
 	self:SendWeaponAnim(ACT_VM_PULLPIN)
 
-	self:ThrowNade(400, -7)  -- Was 5000, now 400 for 0.4kg grenade
+	self:ThrowNade(300, -7)  -- Was 5000, now 300 for 0.3kg grenade
 end
 
 

--- a/lua/weapons/weapon_ace_m249saw/shared.lua
+++ b/lua/weapons/weapon_ace_m249saw/shared.lua
@@ -12,7 +12,7 @@ SWEP.SlotPos = 1 --Priority in which the weapon appears, 1 tries to put it at th
 SWEP.FireRate = 18 --Rounds per second
 
 SWEP.Primary.ClipSize = 300
-SWEP.Primary.DefaultClip = 1800
+SWEP.Primary.DefaultClip = 300
 SWEP.Primary.Automatic = true
 SWEP.Primary.Ammo = "AR2"
 SWEP.Primary.Sound = "ace_weapons/sweps/multi_sound/m249saw_multi.mp3"
@@ -35,7 +35,7 @@ SWEP.HeatMax = 60 --Maximum heat - determines max rate at which recoil is applie
 				--Also determines point at which random spread is at its highest intensity
 				--HeatMax divided by HeatPerShot gives you how many shots until you reach MaxSpread
 
-SWEP.AngularRecoil = 40	--Amount of angular recoil
+SWEP.AngularRecoil = 20	--Amount of angular recoil
 
 --How much the recoil is biased to one side proportional to vertical recoil
 --Positive numbers bias to the right, negative to the left

--- a/lua/weapons/weapon_ace_mac10/shared.lua
+++ b/lua/weapons/weapon_ace_mac10/shared.lua
@@ -87,7 +87,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_mac10/shared.lua
+++ b/lua/weapons/weapon_ace_mac10/shared.lua
@@ -86,8 +86,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_mp5/shared.lua
+++ b/lua/weapons/weapon_ace_mp5/shared.lua
@@ -86,7 +86,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.0055 --Alternatively manually set it
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.0055 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_mp5/shared.lua
+++ b/lua/weapons/weapon_ace_mp5/shared.lua
@@ -86,7 +86,7 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--self.BulletData.DragCoef = 0.0055 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)

--- a/lua/weapons/weapon_ace_p90/shared.lua
+++ b/lua/weapons/weapon_ace_p90/shared.lua
@@ -86,7 +86,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.0025 --Alternatively manually set it
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.0025 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_p90/shared.lua
+++ b/lua/weapons/weapon_ace_p90/shared.lua
@@ -86,7 +86,7 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--self.BulletData.DragCoef = 0.0025 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)

--- a/lua/weapons/weapon_ace_tmp/shared.lua
+++ b/lua/weapons/weapon_ace_tmp/shared.lua
@@ -87,7 +87,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_tmp/shared.lua
+++ b/lua/weapons/weapon_ace_tmp/shared.lua
@@ -86,8 +86,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.005 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_ump45/shared.lua
+++ b/lua/weapons/weapon_ace_ump45/shared.lua
@@ -86,7 +86,7 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)

--- a/lua/weapons/weapon_ace_ump45/shared.lua
+++ b/lua/weapons/weapon_ace_ump45/shared.lua
@@ -86,7 +86,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.005 --Alternatively manually set it
+				self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.005 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_usp/shared.lua
+++ b/lua/weapons/weapon_ace_usp/shared.lua
@@ -89,7 +89,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_usp/shared.lua
+++ b/lua/weapons/weapon_ace_usp/shared.lua
@@ -88,8 +88,8 @@ function SWEP:InitBulletData()
 	self.BulletData.FrArea = 3.1416 * (self.BulletData.Caliber / 2) ^ 2
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
-	self.BulletData.DragCoef = 0.01 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.01 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_xm1014/shared.lua
+++ b/lua/weapons/weapon_ace_xm1014/shared.lua
@@ -88,8 +88,8 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--		self.BulletData.DragCoef  = 0 --Alternatively manually set it
-	--		self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
-	self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+	--self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)
 	self.BulletData.ShovePower = 0.2

--- a/lua/weapons/weapon_ace_xm1014/shared.lua
+++ b/lua/weapons/weapon_ace_xm1014/shared.lua
@@ -88,7 +88,7 @@ function SWEP:InitBulletData()
 	self.BulletData.ProjMass = self.BulletData.FrArea * (self.BulletData.ProjLength * 7.9 / 1000)
 	self.BulletData.PropMass = self.BulletData.FrArea * (self.BulletData.PropLength * ACF.PDensity / 1000) --Volume of the case as a cylinder * Powder density converted from g to kg
 	--		self.BulletData.DragCoef  = 0 --Alternatively manually set it
-			self.BulletData.DragCoef  = ((self.BulletData.FrArea/10000)/self.BulletData.ProjMass)
+			self.BulletData.DragCoef  = ((self.BulletData.FrArea / 10000) / self.BulletData.ProjMass)
 	--self.BulletData.DragCoef = 0.0075 --Alternatively manually set it
 	--Don't touch below here
 	self.BulletData.MuzzleVel = ACF_MuzzleVelocity(self.BulletData.PropMass, self.BulletData.ProjMass, self.BulletData.Caliber)


### PR DESCRIPTION
- Reduced crosshair size to match weapon spread.
- Fixed an issue where, after reloading, the player would accelerate slightly until they re-equipped the weapon.
- Reduced ammo dispensed for AT4 and AT4T from 10 to 2.
- Reduced grenade dispensed from 20 to 5.
- Fixed grenade throwing and explosion size.
- Slightly reduced the recoil of the M249.
- The Galil's tracer is now green, as before.
- Changed the bullet resistance parameters for all SMGs and some pistols
