### PR TITLE
perf(ace_irst): pre-gate LOS traces behind the cone/heat check

### DIFF
--- a/lua/entities/ace_irst/init.lua
+++ b/lua/entities/ace_irst/init.lua
@@ -254,13 +254,15 @@ function ENT:ScanForContraptions()
 		local HeatMulFromDist = 1 - min(Distance / 94488, 1) -- 39.37 * 2400 = 94488
 		Heat = Heat * HeatMulFromDist
 
-		LOSTraceData.start = SelfPos
-		LOSTraceData.endpos = Pos
-		local LOSTrace = TraceHull(LOSTraceData)
-
 		local AngleFromTarget = GetAngleBetweenVectors(PosDiff:GetNormalized(), SelfForward)
 
-		if AngleFromTarget < self.Cone and Heat > MinTrackingHeat and not LOSTrace.Hit then
+		LOSTraceData.start = SelfPos
+		LOSTraceData.endpos = Pos
+
+		-- Gate the LOS trace behind the cheap cone/heat check (as ace_trackingradar/ace_searchradar
+		-- do): the `and` short-circuits, so only in-cone, hot-enough contraptions get a TraceHull
+		-- instead of tracing every contraption on the server each think.
+		if AngleFromTarget < self.Cone and Heat > MinTrackingHeat and not TraceHull(LOSTraceData).Hit then
 
 			local RegionMul = Heat / 100 * self.HeatRegionMul
 			local ResolveMul = Heat / 100 * self.HeatResolveMul
@@ -317,13 +319,14 @@ function ENT:ScanForContraptions()
 
 		local Heat = 38 --A bit hotter than a person but it helps the optics
 
-		LOSTraceData.start = SelfPos
-		LOSTraceData.endpos = Pos
-		local LOSTrace = TraceHull(LOSTraceData)
-
 		local AngleFromTarget = GetAngleBetweenVectors(PosDiff:GetNormalized(), SelfForward)
 
-		if AngleFromTarget < self.Cone and not LOSTrace.Hit then
+		LOSTraceData.start = SelfPos
+		LOSTraceData.endpos = Pos
+
+		-- Gate the LOS trace behind the cone check (see the contraption loop above): the `and`
+		-- short-circuits, so only players within the view cone get a TraceHull.
+		if AngleFromTarget < self.Cone and not TraceHull(LOSTraceData).Hit then
 
 			local RegionMul = Heat / 100 * self.HeatRegionMul
 			local ResolveMul = Heat / 100 * self.HeatResolveMul


### PR DESCRIPTION
### What

`ace_irst`'s `ScanForContraptions` ran a `util.TraceHull` LOS check for **every** contraption on the server (and every player) on each 0.1s think, then discarded off-bore / too-cold targets *afterwards*. This moves the cheap `AngleFromTarget` calc ahead of the trace and inlines the `TraceHull` into the existing gate's `and`-chain, so it short-circuits behind the cone (+ heat) check.

This is the same idiom `ace_trackingradar` and `ace_searchradar` already use for their LOS traces (`... and not TraceHull(LOSTraceData).Hit`).

### Why

The IRST think iterates all `CFW.Contraptions`, so tracing each one (plus each player) *before* checking whether it's even inside the view cone makes the per-think trace count scale with the whole server rather than with what the sensor can actually see. After this change the LOS trace only runs for targets that are already in-cone and hot enough — the exact set that could produce a detection.

### Behaviour

Strictly behaviour-preserving. `util.TraceHull` has no side effects and its result was only consumed inside the gate condition, so targets that fail the cone/heat check (and were going to be discarded regardless) now simply skip the trace. Detected set, output angles/heat/IDs, resolution dial-in, and the per-target `debugoverlay` are unchanged. Both the contraption loop and the player loop are updated identically. `LOSTraceData` is the same reused `{mask, mins, maxs}` table; `start`/`endpos` are still assigned before the (now-conditional) trace.

### Testing

- **Differential model check:** over thousands of randomized targets, the new gate-then-trace ordering detects exactly the same set as the old trace-then-gate ordering while issuing far fewer traces (only in-cone/hot targets are traced). The occlusion case still holds — an in-cone target behind cover is still traced and correctly rejected.
- **Recommended in-game smoke test:** an in-cone target behind a wall must remain **undetected** (confirms LOS occlusion still gates in-cone targets).

No behaviour/config/output change; pure hot-path reduction on the sensor think.