### PR TITLE
Prevent repeated point warnings after contraption splits

### DIFF
--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -155,6 +155,18 @@ do
 	-- Initialize point tracking when a family is created.
 	hook.Add("cfw.family.created", "ACE_InitPoints", ACE_InitPts)
 
+	-- Damage can split a warned vehicle into a fresh CFW contraption. Preserve the one-time
+	-- point warning across that split so debris and detached sections cannot repeat it.
+	local function ACE_InheritPointWarning(parent, child)
+		if not parent or not child then return end
+		if not parent.OTWarnings or not parent.OTWarnings.WarnedOverPoints then return end
+
+		child.OTWarnings = child.OTWarnings or {}
+		child.OTWarnings.WarnedOverPoints = true
+	end
+
+	hook.Add("cfw.contraption.split", "ACE_InheritPointWarning", ACE_InheritPointWarning)
+
 	-- Flag contraptions that are being removed to suppress dirty warnings.
 	hook.Add("cfw.contraption.removed", "ACE_ContraptionRemoving", function(con)
 		if not con then return end


### PR DESCRIPTION
## Summary

- Preserve the one-time over-points warning when CFW splits a damaged vehicle into a child contraption.
- Prevent detached sections and debris from repeating the 10,000-point global chat warning after the original vehicle has already emitted it.
- Leave independent vehicles and children of an unwarned contraption eligible for their first legitimate warning; preserve unrelated child warning state.

## Validation

- Hosted GLuaFixer passes on the final head.
- An executable production-source test verifies warned child and grandchild inheritance, preservation of existing child warning fields, and the unwarned-child case.
- Static regression checks pass on the submitted file.
- `git diff --check` passes.
- CFW split timing and callback arguments were verified against the installed hook consumers. No dedicated-server damage-split run was performed.