### PR TITLE
Bugfix: Make canary deployment manual-only

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,8 +2,6 @@ name: Canary deployment to Workshop
 
 on:
   workflow_dispatch:
-  push:
-    branches: [dev]
 
 concurrency:
   group: workshop-upload


### PR DESCRIPTION
## Summary
- Keep the canary Workshop deployment available through `workflow_dispatch`.
- Remove the automatic `push` trigger on `dev`.

## Why
Merges to `dev` should not automatically attempt a Workshop upload when the canary credentials or upload path are unavailable, it just auto fails every time anyway since we only have one steam account to do auth.
