### PR TITLE
Add automated ACE quality checks

### DIFF
--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -48,7 +48,6 @@ jobs:
       branch: public
       gluatest-ref: 735e52d20c69d14c9a2a8d42f3d6428d1af0936b
       dockerbuild: 'true'
-      custom-overrides: ${{ github.workspace }}/tests/gluatest_overrides/
       additional-setup: bash project/tests/prepare_gluatest_dependencies.sh
       timeout: '5'
       logs-as-artifact: 'true'

--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -5,13 +5,50 @@ on:
     paths:
       - 'lua/**'
       - '!lua/entities/gmod_wire_expression2/**'
+      - 'tests/**'
+      - 'test.py'
+      - '.glualint.json'
+      - '.github/workflows/glualint.yml'
   pull_request:
     paths:
       - 'lua/**'
       - '!lua/entities/gmod_wire_expression2/**'
+      - 'tests/**'
+      - 'test.py'
+      - '.glualint.json'
+      - '.github/workflows/glualint.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ace-quality-${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   Lint:
-    uses: FPtje/GLuaFixer/.github/workflows/glualint.yml@master
+    uses: FPtje/GLuaFixer/.github/workflows/glualint.yml@7d26f3a416e6174991c21c962aaf295ff3e17f52 # master, 2026-07-17
     with:
       config: .glualint.json
+
+  OfflineTests:
+    name: Offline definition tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ACE
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Run Python tests
+        run: python -m unittest discover -s tests/python -p 'test_*.py' -v
+
+  GLuaTest:
+    name: Native GMod server tests
+    uses: CFC-Servers/GLuaTest/.github/workflows/run_tests.yml@735e52d20c69d14c9a2a8d42f3d6428d1af0936b # main, 2026-07-17
+    with:
+      branch: public
+      gluatest-ref: 735e52d20c69d14c9a2a8d42f3d6428d1af0936b
+      dockerbuild: 'true'
+      custom-overrides: ${{ github.workspace }}/tests/gluatest_overrides/
+      additional-setup: bash project/tests/prepare_gluatest_dependencies.sh
+      timeout: '5'
+      logs-as-artifact: 'true'

--- a/lua/tests/ace/000_discovery_canary.lua
+++ b/lua/tests/ace/000_discovery_canary.lua
@@ -1,0 +1,11 @@
+return {
+	groupName = "ACE GLuaTest discovery canary",
+	cases = {
+		{
+			name = "discovers and executes the native ACE suite",
+			func = function()
+				expect(true).to.equal(true)
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/entity_registration.lua
+++ b/lua/tests/ace/entity_registration.lua
@@ -1,0 +1,23 @@
+return {
+	groupName = "ACE and ACF scripted entity registration",
+	cases = {
+		{
+			name = "registers every mounted ACE and ACF entity",
+			func = function()
+				local _, folders = file.Find("entities/*", "LUA")
+				local checked = 0
+
+				for _, className in ipairs(folders) do
+					if className:match("^ace_") or className:match("^acf_") then
+						local stored = scripted_ents.GetStored(className)
+						expect(stored).to.exist()
+						expect(stored.t).to.exist()
+						checked = checked + 1
+					end
+				end
+
+				expect(checked).to.beGreaterThan(0)
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/registries.lua
+++ b/lua/tests/ace/registries.lua
@@ -1,0 +1,112 @@
+local function countEntries(registry, name)
+	local count = 0
+	for id, entry in pairs(registry) do
+		expect(type(id)).to.equal("string")
+		expect(type(entry)).to.equal("table")
+		expect(entry.id).to.equal(id)
+		count = count + 1
+	end
+
+	expect(count).to.beGreaterThan(0)
+	return count
+end
+
+return {
+	groupName = "ACE and ACF runtime registries",
+	cases = {
+		{
+			name = "exposes every loader category",
+			func = function()
+				expect(ACF).to.exist()
+				expect(ACF.Weapons).to.exist()
+				expect(ACF.Classes).to.exist()
+				expect(ACE).to.exist()
+
+				for _, name in ipairs({
+					"Ammo", "LegacyAmmo", "Guns", "Racks", "Engines", "Gearboxes",
+					"FuelTanks", "FuelTanksSize", "Radars", "Tools", "Crewseats",
+					"Extras", "Explosives", "Mobility",
+				}) do
+					expect(ACF.Weapons[name]).to.exist()
+					countEntries(ACF.Weapons[name], name)
+				end
+
+				for _, name in ipairs({ "GunClass", "Rack", "Radar" }) do
+					expect(ACF.Classes[name]).to.exist()
+					countEntries(ACF.Classes[name], name)
+				end
+			end,
+		},
+		{
+			name = "preserves the required shape of core definitions",
+			func = function()
+				for id, gun in pairs(ACF.Weapons.Guns) do
+					expect(gun.round).to.exist()
+					expect(gun.gunclass).to.exist()
+					expect(gun.caliber).to.beA("number")
+					expect(gun.caliber).to.beGreaterThan(0)
+					expect(id).to.equal(gun.id)
+				end
+
+				for id, engine in pairs(ACF.Weapons.Engines) do
+					expect(engine.torque).to.beA("number")
+					expect(engine.limitrpm).to.beA("number")
+					expect(engine.limitrpm).to.beGreaterThan(engine.idlerpm)
+					expect(id).to.equal(engine.id)
+				end
+
+				for id, gearbox in pairs(ACF.Weapons.Gearboxes) do
+					expect(gearbox.gears).to.beA("number")
+					expect(gearbox.geartable).to.beA("table")
+					expect(id).to.equal(gearbox.id)
+				end
+			end,
+		},
+		{
+			name = "publishes ACE extension registries",
+			func = function()
+				expect(ACE.MuzzleFlashes).to.exist()
+				expect(ACE.ModelData).to.exist()
+				expect(ACE.MineData).to.exist()
+				expect(ACE.GSounds).to.exist()
+				expect(ACE.GSounds.GunFire).to.exist()
+				countEntries(ACE.MineData, "MineData")
+			end,
+		},
+		{
+			name = "loads the CFW ACE extension methods",
+			func = function()
+				expect(CFW).to.exist()
+				expect(CFW.Classes).to.exist()
+				expect(CFW.Classes.Contraption).to.exist()
+				for _, name in ipairs({
+					"GetACEBaseplate", "GetACEAltitude", "GetACEHottestEntity",
+					"GetACEHotEnts", "GetACEHeatPosition",
+				}) do
+					expect(CFW.Classes.Contraption[name]).to.beA("function")
+				end
+			end,
+		},
+		{
+			name = "keeps round type and network ID registries coherent",
+			func = function()
+				expect(ACF.RoundTypes).to.exist()
+				expect(ACF.IdRounds).to.exist()
+				local count = 0
+
+				for roundType, round in pairs(ACF.RoundTypes) do
+					expect(type(roundType)).to.equal("string")
+					expect(type(round)).to.equal("table")
+					expect(round.Type).to.equal(roundType)
+					expect(round.create).to.beA("function")
+					if round.netid then
+						expect(ACF.IdRounds[round.netid]).to.beA("string")
+					end
+					count = count + 1
+				end
+
+				expect(count).to.beGreaterThan(0)
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/registries.lua
+++ b/lua/tests/ace/registries.lua
@@ -1,13 +1,13 @@
-local function countEntries(registry)
+local function countEntries(registry, expectValue)
 	local count = 0
 	for id, entry in pairs(registry) do
-		expect(type(id)).to.equal("string")
-		expect(type(entry)).to.equal("table")
-		expect(entry.id).to.equal(id)
+		expectValue(type(id)).to.equal("string")
+		expectValue(type(entry)).to.equal("table")
+		expectValue(entry.id).to.equal(id)
 		count = count + 1
 	end
 
-	expect(count).to.beGreaterThan(0)
+	expectValue(count).to.beGreaterThan(0)
 	return count
 end
 
@@ -28,12 +28,12 @@ return {
 					"Extras", "Explosives", "Mobility",
 				}) do
 					expect(ACF.Weapons[name]).to.exist()
-					countEntries(ACF.Weapons[name])
+					countEntries(ACF.Weapons[name], expect)
 				end
 
 				for _, name in ipairs({ "GunClass", "Rack", "Radar" }) do
 					expect(ACF.Classes[name]).to.exist()
-					countEntries(ACF.Classes[name])
+					countEntries(ACF.Classes[name], expect)
 				end
 			end,
 		},
@@ -70,7 +70,7 @@ return {
 				expect(ACE.MineData).to.exist()
 				expect(ACE.GSounds).to.exist()
 				expect(ACE.GSounds.GunFire).to.exist()
-				countEntries(ACE.MineData)
+				countEntries(ACE.MineData, expect)
 			end,
 		},
 		{
@@ -98,7 +98,9 @@ return {
 					expect(type(roundType)).to.equal("string")
 					expect(type(round)).to.equal("table")
 					expect(round.Type).to.equal(roundType)
-					expect(round.create).to.beA("function")
+					if round.netid then
+						expect(round.create).to.beA("function")
+					end
 					if round.netid then
 						expect(ACF.IdRounds[round.netid]).to.beA("string")
 					end

--- a/lua/tests/ace/registries.lua
+++ b/lua/tests/ace/registries.lua
@@ -1,4 +1,4 @@
-local function countEntries(registry, name)
+local function countEntries(registry)
 	local count = 0
 	for id, entry in pairs(registry) do
 		expect(type(id)).to.equal("string")
@@ -28,12 +28,12 @@ return {
 					"Extras", "Explosives", "Mobility",
 				}) do
 					expect(ACF.Weapons[name]).to.exist()
-					countEntries(ACF.Weapons[name], name)
+					countEntries(ACF.Weapons[name])
 				end
 
 				for _, name in ipairs({ "GunClass", "Rack", "Radar" }) do
 					expect(ACF.Classes[name]).to.exist()
-					countEntries(ACF.Classes[name], name)
+					countEntries(ACF.Classes[name])
 				end
 			end,
 		},
@@ -70,7 +70,7 @@ return {
 				expect(ACE.MineData).to.exist()
 				expect(ACE.GSounds).to.exist()
 				expect(ACE.GSounds.GunFire).to.exist()
-				countEntries(ACE.MineData, "MineData")
+				countEntries(ACE.MineData)
 			end,
 		},
 		{

--- a/tests/gluatest_overrides/lua/autorun/ace_gluatest_guard.lua
+++ b/tests/gluatest_overrides/lua/autorun/ace_gluatest_guard.lua
@@ -1,0 +1,27 @@
+local canaryGroupName = "ACE GLuaTest discovery canary"
+local canaryCaseName = "discovers and executes the native ACE suite"
+
+hook.Add("GLuaTest_Finished", "ACE_NativeSuiteGuard", function(testGroups, results)
+	local caseCount = 0
+	local canaryPassed = false
+
+	for _, group in ipairs(testGroups or {}) do
+		caseCount = caseCount + #(group.cases or {})
+		if group.groupName == canaryGroupName then
+			for _, result in ipairs(results or {}) do
+				if result.testGroup == group
+					and result.case
+					and result.case.name == canaryCaseName
+					and result.success == true then
+					canaryPassed = true
+				end
+			end
+		end
+	end
+
+	if caseCount == 0 or not canaryPassed then
+		file.Write("gluatest_failures.json", util.TableToJSON({ {
+			reason = "ACE native GLuaTest discovery guard did not observe the canary",
+		} }))
+	end
+end)

--- a/tests/prepare_gluatest_dependencies.sh
+++ b/tests/prepare_gluatest_dependencies.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GLuaTest's requirements file accepts branches, not immutable commit IDs. Clone
+# the exact reviewed dependency commits into its override tree instead, so the
+# native job does not silently change when a dependency's default branch moves.
+override_root="${GITHUB_WORKSPACE}/garrysmod_override/addons"
+mkdir --parents "$override_root"
+
+clone_at_commit() {
+	local repository="$1"
+	local commit="$2"
+	local addon_name="$3"
+	local destination="$override_root/$addon_name"
+
+	rm --recursive --force "$destination"
+	git clone --quiet --no-checkout --depth 1 "$repository" "$destination"
+	git -C "$destination" fetch --quiet --depth 1 origin "$commit"
+	git -C "$destination" checkout --quiet --detach "$commit"
+}
+
+clone_at_commit "https://github.com/ACF-Team/CFW.git" \
+	"5bb6f9fec64d7aa62abd01b49b2a75acf5e7712d" "cfw"
+clone_at_commit "https://github.com/wiremod/wire.git" \
+	"6fdc26ac91264054e4587e58bcc4ec3d6c382abc" "wire"
+clone_at_commit "https://github.com/wiremod/advdupe2.git" \
+	"3c6dda8d8c47d399c010628255d0f63303562959" "advdupe2"

--- a/tests/prepare_gluatest_dependencies.sh
+++ b/tests/prepare_gluatest_dependencies.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 override_root="${GITHUB_WORKSPACE}/garrysmod_override/addons"
 mkdir --parents "$override_root"
 
+# The reusable workflow's custom-overrides input is evaluated outside the caller's
+# workspace context. Copy the guard from the checked-out project explicitly instead.
+guard_root="${GITHUB_WORKSPACE}/garrysmod_override/lua/autorun"
+mkdir --parents "$guard_root"
+cp "${GITHUB_WORKSPACE}/project/tests/gluatest_overrides/lua/autorun/ace_gluatest_guard.lua" \
+	"${guard_root}/ace_gluatest_guard.lua"
+
 clone_at_commit() {
 	local repository="$1"
 	local commit="$2"

--- a/tests/python/lua_source.py
+++ b/tests/python/lua_source.py
@@ -1,0 +1,214 @@
+"""Small Lua lexer helpers for test-only source audits.
+
+This is intentionally not a Lua parser. It only skips comments and string literals
+correctly enough to identify calls whose first argument is a quoted identifier.
+"""
+
+import re
+
+
+IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+LONG_BRACKET = re.compile(r"\[(=*)\[")
+
+
+def _long_bracket_end(source: str, start: int):
+    match = LONG_BRACKET.match(source, start)
+    if not match:
+        return None
+
+    closing = "]" + match.group(1) + "]"
+    end = source.find(closing, match.end())
+    return len(source) if end < 0 else end + len(closing)
+
+
+def skip_string_or_comment(source: str, start: int):
+    """Return the index immediately after a quote, long string, or comment."""
+
+    if source.startswith("--", start):
+        long_end = _long_bracket_end(source, start + 2)
+        if long_end is not None:
+            return long_end
+        newline = source.find("\n", start + 2)
+        return len(source) if newline < 0 else newline + 1
+
+    if source[start] in "'\"":
+        quote = source[start]
+        index = start + 1
+        while index < len(source):
+            if source[index] == "\\":
+                index += 2
+            elif source[index] == quote:
+                return index + 1
+            else:
+                index += 1
+        return len(source)
+
+    long_end = _long_bracket_end(source, start)
+    return long_end if long_end is not None else start + 1
+
+
+def skip_space_and_comments(source: str, start: int):
+    index = start
+    while index < len(source):
+        if source[index].isspace():
+            index += 1
+        elif source.startswith("--", index):
+            index = skip_string_or_comment(source, index)
+        else:
+            break
+    return index
+
+
+def read_quoted_string(source: str, start: int):
+    if start >= len(source) or source[start] not in "'\"":
+        return None, start
+
+    quote = source[start]
+    index = start + 1
+    value = []
+    while index < len(source):
+        char = source[index]
+        if char == "\\" and index + 1 < len(source):
+            value.append(source[index + 1])
+            index += 2
+        elif char == quote:
+            return "".join(value), index + 1
+        else:
+            value.append(char)
+            index += 1
+    return None, len(source)
+
+
+def iter_named_calls(source: str, function_name: str):
+    """Yield ``(first_string_argument, name_offset, after_argument)`` calls."""
+
+    index = 0
+    while index < len(source):
+        if source[index].isspace():
+            index += 1
+            continue
+        if source.startswith("--", index) or source[index] in "'\"[":
+            index = skip_string_or_comment(source, index)
+            continue
+
+        match = IDENTIFIER.match(source, index)
+        if not match:
+            index += 1
+            continue
+
+        token = match.group(0)
+        index = match.end()
+        if token != function_name:
+            continue
+        if match.start() > 0 and source[match.start() - 1] == ".":
+            continue
+
+        call_index = skip_space_and_comments(source, index)
+        if call_index >= len(source) or source[call_index] != "(":
+            continue
+
+        argument_index = skip_space_and_comments(source, call_index + 1)
+        value, after_argument = read_quoted_string(source, argument_index)
+        if value is not None:
+            yield value, match.start(), after_argument
+
+
+def iter_qualified_string_assignments(source: str, qualified_name: str):
+    """Yield string values assigned to a dotted Lua name, ignoring non-code text."""
+
+    parts = qualified_name.split(".")
+    index = 0
+    while index < len(source):
+        if source[index].isspace():
+            index += 1
+            continue
+        if source.startswith("--", index) or source[index] in "'\"[":
+            index = skip_string_or_comment(source, index)
+            continue
+
+        match = IDENTIFIER.match(source, index)
+        if not match:
+            index += 1
+            continue
+
+        if match.group(0) != parts[0]:
+            index = match.end()
+            continue
+
+        cursor = match.end()
+        matched = True
+        for part in parts[1:]:
+            cursor = skip_space_and_comments(source, cursor)
+            if cursor >= len(source) or source[cursor] != ".":
+                matched = False
+                break
+            cursor = skip_space_and_comments(source, cursor + 1)
+            part_match = IDENTIFIER.match(source, cursor)
+            if not part_match or part_match.group(0) != part:
+                matched = False
+                break
+            cursor = part_match.end()
+
+        if matched:
+            cursor = skip_space_and_comments(source, cursor)
+            if cursor < len(source) and source[cursor] == "=":
+                value, _ = read_quoted_string(
+                    source, skip_space_and_comments(source, cursor + 1)
+                )
+                if value is not None:
+                    yield value, match.start()
+
+        index = match.end()
+
+
+def code_without_comments_and_strings(source: str):
+    """Replace ignored Lua text with spaces while preserving source positions."""
+
+    result = list(source)
+    index = 0
+    while index < len(source):
+        if (
+            source.startswith("--", index)
+            or source[index] in "'\""
+            or LONG_BRACKET.match(source, index)
+        ):
+            end = skip_string_or_comment(source, index)
+            for position in range(index, end):
+                if result[position] not in "\r\n":
+                    result[position] = " "
+            index = end
+        else:
+            index += 1
+    return "".join(result)
+
+
+def find_call_table(source: str, after_argument: int):
+    """Return the first table argument after a quoted call argument, if present."""
+
+    index = skip_space_and_comments(source, after_argument)
+    if index >= len(source) or source[index] != ",":
+        return None
+
+    index = skip_space_and_comments(source, index + 1)
+    if index >= len(source) or source[index] != "{":
+        return None
+
+    end = find_matching_brace(source, index)
+    return None if end is None else source[index + 1 : end]
+
+
+def find_matching_brace(source: str, start: int):
+    depth = 0
+    index = start
+    while index < len(source):
+        if source.startswith("--", index) or source[index] in "'\"[":
+            index = skip_string_or_comment(source, index)
+            continue
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None

--- a/tests/python/test_lua_source.py
+++ b/tests/python/test_lua_source.py
@@ -1,0 +1,67 @@
+"""Regression tests for the comment/string-aware Lua source helpers."""
+
+import unittest
+
+from lua_source import (
+    code_without_comments_and_strings,
+    find_call_table,
+    find_matching_brace,
+    iter_named_calls,
+    iter_qualified_string_assignments,
+)
+
+
+class LuaSourceHelperTests(unittest.TestCase):
+    def test_code_view_preserves_positions_and_hides_ignored_text(self):
+        source = 'call("real") -- fake("comment")\nlocal long = [[fake("long")]]\n'
+        code = code_without_comments_and_strings(source)
+
+        self.assertEqual(len(source), len(code))
+        self.assertIn("call(      )", code)
+        self.assertNotIn("fake", code)
+        self.assertEqual(source.index("call"), code.index("call"))
+
+    def test_named_calls_ignore_comments_strings_and_dotted_members(self):
+        source = """
+        -- ACF_defineGun(\"fake-comment\")
+        local text = 'ACF_defineGun(\\\"fake-string\\\")'
+        ACF_defineGun("real")
+        object.ACF_defineGun("not-a-global-call")
+        """
+
+        self.assertEqual(
+            [(value, start) for value, start, _ in iter_named_calls(source, "ACF_defineGun")],
+            [("real", source.index('ACF_defineGun("real")'))],
+        )
+
+    def test_qualified_assignments_require_code_and_exact_name(self):
+        source = """
+        -- ACE.Value = \"comment\"
+        local text = 'ACE.Value = "string"'
+        ACE.Value = "real"
+        ACE.ValueExtra = "wrong-name"
+        Other.Value = "wrong-root"
+        """
+
+        self.assertEqual(
+            [(value, start) for value, start in iter_qualified_string_assignments(source, "ACE.Value")],
+            [("real", source.index('ACE.Value = "real"'))],
+        )
+
+    def test_call_table_matches_nested_tables_and_quoted_braces(self):
+        source = 'register("id", { outer = { value = 1 }, text = "}" })'
+        call_start = source.index("register")
+        argument_end = source.index('"id"') + len('"id"')
+
+        table = find_call_table(source, argument_end)
+
+        self.assertEqual(' outer = { value = 1 }, text = "}" ', table)
+        self.assertEqual(source.rindex("}"), find_matching_brace(source, source.index("{")))
+
+    def test_missing_or_malformed_tables_return_none(self):
+        self.assertIsNone(find_call_table('register("id", value)', len('register("id"')))
+        self.assertIsNone(find_matching_brace("{ nested", 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_missile_definitions.py
+++ b/tests/python/test_missile_definitions.py
@@ -1,0 +1,98 @@
+"""Regression tests for the repository's missile-definition audit."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+from lua_source import find_call_table, iter_named_calls
+
+
+REPO = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("ace_definition_audit", REPO / "test.py")
+AUDIT = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(AUDIT)
+
+
+class MissileDefinitionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        missile_dir = REPO / AUDIT.MISSILES_DIR
+        cls.files = sorted(missile_dir.glob("*.lua"))
+        cls.missiles = [
+            missile
+            for path in cls.files
+            for missile in AUDIT.parse_missile_file(path)
+        ]
+        cls.source_definitions = []
+        for path in cls.files:
+            source = path.read_text(encoding="utf-8")
+            for name, _, after_argument in iter_named_calls(source, "ACF_defineGun"):
+                cls.source_definitions.append(
+                    {
+                        "name": name,
+                        "file": path.name,
+                        "body": find_call_table(source, after_argument),
+                    }
+                )
+
+    def test_missile_definition_directory_is_present(self):
+        self.assertTrue(self.files, "no missile definition files were found")
+        self.assertTrue(self.missiles, "no missile definitions were parsed")
+
+    def test_every_source_missile_is_parsed(self):
+        source_names = [definition["name"] for definition in self.source_definitions]
+        parsed_names = [missile["name"] for missile in self.missiles]
+        self.assertEqual(
+            len(source_names),
+            len(set(source_names)),
+            "duplicate source missile definitions were found",
+        )
+        self.assertEqual(source_names, parsed_names)
+
+    def test_every_missile_has_an_explicit_real_caliber_source(self):
+        for definition in self.source_definitions:
+            with self.subTest(missile=definition["name"], file=definition["file"]):
+                has_comment = bool(
+                    definition["body"]
+                    and AUDIT.extract_comment_real_caliber_cm(definition["body"])
+                )
+                self.assertTrue(
+                    definition["name"] in AUDIT.REAL_CALIBERS or has_comment,
+                    "missing authoritative real-caliber annotation",
+                )
+
+    def test_minimum_projectile_length_is_well_formed(self):
+        for missile in self.missiles:
+            with self.subTest(missile=missile["name"]):
+                self.assertGreater(missile["maxlength"], 0)
+                self.assertGreaterEqual(missile["minproj_current"], 0)
+                self.assertLessEqual(
+                    missile["minproj_current"], missile["maxlength"]
+                )
+
+    def test_real_caliber_annotations_match_code(self):
+        for missile in self.missiles:
+            with self.subTest(missile=missile["name"]):
+                self.assertFalse(
+                    missile["body_mismatch"],
+                    "real-caliber annotation disagrees with the parsed caliber",
+                )
+
+    def test_current_minimum_projectile_rule_is_not_legacy_sized(self):
+        # Every missile should use the current 0.5x default or an explicitly smaller fixed rule.
+        for missile in self.missiles:
+            with self.subTest(missile=missile["name"]):
+                if missile["minproj_source"].startswith("ratio:"):
+                    self.assertEqual("ratio:0.5", missile["minproj_source"])
+                    self.assertAlmostEqual(
+                        missile["body_caliber"] * AUDIT.DEFAULT_MISSILE_MINPROJ_RATIO,
+                        missile["minproj_current"],
+                    )
+                else:
+                    self.assertEqual("fixed", missile["minproj_source"])
+                self.assertLess(missile["minproj_current"], missile["minproj_legacy"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_native_suite_manifest.py
+++ b/tests/python/test_native_suite_manifest.py
@@ -1,0 +1,34 @@
+"""Keep the native GLuaTest suite visible to CI and reviewers."""
+
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+NATIVE_ROOT = REPO / "lua" / "tests" / "ace"
+CANARY = NATIVE_ROOT / "000_discovery_canary.lua"
+GUARD = REPO / "tests" / "gluatest_overrides" / "lua" / "autorun" / "ace_gluatest_guard.lua"
+
+
+class NativeSuiteManifestTests(unittest.TestCase):
+    def test_native_suite_contains_a_discovery_canary(self):
+        self.assertTrue(CANARY.is_file())
+        self.assertIn("groupName", CANARY.read_text(encoding="utf-8"))
+        self.assertIn("discovers and executes", CANARY.read_text(encoding="utf-8"))
+
+    def test_native_suite_contains_multiple_groups(self):
+        suites = {path.name for path in NATIVE_ROOT.glob("*.lua")}
+        self.assertEqual(
+            {"000_discovery_canary.lua", "entity_registration.lua", "registries.lua"},
+            suites,
+        )
+
+    def test_native_job_has_an_external_discovery_guard(self):
+        guard = GUARD.read_text(encoding="utf-8")
+        self.assertIn("GLuaTest_Finished", guard)
+        self.assertIn("gluatest_failures.json", guard)
+        self.assertIn("ACE GLuaTest discovery canary", guard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_registry_definitions.py
+++ b/tests/python/test_registry_definitions.py
@@ -1,0 +1,157 @@
+"""Static checks for ACE/ACF definition IDs before the runtime loader sees them."""
+
+from collections import defaultdict
+from pathlib import Path
+import unittest
+
+from lua_source import (
+    code_without_comments_and_strings,
+    iter_qualified_string_assignments,
+    iter_named_calls,
+)
+
+
+REPO = Path(__file__).resolve().parents[2]
+SHARED_ROOT = REPO / "lua" / "acf" / "shared"
+ROUND_ROOT = SHARED_ROOT / "rounds"
+
+DEFINITION_FUNCTIONS = {
+    "ACF_DefineEntity",
+    "ACE_DefineCrewseat",
+    "ACE_DefineExtras",
+    "ACE_DefineMuzzleFlash",
+    "ACE_DefineGunFireSound",
+    "ACF_defineGunClass",
+    "ACF_defineGun",
+    "ACE_DefineAmmoCrate",
+    "ACE_DefineLegacyAmmoCrate",
+    "ACF_DefineRack",
+    "ACF_DefineRackClass",
+    "ACF_DefineEngine",
+    "ACF_DefineGearbox",
+    "ACF_DefineFuelTank",
+    "ACF_DefineFuelTankSize",
+    "ACF_DefineRadar",
+    "ACF_DefineRadarClass",
+    "ACF_DefineTrackRadar",
+    "ACF_DefineTrackRadarClass",
+    "ACF_DefineSonar",
+    "ACF_DefineSonarClass",
+    "ACF_DefineIRST",
+    "ACF_DefineIRSTClass",
+    "ACF_DefineVHeatSource",
+    "ACE_DefineExplosive",
+    "ACE_DefineMine",
+}
+
+
+def collect_definitions():
+    definitions = defaultdict(list)
+
+    for path in SHARED_ROOT.rglob("*.lua"):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        for function in DEFINITION_FUNCTIONS:
+            for identifier, _, _ in iter_named_calls(source, function):
+                definitions[function].append((identifier, path))
+
+    return definitions
+
+
+class RegistryDefinitionTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.definitions = collect_definitions()
+
+    def test_every_definition_family_has_source_entries(self):
+        for function in sorted(DEFINITION_FUNCTIONS):
+            with self.subTest(function=function):
+                self.assertTrue(
+                    self.definitions[function],
+                    f"{function} has no source definitions",
+                )
+
+    def test_definition_ids_are_unique_within_each_family(self):
+        for function in sorted(DEFINITION_FUNCTIONS):
+            entries = self.definitions[function]
+            locations = defaultdict(list)
+            for identifier, path in entries:
+                locations[identifier].append(str(path.relative_to(REPO)))
+            duplicates = {
+                identifier: paths
+                for identifier, paths in locations.items()
+                if len(paths) > 1
+            }
+            with self.subTest(function=function):
+                self.assertEqual({}, duplicates, f"duplicate IDs: {duplicates}")
+
+    def test_definition_ids_are_not_blank(self):
+        for function, entries in self.definitions.items():
+            for identifier, path in entries:
+                with self.subTest(function=function, source=path):
+                    self.assertTrue(identifier.strip())
+
+    def test_definition_scanner_ignores_comments_and_strings(self):
+        source = '''
+            -- ACF_defineGun("commented", {})
+            local example = "ACF_defineGun('quoted', {})"
+            local long_comment = --[=[ ACF_defineGun("long comment", {}) ]=]
+                "ignored"
+            local long_string = [=[ ACF_defineGun("long string", {}) ]=]
+            object.ACF_defineGun("method-qualified", {})
+            ACF_defineGun("real", {})
+        '''
+
+        self.assertEqual(
+            ["real"],
+            [
+                identifier
+                for identifier, _, _ in iter_named_calls(source, "ACF_defineGun")
+            ],
+        )
+
+    def test_round_scanner_ignores_comments_and_strings(self):
+        source = '''
+            -- Round.Type = "commented"
+            local text = [=[ Round.Type = "quoted" ]=]
+            Round . Type = "real"
+            ACF.RoundTypes[Round.Type] = Round
+        '''
+
+        self.assertEqual(
+            ["real"],
+            [
+                value
+                for value, _ in iter_qualified_string_assignments(source, "Round.Type")
+            ],
+        )
+        code = code_without_comments_and_strings(source)
+        self.assertRegex(
+            code,
+            r"ACF\s*\.\s*RoundTypes\s*\[\s*Round\s*\.\s*Type\s*\]"
+            r"\s*=\s*Round",
+        )
+
+    def test_round_sources_have_unique_types_and_register_themselves(self):
+        round_types = []
+        for path in sorted(ROUND_ROOT.glob("round*.lua")):
+            source = path.read_text(encoding="utf-8", errors="replace")
+            matches = [
+                value
+                for value, _ in iter_qualified_string_assignments(source, "Round.Type")
+            ]
+            with self.subTest(source=path):
+                self.assertEqual(1, len(matches))
+                code = code_without_comments_and_strings(source)
+                self.assertRegex(
+                    code,
+                    r"ACF\s*\.\s*RoundTypes\s*\[\s*Round\s*\.\s*Type\s*\]"
+                    r"\s*=\s*Round",
+                )
+            round_types.extend(matches)
+
+        self.assertTrue(round_types, "no round definitions were found")
+        self.assertEqual(len(round_types), len(set(round_types)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_repository_structure.py
+++ b/tests/python/test_repository_structure.py
@@ -1,0 +1,95 @@
+"""Static integrity checks for the ACE addon layout and load-time references."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+LUA_ROOT = REPO / "lua"
+ENTITY_ROOT = LUA_ROOT / "entities"
+
+
+class RepositoryStructureTests(unittest.TestCase):
+    def test_entity_directories_have_the_standard_file_set(self):
+        entity_dirs = sorted(
+            path
+            for path in ENTITY_ROOT.iterdir()
+            if path.is_dir() and path.name != "gmod_wire_expression2"
+        )
+
+        self.assertTrue(entity_dirs, "no ACE/ACF entity directories were found")
+        for entity_dir in entity_dirs:
+            with self.subTest(entity=entity_dir.name):
+                self.assertTrue((entity_dir / "init.lua").is_file())
+                self.assertTrue((entity_dir / "shared.lua").is_file())
+                self.assertTrue((entity_dir / "cl_init.lua").is_file())
+
+    def test_entity_initializers_send_shared_and_client_code(self):
+        for entity_dir in sorted(ENTITY_ROOT.iterdir()):
+            if not entity_dir.is_dir() or entity_dir.name == "gmod_wire_expression2":
+                continue
+
+            source = (entity_dir / "init.lua").read_text(encoding="utf-8")
+            with self.subTest(entity=entity_dir.name):
+                self.assertRegex(source, r"AddCSLuaFile\s*\(\s*[\"']shared\.lua")
+                self.assertRegex(source, r"AddCSLuaFile\s*\(\s*[\"']cl_init\.lua")
+
+    def test_duplicator_entity_class_registrations_are_unique_and_mounted(self):
+        pattern = re.compile(
+            r"duplicator\.RegisterEntityClass\s*\(\s*[\"']([^\"']+)[\"']"
+        )
+        registrations = []
+        for path in LUA_ROOT.rglob("*.lua"):
+            source = path.read_text(encoding="utf-8", errors="replace")
+            registrations.extend((match, path) for match in pattern.finditer(source))
+
+        classes = [match.group(1) for match, _ in registrations]
+        self.assertTrue(classes, "no duplicator entity classes were registered")
+        self.assertEqual(len(classes), len(set(classes)), "duplicate duplicator class IDs")
+
+        for class_name, path in ((match.group(1), path) for match, path in registrations):
+            with self.subTest(class_name=class_name, source=path):
+                self.assertTrue(
+                    (ENTITY_ROOT / class_name).is_dir(),
+                    f"{class_name} is registered but has no entity directory",
+                )
+
+    def test_direct_addcslua_file_references_resolve(self):
+        pattern = re.compile(r"AddCSLuaFile\s*\(\s*[\"']([^\"']+)[\"']")
+        missing = []
+
+        for source_path in LUA_ROOT.rglob("*.lua"):
+            source = source_path.read_text(encoding="utf-8", errors="replace")
+            for match in pattern.finditer(source):
+                # The loader also passes directory prefixes before concatenating a
+                # discovered filename; those are not file references to resolve.
+                if match.group(1).endswith("/"):
+                    continue
+                relative = Path(match.group(1).replace("/", "/"))
+                if len(relative.parts) == 1:
+                    target = source_path.parent / relative
+                else:
+                    target = LUA_ROOT.joinpath(*relative.parts)
+
+                if not target.is_file():
+                    missing.append(f"{source_path.relative_to(REPO)} -> {match.group(1)}")
+
+        self.assertEqual([], missing, "direct AddCSLuaFile references do not resolve: " + ", ".join(missing))
+
+    def test_loader_declared_shared_folders_exist(self):
+        loader = (LUA_ROOT / "acf" / "shared" / "sh_ace_loader.lua").read_text(
+            encoding="utf-8"
+        )
+        folders = re.findall(r"^\s*\"([a-z]+)\",\s*$", loader, re.MULTILINE)
+        self.assertTrue(folders, "the shared loader declared no source folders")
+
+        for folder in folders:
+            with self.subTest(folder=folder):
+                directory = LUA_ROOT / "acf" / "shared" / folder
+                self.assertTrue(directory.is_dir())
+                self.assertTrue(list(directory.glob("*.lua")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add offline Python integrity checks for missile definitions, registries, entities, loader paths, and native-suite manifests.
- Add native GLuaTest smoke suites for registry loading, scripted-entity registration, and test discovery.
- Run the offline and native quality gates automatically with the existing GLuaFixer workflow.
- Pin the effective test workflow and external dependency revisions, with a native discovery guard to prevent empty-suite false greens.

## Why

Linting catches syntax and style issues, but it does not prove that ACE definitions load, registrations are coherent, dependencies mount, or native test discovery works. These checks make those failures visible on commits and pull requests.

## Validation

- 25 Python tests pass on the clean `dev`-based branch, including lexer-helper regression coverage for the source audits.
- The native test and override Lua files compile successfully with LuaJIT.
- Workflow YAML and dependency setup Bash syntax validate successfully.
- Native server execution is delegated to the hosted GLuaTest check.
