### PR TITLE
Fix Starfall acf library crash on newer StarfallEx (getent nil)

### DIFF
--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -150,7 +150,7 @@ local acf_library = instance.Libraries.acf
 local ents_methods = instance.Types.Entity.Methods
 local vec_meta, vwrap, vunwrap = instance.Types.Vector, instance.Types.Vector.Wrap, instance.Types.Vector.Unwrap
 local sanitize = instance.Sanitize
-local getent = instance.Types.Entity.GetEntity
+local getent = instance.Types.Entity.Unwrap or instance.Types.Entity.GetEntity
 
 local function restrictInfo(ent)
 	if GetConVar("acf_restrictinfo"):GetInt() ~= 0 then


### PR DESCRIPTION
## Problem
Every `acf*` Starfall method throws on current StarfallEx:
```
starfall/libs_sv/acf.lua:1516: attempt to call upvalue 'getent' (a nil value)
  ... in function 'acfIsGearbox'   (also acfCaliber, acfRPM, acfType, ... - all of them)
```
This takes down ACE's **entire** Starfall API for everyone on the server, not just one chip - every `acf*` method shares the same `getent` upvalue.

## Root cause
`lua/starfall/libs_sv/acf.lua:153` caches the entity-unwrap helper by its **old** name:
```lua
local getent = instance.Types.Entity.GetEntity
```
Current StarfallEx no longer sets `GetEntity` at type registration - it provides it only as a *backwards-compat alias* assigned **inside the `entities` library's instance hook**:
```lua
-- starfall/lua/starfall/libs_sh/entities.lua
ent_meta.GetEntity = ent_meta.Unwrap -- Backwards compat
```
That hook runs **after** this `acf` library hook (`acf` < `entities` in load order), so `GetEntity` is still `nil` when `acf.lua` captures it -> `getent` is `nil` for the whole library.

`Unwrap` is the canonical accessor and is set at **type registration** (before any library instance hook runs), so it is always available - it is what every other StarfallEx lib already uses (e.g. `libs_sh/entities.lua`: `eunwrap = instance.Types.Entity.Unwrap`).

## Fix
```diff
-local getent = instance.Types.Entity.GetEntity
+local getent = instance.Types.Entity.Unwrap or instance.Types.Entity.GetEntity
```
The `or GetEntity` fallback keeps it working on older StarfallEx builds that only exposed `GetEntity`. (If you only target current StarfallEx, plain `instance.Types.Entity.Unwrap` is equivalent.)

## Impact / severity
High - on any StarfallEx version where `GetEntity` is only the late compat alias, **all** ACE Starfall functions error. Older StarfallEx is unaffected, so it surfaces as servers update StarfallEx.

## Testing
Confirmed `instance.Types.Entity.GetEntity` is `nil` at `acf.lua` load on current StarfallEx (only set later by the entities hook), and `instance.Types.Entity.Unwrap` resolves to the unwrap function. One-line change; no behavior change beyond restoring the previously-working accessor.
