### PR TITLE
Fix gun locking up empty after a crate runs dry

### DIFF
--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -886,7 +886,13 @@ do
 
 		local bool = true
 
-		if ( bool and self.IsUnderWeight and self.Ready and self.Legal ) then
+		-- An empty gun reports Ready = 0 (correct for wire), but it must still be
+		-- able to attempt a reload when fired, otherwise it stays locked empty once
+		-- its crate runs dry. Letting it through here lands in the else branch below,
+		-- which calls LoadAmmo to pull a round from any active crate.
+		local isEmpty = self.BulletData.Type == "Empty"
+
+		if ( bool and self.IsUnderWeight and (self.Ready or isEmpty) and self.Legal ) then
 
 			local Blacklist = {}
 			if not ACF.AmmoBlacklist[self.BulletData.Type] then


### PR DESCRIPTION
Dev-only regression (f4de9c5f): an empty gun now reports Ready = 0, which
also gated it out of FireShell's reload path, so it could never reload. Let
an empty gun into the firing block via (self.Ready or isEmpty); Ready
reporting is unchanged.
