### PR TITLE
Fix duplicated primitives getting permanently wrong armor (stale placeholder area)

### DIFF
--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -37,6 +37,7 @@ local function QueueArmorRecalculation(ent)
 end
 
 hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", QueueArmorRecalculation)
+hook.Add("Primitive_PreRebuildPhysics", "ACE_RememberPrimitiveCollisionGroup", RememberCollisionGroup)
 hook.Add("ProperClippingClipAdded", "ACE_RememberClipCollisionGroup", RememberCollisionGroup)
 hook.Add("ProperClippingPhysicsClipped", "ACE_PhysicsClippedArmorRecalc", QueueArmorRecalculation)
 hook.Add("ProperClippingPhysicsReset", "ACE_PhysicsResetArmorRecalc", QueueArmorRecalculation)

--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -3,7 +3,7 @@
 local collisionGroups = setmetatable({}, { __mode = "k" })
 
 local function RememberCollisionGroup(ent)
-	if not IsValid(ent) or collisionGroups[ent] ~= nil then return end
+	if not IsValid(ent) then return end
 
 	collisionGroups[ent] = ent:GetCollisionGroup()
 end

--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -1,0 +1,14 @@
+-- Primitive-addon entities rebuild their physics object after spawn/paste; ACF caches
+-- ent.ACF.Area once and never recomputes it, so armor evaluated against the pre-rebuild
+-- placeholder stays wrong forever (armor is inversely proportional to cached area).
+-- Recompute ACF state from the real mesh whenever a primitive finishes rebuilding.
+hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", function(ent)
+	if not IsValid(ent) or not ent.ACF then return end
+
+	ent.ACF.Area = nil
+	ent.ACF.PhysObj = nil
+	if ACF_Activate then ACF_Activate(ent, true) end
+
+	local con = ent.CFW_GetContraption and ent:CFW_GetContraption()
+	if con and ACE_MarkArmorDirty then ACE_MarkArmorDirty(con, ent) end
+end)

--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -1,18 +1,42 @@
--- The hook runs before Primitive restores physics properties, so restore the preserved mass
--- before recalculating ACF state. Per-entity cache invalidation also covers orphan primitives.
-hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", function(ent, properties)
-	if not IsValid(ent) or not ent.ACF then return end
+-- Physics rebuild hooks can run before Primitive and Proper Clipping finish restoring properties.
+-- Defer and coalesce recalculation until the final physics object is ready.
+local collisionGroups = setmetatable({}, { __mode = "k" })
 
-	local phys = ent:GetPhysicsObject()
-	if IsValid(phys) and istable(properties) and isnumber(properties.mass) then
-		phys:SetMass(properties.mass)
-	end
+local function RememberCollisionGroup(ent)
+	if not IsValid(ent) or collisionGroups[ent] ~= nil then return end
 
-	ent.ACF.Area = nil
-	ent.ACF.PhysObj = nil
-	if ACF_Activate then ACF_Activate(ent, true) end
-	if ACE_ClearArmorPointCache then ACE_ClearArmorPointCache(ent) end
+	collisionGroups[ent] = ent:GetCollisionGroup()
+end
 
-	local con = ent.CFW_GetContraption and ent:CFW_GetContraption()
-	if con and ACE_MarkArmorDirty then ACE_MarkArmorDirty(con, ent) end
-end)
+local function QueueArmorRecalculation(ent)
+	if not IsValid(ent) then return end
+	if ent.ACE_PrimitiveArmorRecalcQueued then return end
+
+	ent.ACE_PrimitiveArmorRecalcQueued = true
+	timer.Simple(0, function()
+		if not IsValid(ent) then return end
+
+		ent.ACE_PrimitiveArmorRecalcQueued = nil
+		local phys = ent:GetPhysicsObject()
+		if not IsValid(phys) then return end
+		local collisionGroup = collisionGroups[ent]
+		if collisionGroup ~= nil and ent:GetCollisionGroup() ~= collisionGroup then
+			ent:SetCollisionGroup(collisionGroup)
+		end
+
+		if ent.ACF then
+			ent.ACF.Area = nil
+			ent.ACF.PhysObj = nil
+		end
+		if ACF_Activate then ACF_Activate(ent, true) end
+		if ACE_ClearArmorPointCache then ACE_ClearArmorPointCache(ent) end
+
+		local con = ent.CFW_GetContraption and ent:CFW_GetContraption()
+		if ACE_MarkArmorDirty then ACE_MarkArmorDirty(con, ent) end
+	end)
+end
+
+hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", QueueArmorRecalculation)
+hook.Add("ProperClippingClipAdded", "ACE_RememberClipCollisionGroup", RememberCollisionGroup)
+hook.Add("ProperClippingPhysicsClipped", "ACE_PhysicsClippedArmorRecalc", QueueArmorRecalculation)
+hook.Add("ProperClippingPhysicsReset", "ACE_PhysicsResetArmorRecalc", QueueArmorRecalculation)

--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -1,13 +1,17 @@
--- Primitive-addon entities rebuild their physics object after spawn/paste; ACF caches
--- ent.ACF.Area once and never recomputes it, so armor evaluated against the pre-rebuild
--- placeholder stays wrong forever (armor is inversely proportional to cached area).
--- Recompute ACF state from the real mesh whenever a primitive finishes rebuilding.
-hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", function(ent)
+-- The hook runs before Primitive restores physics properties, so restore the preserved mass
+-- before recalculating ACF state. Per-entity cache invalidation also covers orphan primitives.
+hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", function(ent, properties)
 	if not IsValid(ent) or not ent.ACF then return end
+
+	local phys = ent:GetPhysicsObject()
+	if IsValid(phys) and istable(properties) and isnumber(properties.mass) then
+		phys:SetMass(properties.mass)
+	end
 
 	ent.ACF.Area = nil
 	ent.ACF.PhysObj = nil
 	if ACF_Activate then ACF_Activate(ent, true) end
+	if ACE_ClearArmorPointCache then ACE_ClearArmorPointCache(ent) end
 
 	local con = ent.CFW_GetContraption and ent:CFW_GetContraption()
 	if con and ACE_MarkArmorDirty then ACE_MarkArmorDirty(con, ent) end


### PR DESCRIPTION
## Problem

Primitive-addon entities rebuild their physics asynchronously after a dupe pastes. ACE armor evaluated against the placeholder physics caches a wrong `ent.ACF.Area`, and the activation guard never recomputes a cached area — so duplicated primitives keep permanently wrong armor and health. Proper Clipping can also replace the physics object during the same hook dispatch, and neither addon restores the entity's collision group after a rebuild.

## Fix

- Defers ACE armor recalculation with a coalesced next-tick queue, so it always runs after Primitive and Proper Clipping finish rebuilding and restoring physics properties, regardless of hook registration order.
- Recomputes ACF area/armor state from the final physics object, preserving the entity's current damage percentage.
- Clears the entity's armor-point cache and dirties the owning contraption's totals when one exists; orphan primitives are handled without one.
- Captures the collision group before rebuilds and clip changes and restores it once the final physics object is ready.

## Validation

- Lint passes.
- Verified on a dedicated server against the final head: primitives across shape and size extremes, physics-clipped props (including a forced adversarial ordering where the armor recalculation hook runs before the clipping handler replaces the physics object), repeated rebuilds with damage and mass modifiers, parented and orphan entities, and clip reset all end with armor state matching freshly spawned controls.
- A large corpus of saved builds pastes cleanly with this hook active; the only non-passing cases trace to stale dupe content (deleted models, unreproducible legacy clip data), not armor regressions.
