### PR TITLE
Bugfix: Rubber Eating Spall

### DIFF
--- a/lua/acf/client/cl_acfmenu_gui.lua
+++ b/lua/acf/client/cl_acfmenu_gui.lua
@@ -439,7 +439,7 @@ function PANEL:UpdateRoundCostPreview()
 
 	local DisplayTable = self.ActiveDisplayTable
 	if not istable(DisplayTable) or DisplayTable.type ~= "Ammo" or DisplayTable.Type == "Refill" then return end
-	if not ACF_GetRoundFromCVars or not ACE_Points_RoundFromBullet or not ACE_Points_BaseRoundCost then return end
+	if not ACF_GetRoundFromCVars or not ACE.Points_RoundFromBullet or not ACE.Points_BaseRoundCost then return end
 	if not IsValid(self.CustomDisplay) then return end
 
 	local RoundType = ACF.RoundTypes[DisplayTable.Type or ""]
@@ -452,10 +452,10 @@ function PANEL:UpdateRoundCostPreview()
 	BulletData.Type = DisplayTable.Type or RawData.Type
 	BulletData.Data7 = RawData.Data7
 
-	local Round = ACE_Points_RoundFromBullet(BulletData)
+	local Round = ACE.Points_RoundFromBullet(BulletData)
 	if not Round then return end
 
-	local Cost = string.Comma(math.Round(ACE_Points_BaseRoundCost(Round)))
+	local Cost = string.Comma(math.Round(ACE.Points_BaseRoundCost(Round)))
 	self:CPanelText("ACEBaseRoundCost", "Base Round Cost: " .. Cost .. "\nCrate Inventory Points: 0", "DermaDefaultBold")
 	self.CustomDisplay:PerformLayout()
 
@@ -1409,7 +1409,7 @@ function ACFCrewMenuGUICreate(Table)
 
 	local function GetCameraForPose(poseName)
 		-- Check if it's a standing pose
-		if ACE_IsStandingPose and ACE_IsStandingPose(poseName) then
+		if ACE.IsStandingPose and ACE.IsStandingPose(poseName) then
 			return CameraPresets.Standing
 		end
 
@@ -1718,7 +1718,7 @@ function ACEExplosiveGUICreate(Table)
 		local fragMass   = vol * CM3 * (1 - f) * 7.9 / 1000
 		local physMass   = fillerMass + fragMass * (ACF.ExplosiveCasingMul or 0.08)
 		local radius     = fillerMass ^ 0.33 * 8
-		local points = ACE_Points_ChargeCost and math.Round(ACE_Points_ChargeCost(fillerMass), 1) or 0
+		local points = ACE.Points_ChargeCost and math.Round(ACE.Points_ChargeCost(fillerMass), 1) or 0
 		return "HE Filler: " .. math.Round(fillerMass, 2) .. " kg"
 			.. "\nBlast Radius: " .. math.Round(radius, 1) .. " m"
 			.. "\nBlast Energy: " .. math.Round(fillerMass * (ACF.HEPower or 8000), 0) .. " KJ"

--- a/lua/acf/client/cl_soundbase.lua
+++ b/lua/acf/client/cl_soundbase.lua
@@ -63,7 +63,7 @@ do
 	--Global sound function. In order to be modified by a convar config
 	--If the Origin is an entity, uses entity:EmitSound( SoundTxt , SoundLevel, Pitch, Volume )
 	--If the Origin is a vector Position, uses sound.Play(SoundTxt, Position, SoundLevel, Pitch, Volume)
-	function ACE_EmitSound( SoundTxt, Origin, SoundLevel, Pitch, Volume )
+	function ACE.EmitSound( SoundTxt, Origin, SoundLevel, Pitch, Volume )
 
 		Volume = math.min( Volume, 1 )
 		local VolumeConfig = GetConVar("acf_sound_volume"):GetInt() / 100
@@ -76,7 +76,7 @@ do
 	end
 
 	--Gets the player's point of view if he's using a camera. Returns the entity input if no external entity is involved.
-	function ACE_SGetHearingEntity( ply )
+	function ACE.SGetHearingEntity( ply )
 		if not IsValid(ply) then return ply end
 
 		------------------------------- Method 1: Via Camera tool -------------------------------
@@ -104,7 +104,7 @@ do
 
 
 
-	function ACE_GetDistanceTime( Dist )
+	function ACE.GetDistanceTime( Dist )
 		return (Dist / 13503) * ACE.DelayMultipler
 	end
 
@@ -115,25 +115,25 @@ do
 	end
 
 	--Used for those extremely quiet sounds, which should be heard close to the player
-	function ACE_SInDistance( Pos, Distance )
+	function ACE.SInDistance( Pos, Distance )
 
 		local ply    = LocalPlayer()
 
-		local entply = ACE_SGetHearingEntity( ply )
+		local entply = ACE.SGetHearingEntity( ply )
 		local plyPos = entply:IsPlayer() and ACE.GetHeadPos( ply ) or entply:GetPos()
 
 		--return true if the distance is lower than the maximum distance
-		if ACE_InDist( plyPos, Pos, Distance ) then return true end
+		if ACE.InDist( plyPos, Pos, Distance ) then return true end
 
 		return false
 	end
 
 	--Gives the approaching speed of an object at a position moving a speed.
-	function ACE_Approaching( Pos, Flight )
+	function ACE.Approaching( Pos, Flight )
 
 		local ply    = LocalPlayer()
 
-		local entply = ACE_SGetHearingEntity( ply )
+		local entply = ACE.SGetHearingEntity( ply )
 		local plyPos = entply:IsPlayer() and ACE.GetHeadPos( ply ) or entply:GetPos()
 
 		local CurDist = (plyPos - Pos):Length()
@@ -143,7 +143,7 @@ do
 	end
 
 	--Used to see if the player has line of sight with the event
-	function ACE_SHasLOS( EventPos )
+	function ACE.SHasLOS( EventPos )
 
 		local ply = LocalPlayer()
 		local headPos = ACE.GetHeadPos( ply )
@@ -158,10 +158,10 @@ do
 		return false
 	end
 
-	function ACE_SIsInDoor()
+	function ACE.SIsInDoor()
 
 		local ply    = LocalPlayer()
-		local entply = ACE_SGetHearingEntity( ply )
+		local entply = ACE.SGetHearingEntity( ply )
 		local plyPos = entply.aceposoverride or entply:GetPos()
 
 		local CeilTr	= {}
@@ -189,11 +189,11 @@ do
 	}
 
 	function eventBase:OnArrived()
-		self.Entity = ACE_SGetHearingEntity(LocalPlayer())
+		self.Entity = ACE.SGetHearingEntity(LocalPlayer())
 	end
 
 	function eventBase:Play()
-		ACE_EmitSound(self.Sound, self.Origin or self.Entity, self.SoundLevel, self.Pitch, self.Volume)
+		ACE.EmitSound(self.Sound, self.Origin or self.Entity, self.SoundLevel, self.Pitch, self.Volume)
 	end
 
 	local function newSoundEvent(event)
@@ -275,14 +275,14 @@ do
 	end
 
 	--Handles Explosion sounds
-	function ACE_SBlast( HitPos, Radius, HitWater, HitWorld )
+	function ACE.SBlast( HitPos, Radius, HitWater, HitWorld )
 		local event = newSoundEvent({
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - HitPos):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - HitPos):Length())
 		})
 
 		-- doing it in a hacky way, since it needs more then one sound, but should be no isuess
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 			local hearingPos = getHearingPos(hearingEntity)
 			local distance = (hearingPos - HitPos):Length()
 
@@ -292,7 +292,7 @@ do
 			if not HitWater then
 				local Sound, volFix, pitchFix = getBlastSoundAboveWater(distance, Radius)
 
-				if not ACE_SHasLOS( HitPos ) and ACE_SIsInDoor() then
+				if not ACE.SHasLOS( HitPos ) and ACE.SIsInDoor() then
 					volFix = volFix * 0.5
 				end
 
@@ -304,7 +304,7 @@ do
 				if not ply:HasGodMode() then
 					local tinZone = math.max(Radius * 80, 50) * ACE.TinnitusZoneMultipler
 
-					if distance <= tinZone and ACE_SHasLOS(HitPos) and hearingEntity == ply and not ply.aceposoverride then
+					if distance <= tinZone and ACE.SHasLOS(HitPos) and hearingEntity == ply and not ply.aceposoverride then
 
 						hearingEntity:SetDSP(33, true)
 
@@ -312,7 +312,7 @@ do
 
 							-- See if it supress the current tinnitus and creates a new one, from 0. Should stop the HE spam tinnitus
 							hearingEntity:StopSound("acf_other/explosions/ring/tinnitus.mp3")
-							ACE_EmitSound("acf_other/explosions/ring/tinnitus.mp3", hearingEntity, 75, 100, 1 )
+							ACE.EmitSound("acf_other/explosions/ring/tinnitus.mp3", hearingEntity, 75, 100, 1 )
 
 						end
 					end
@@ -320,20 +320,20 @@ do
 					--debugoverlay.Sphere(HitPos, TinZone, 15, Color(0,0,255,32), 1)
 				end
 
-				ACE_EmitSound( Sound or "", hearingEntity, 75, pitch, volume)
+				ACE.EmitSound( Sound or "", hearingEntity, 75, pitch, volume)
 
 				--play dirt sounds
 				if Radius >= ACE.SoundSmallEx and HitWorld then
-					ACE_EmitSound( ACE.Sounds["Debris"]["low"]["close"][math.random(1,#ACE.Sounds["Debris"]["low"]["close"])] or "", hearingPos + (HitPos - hearingPos):GetNormalized() * 64, 80, pitch * pitchFix, volume * volFix / 20 )
-					ACE_EmitSound( ACE.Sounds["Debris"]["high"]["close"][math.random(1,#ACE.Sounds["Debris"]["high"]["close"])] or "", hearingPos + (HitPos - hearingPos):GetNormalized() * 64, 80, (pitch * pitchFix) / 0.5, volume * volFix / 20 )
+					ACE.EmitSound( ACE.Sounds["Debris"]["low"]["close"][math.random(1,#ACE.Sounds["Debris"]["low"]["close"])] or "", hearingPos + (HitPos - hearingPos):GetNormalized() * 64, 80, pitch * pitchFix, volume * volFix / 20 )
+					ACE.EmitSound( ACE.Sounds["Debris"]["high"]["close"][math.random(1,#ACE.Sounds["Debris"]["high"]["close"])] or "", hearingPos + (HitPos - hearingPos):GetNormalized() * 64, 80, (pitch * pitchFix) / 0.5, volume * volFix / 20 )
 				end
 
 				return
 			end
 
 			-- underwater
-			ACE_EmitSound( "ambient/water/water_splash" .. math.random(1,3) .. ".wav", hearingEntity, 75, math.max(pitch * 0.75,65), volume * 0.075 )
-			ACE_EmitSound( "^weapons/underwater_explode3.wav", hearingEntity, 75, math.max(pitch * 0.75,65), volume * 0.075 )
+			ACE.EmitSound( "ambient/water/water_splash" .. math.random(1,3) .. ".wav", hearingEntity, 75, math.max(pitch * 0.75,65), volume * 0.075 )
+			ACE.EmitSound( "^weapons/underwater_explode3.wav", hearingEntity, 75, math.max(pitch * 0.75,65), volume * 0.075 )
 		end
 
 		function event:Play() end
@@ -370,18 +370,18 @@ do
 	end
 
 	--Handles ricochet sounds
-	function ACE_SBulletImpact( HitPos, Caliber, Velocity, _, Material )
+	function ACE.SBulletImpact( HitPos, Caliber, Velocity, _, Material )
 		local event = newSoundEvent({
 			Origin = HitPos,
 
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - HitPos):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - HitPos):Length())
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 
 			local volFix, pitchFix = bulletImpactCaliberFix(Caliber)
-			if not ACE_SHasLOS( HitPos ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( HitPos ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.5
 			end
 
@@ -426,16 +426,16 @@ do
 	end
 
 	--Handles ricochet sounds 
-	function ACE_SRicochet( HitPos, Caliber, Velocity, HitWorld, Material )
+	function ACE.SRicochet( HitPos, Caliber, Velocity, HitWorld, Material )
 		local event = newSoundEvent({
 			SoundLevel = 100,
 			Pitch = math.Clamp(Velocity * 0.001, 90, 150),
 
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - HitPos):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - HitPos):Length())
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 
 			local volFix, pitchFix = 1, 1
 			if not HitWorld then
@@ -451,7 +451,7 @@ do
 				self.Sound = getImpactSound(Material or "invalid")
 			end
 
-			if not ACE_SHasLOS( HitPos ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( HitPos ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.5
 			end
 
@@ -481,17 +481,17 @@ do
 	end
 
 	--Handles penetration sounds
-	function ACE_SPenetration( HitPos, Caliber, Velocity, HitWorld, Material, Mass )
+	function ACE.SPenetration( HitPos, Caliber, Velocity, HitWorld, Material, Mass )
 		local event = newSoundEvent({
 			Sound = "acf_other/penetratingshots/penetrations/large/close/pen" .. math.random(3) .. ".mp3",
 
 			Pitch = math.Clamp(Velocity * 1, 90, 150),
 
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - HitPos):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - HitPos):Length())
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 
 			self.Entity = hearingEntity
 
@@ -505,7 +505,7 @@ do
 				self.Sound = getImpactSound(Material or "invalid")
 			end
 
-			if not ACE_SHasLOS( HitPos ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( HitPos ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.5
 			end
 
@@ -526,13 +526,13 @@ do
 	-- Nothing is accessing it so avoid globals everywhere
 	local fireSoundPackageIndex = {}
 
-	function ACE_SGunFire( Gun, Sound, PitchOverride, Propellant )
+	function ACE.SGunFire( Gun, Sound, PitchOverride, Propellant )
 		if not IsValid(Gun) then return end
 		if not Sound or Sound == "" then return end
 
 		Propellant = math.max(Propellant,50)
 
-		local hearingPos = getHearingPos(ACE_SGetHearingEntity( LocalPlayer() ))
+		local hearingPos = getHearingPos(ACE.SGetHearingEntity( LocalPlayer() ))
 
 		local event = newSoundEvent({
 			Sound = Sound or "",
@@ -540,13 +540,13 @@ do
 			SoundLevel = 100,
 			Pitch = PitchOverride,
 
-			Duration = ACE_GetDistanceTime((hearingPos - Gun:GetPos()):Length()),
+			Duration = ACE.GetDistanceTime((hearingPos - Gun:GetPos()):Length()),
 
 			Origin = Gun:GetPos()
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 			local hearingPos = getHearingPos(hearingEntity)
 			local origin = self.Origin
 
@@ -575,7 +575,7 @@ do
 				fireSoundPackageIndex[gunID] = index
 			end
 
-			if not ACE_SHasLOS( origin ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( origin ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.025
 			end
 
@@ -607,27 +607,27 @@ do
 	end
 
 	--TODO: Leave 5 sounds per caliber type. 22 7.26mm sounds go brrrr
-	function ACE_SBulletCrack( BulletData, Caliber )
+	function ACE.SBulletCrack( BulletData, Caliber )
 
 		-- flag this, so we are not playing this sound for this bullet next time
 		BulletData.CrackCreated = true
 
 		local CrackPos = BulletData.SimPos - BulletData.SimFlight:GetNormalized() * 5000
-		local distance = (getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - CrackPos):Length()
+		local distance = (getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - CrackPos):Length()
 
 		local event = newSoundEvent({
 			Volume = 10000 / distance,
 
-			Duration = ACE_GetDistanceTime(distance)
+			Duration = ACE.GetDistanceTime(distance)
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 
 			local Sound, volFix = getBulletCrackSound(Caliber)
 			self.Sound = Sound
 
-			if not ACE_SHasLOS( BulletData.SimPos ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( BulletData.SimPos ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.025
 			end
 			self.Volume = self.Volume * volFix
@@ -638,21 +638,21 @@ do
 
 
 	--TODO: Leave 5 sounds per caliber type. 22 7.26mm sounds go brrrr
-	function ACE_SBulletWhistle( BulletData )
+	function ACE.SBulletWhistle( BulletData )
 		-- flag this, so we are not playing this sound for this bullet next time
 		BulletData.HasWhistled = true
 
 		local event = newSoundEvent({
 			Sound = "acf_extra/ACE/SoundsMaccnificient/IncomingShell/whistle_arty_0" .. math.random(3) .. ".wav",
 
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - BulletData.SimPos):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - BulletData.SimPos):Length())
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 
 			local volFix = 1
-			if not ACE_SHasLOS( BulletData.SimPos ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( BulletData.SimPos ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.5
 			end
 			self.Volume = 10000 * volFix
@@ -668,22 +668,22 @@ do
 
 
 	--For any miscellaneous sound. BaseDistVolume is the Max dist where Volume will be 1. The volume will start losing dbs beyond this distance. In Units.
-	function ACE_SimpleSound( Sound, Origin, Pitch, BaseDistVolume  )
+	function ACE.SimpleSound( Sound, Origin, Pitch, BaseDistVolume  )
 		local event = newSoundEvent({
 			Sound = Sound or "",
 
 			SoundLevel = 100,
 			Pitch = Pitch,
 
-			Duration = ACE_GetDistanceTime((getHearingPos(ACE_SGetHearingEntity(LocalPlayer())) - Origin):Length())
+			Duration = ACE.GetDistanceTime((getHearingPos(ACE.SGetHearingEntity(LocalPlayer())) - Origin):Length())
 		})
 
 		function event:OnArrived()
-			local hearingEntity = ACE_SGetHearingEntity(LocalPlayer())
+			local hearingEntity = ACE.SGetHearingEntity(LocalPlayer())
 			local hearingPos = getHearingPos(hearingEntity)
 
 			local volFix = 1
-			if not ACE_SHasLOS( Origin ) and ACE_SIsInDoor() then
+			if not ACE.SHasLOS( Origin ) and ACE.SIsInDoor() then
 				volFix = volFix * 0.025
 			end
 

--- a/lua/acf/client/gui/cl_acfsetpermission.lua
+++ b/lua/acf/client/gui/cl_acfsetpermission.lua
@@ -38,13 +38,13 @@ local button3
 local status
 local status2
 
-function ACE_ReceiveDPStatus()
+function ACE.ReceiveDPStatus()
 
 	cvarstat = net.ReadBool() or false
 	Permissions:Update()
 
 end
-net.Receive( "ACE_DPStatus", ACE_ReceiveDPStatus )
+net.Receive( "ACE_DPStatus", ACE.ReceiveDPStatus )
 
 net.Receive("ACF_refreshpermissions", function()
 

--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -381,7 +381,7 @@ do
 			end
 		}
 
-		function ACE_PerformHitResolution( Index, Bullet, FlightRes, Retry, Type )
+		function ACE.PerformHitResolution( Index, Bullet, FlightRes, Retry, Type )
 			Hit_Resolutions[Retry or "Hit"](Index, Bullet, FlightRes, Type)
 		end
 	end
@@ -485,7 +485,7 @@ do
 			end
 
 			--If we should do the same trace again, then do so
-			ACE_PerformHitResolution(Index, Bullet, FlightRes, Retry, "propimpact")
+			ACE.PerformHitResolution(Index, Bullet, FlightRes, Retry, "propimpact")
 
 		--bullet hit the world
 		elseif FlightRes.HitWorld then
@@ -498,7 +498,7 @@ do
 				local Retry = ACF_BulletWorldImpact( Index, Bullet, FlightRes.HitPos, FlightRes.HitNormal )
 
 				--If we should do the same trace again, then do so
-				ACE_PerformHitResolution(Index, Bullet, FlightRes, Retry, "worldimpact")
+				ACE.PerformHitResolution(Index, Bullet, FlightRes, Retry, "worldimpact")
 
 			--hit skybox
 			else

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -78,7 +78,7 @@ function ACF_Activate( Entity , Recalc )
 	local Ductility = math.Clamp( Entity.ACF.Ductility, -0.8, 0.8 )
 
 	local Mat	= Entity.ACF.Material or "RHA"
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 
 	local massMod	= MatData.massMod
 
@@ -193,7 +193,7 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	local losArmorHealth = armor ^ 1.1 * (3 + math.min(1 / math.abs(math.cos(math.rad(Angle)) ^ ACF.SlopeEffectFactor), 2.8) * 0.5)	-- Bc people had to abuse armor angling, FML
 
 	local Mat			= Entity.ACF.Material or "RHA"	--very important thing
-	local MatData		= ACE_GetMaterialData( Mat )
+	local MatData		= ACE.GetMaterialData( Mat )
 
 	local damageMult		= 1
 
@@ -222,7 +222,7 @@ function ACF_CalcDamage( Entity , Energy , FrArea , Angle , Type) --y=-5/16x + b
 	end
 
 	-- RHA Penetration
-	local maxPenetration = ACE_CalcPenetration(Energy, FrArea)
+	local maxPenetration = ACE.CalcPenetration(Energy, FrArea)
 
 	-- Projectile caliber. Messy, function signature
 	local caliber = 20 * (FrArea ^ (1 / ACF.PenAreaMod) / 3.1416) ^ 0.5
@@ -609,7 +609,7 @@ end
 	This one is more simple than the original function.
 	Creates a rope without any constraint
 ------------------------------------------------------------------------]]
-function ACE_CreateLinkRope( Pos, Ent1, LPos1, Ent2, LPos2 )
+function ACE.CreateLinkRope( Pos, Ent1, LPos1, Ent2, LPos2 )
 
 	local rope = ents.Create( "keyframe_rope" )
 	rope:SetPos( Pos )
@@ -644,7 +644,7 @@ end
 	This one is more simple than the original function.
 	Creates a rope without any constraint
 ------------------------------------------------------------------------]]
-function ACE_CreateSZRope( Pos, Ent, LPos1, LPos2 )
+function ACE.CreateSZRope( Pos, Ent, LPos1, LPos2 )
 
 	local rope = ents.Create( "keyframe_rope" )
 	rope:SetPos( Pos )
@@ -673,7 +673,7 @@ function ACE_CreateSZRope( Pos, Ent, LPos1, LPos2 )
 
 end
 
-function ACE_VisualizeSZ(Point1, Point2)
+function ACE.VisualizeSZ(Point1, Point2)
 
 	local SZEnt = ents.Create("prop_physics")
 	if SZEnt:IsValid() then
@@ -693,81 +693,81 @@ function ACE_VisualizeSZ(Point1, Point2)
 	local PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
 	local LPT1 = SZEnt:WorldToLocal(PT1)
 	local LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point1.x,Point1.y,Point2.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
 	PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	--Lower Rectangle
 	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 	--4 corners
 	PT1 = Vector(Point2.x,Point2.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point2.x,Point2.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point1.x,Point1.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point1.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point1.x,Point2.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point1.x,Point2.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 	PT1 = Vector(Point2.x,Point1.y,Point1.z) + Vector(0,0,2)
 	PT2 = Vector(Point2.x,Point1.y,Point2.z) + Vector(0,0,2)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 
 --[[
 	PT1 = Vector(Point1.x,Point1.y,Point1.z)
 	PT2 = Vector(Point2.x,Point1.y,Point1.z)
 	LPT1 = SZEnt:WorldToLocal(PT1)
 	LPT2 = SZEnt:WorldToLocal(PT2)
-	ACE_CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
+	ACE.CreateSZRope( PT1, SZEnt, LPT1, LPT2 )
 ]]--
 
 	return SZEnt
@@ -786,7 +786,7 @@ local WireTable = {
 	gmod_wire_joystick_multi = true
 }
 
-function ACE_GetWeaponUser( Weapon, inp )
+function ACE.GetWeaponUser( Weapon, inp )
 	if not IsValid(inp) then return end
 
 	if inp:GetClass() == "gmod_wire_adv_pod" then
@@ -811,13 +811,13 @@ function ACE_GetWeaponUser( Weapon, inp )
 		end
 	elseif inp:GetClass() == "gmod_wire_expression2" then
 		if inp.Inputs.Fire then
-			return ACE_GetWeaponUser( Weapon, inp.Inputs.Fire.Src )
+			return ACE.GetWeaponUser( Weapon, inp.Inputs.Fire.Src )
 		elseif inp.Inputs.Shoot then
-			return ACE_GetWeaponUser( Weapon, inp.Inputs.Shoot.Src )
+			return ACE.GetWeaponUser( Weapon, inp.Inputs.Shoot.Src )
 		elseif inp.Inputs then
 			for _,v in pairs(inp.Inputs) do
 				if IsValid(v.Src) and WireTable[v.Src:GetClass()] then
-					return ACE_GetWeaponUser( Weapon, v.Src )
+					return ACE.GetWeaponUser( Weapon, v.Src )
 				end
 			end
 		end

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -702,7 +702,12 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 	local Entity_Crit_Hit_Factor = 1.01
 
-	local SpallRes = util.TraceLine(ACE.Spall[Index])
+	local SpallTrace = ACE.Spall[Index]
+	local SpallDirection = HitVec:GetNormalized()
+	if SpallTrace and SpallTrace.start and SpallTrace.endpos then
+		SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()
+	end
+	local SpallRes = util.TraceLine(SpallTrace)
 
 	-- Check if spalling hit something
 	if SpallRes.Hit and ACF_Check( SpallRes.Entity ) then
@@ -718,19 +723,19 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 				ACE.Spall[Index] = {}
 				ACE.Spall[Index].start  = SpallRes.HitPos
-				ACE.Spall[Index].endpos = SpallRes.HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-				ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
 
 		end
 
 		-- Get the spalling hitAngle
-		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , HitVec )
+		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , SpallDirection )
 		-- print("ANGLE: " .. Angle)
 
 		local Mat		= SpallRes.Entity.ACF.Material or "RHA"
@@ -766,7 +771,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		-- continuation filter below so this impact cannot spawn a second retry.
 		local Debris
 		if HitRes.Kill then
-			Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
+			Debris = ACF_APKill( SpallRes.Entity , SpallDirection , SpallEnergy.Kinetic )
 		end
 
 		-- Applies a decal
@@ -787,7 +792,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
-			ACE.Spall[Index].endpos = SpallRes.HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
@@ -796,7 +801,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 			-- Blue trace means spall penetrated and will continue.
 
 			-- Retry
-			ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+			ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
 		else
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -90,7 +90,7 @@ function ACF_HE( Hitpos , _ , FillerMass, FragMass, Inflictor, NoOcc, Gun, Blast
 		IsValid(Gun) and Gun:EntIndex() or "nil"
 	)
 
-	local Radius       = ACE_CalculateHERadius(FillerMass) -- Scalling law found on the net, based on 1PSI overpressure from 1 kg of TNT at 15m.
+	local Radius       = ACE.CalculateHERadius(FillerMass) -- Scalling law found on the net, based on 1PSI overpressure from 1 kg of TNT at 15m.
 	local MaxSphere    = 4 * PI * (Radius * 2.54) ^ 2 -- Surface Area of the sphere at maximum radius
 	local Power        = FillerMass * ACF.HEPower -- Power in KiloJoules of the filler mass of  TNT
 	local Amp          = math.min(Power / 2000, 50)
@@ -143,7 +143,7 @@ function ACF_HE( Hitpos , _ , FillerMass, FragMass, Inflictor, NoOcc, Gun, Blast
 			local SqDist = Hitpos:DistToSqr( epos )
 			if SqDist > RadSq then continue end --Perhaps a table storing positions would be faster?
 
-			local LosArmor = ACE_LOSMultiTrace(Hitpos,epos, HEPen)
+			local LosArmor = ACE.LOSMultiTrace(Hitpos,epos, HEPen)
 			--print("LosArmor: " .. LosArmor)
 
 			local Dist = math.sqrt(SqDist)
@@ -411,7 +411,7 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 	if not ACF.Spalling then return end
 
 	local Mat		= Material or "RHA"
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 
 	-- Spall damage
 	local SpallMul	= MatData.spallmult or 1
@@ -541,7 +541,7 @@ function ACF_PropShockwave( HitPos, HitVec, Filter, Caliber )
 				local space = math.abs( (HitFronts[iteration] - HitBacks[iteration - 1]):Length() )
 				--prop's material
 				local mat = tracefront.Entity.ACF and tracefront.Entity.ACF.Material or "RHA"
-				local MatData = ACE_GetMaterialData( mat )
+				local MatData = ACE.GetMaterialData( mat )
 				local Hasvoid = false
 				local NotOverlap = false
 				--print("DATA TABLE - DONT FUCKING DELETE")
@@ -617,7 +617,7 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 	if not ACF.Spalling then return end
 
 	local Mat		= Material or "RHA"
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 
 	-- Spall damage
 	local SpallMul	= MatData.spallmult or 1
@@ -731,7 +731,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		-- print("ANGLE: " .. Angle)
 
 		local Mat		= SpallRes.Entity.ACF.Material or "RHA"
-		local MatData	= ACE_GetMaterialData( Mat )
+		local MatData	= ACE.GetMaterialData( Mat )
 
 		local spall_resistance = MatData.spallresist
 
@@ -1089,7 +1089,7 @@ function ACF_HEKill( Entity , HitVector , Energy , BlastPos )
 	do
 		--ERA props should not create debris
 		local Mat = (Entity.ACF and Entity.ACF.Material) or "RHA"
-		local MatData = ACE_GetMaterialData( Mat )
+		local MatData = ACE.GetMaterialData( Mat )
 		if MatData.IsExplosive then return end
 	end
 
@@ -1145,7 +1145,7 @@ function ACF_APKill( Entity , HitVector , Power )
 	do
 		--ERA props should not create debris
 		local Mat = (Entity.ACF and Entity.ACF.Material) or "RHA"
-		local MatData = ACE_GetMaterialData( Mat )
+		local MatData = ACE.GetMaterialData( Mat )
 		if MatData.IsExplosive then return end
 	end
 
@@ -1204,7 +1204,7 @@ do
 		HVAP = true
 	}
 	local function IsMissileAmmoData( bullet )
-		local gunClass = ACE_GetAmmoGunClass(bullet)
+		local gunClass = ACE.GetAmmoGunClass(bullet)
 		if not gunClass then return false end
 
 		local classes = ACF and ACF.Classes and ACF.Classes.GunClass
@@ -1214,19 +1214,19 @@ do
 	end
 
 	local function ResolveCookoffRoundType(ent, bullet)
-		return ACE_ResolveAmmoType(ent, bullet)
+		return ACE.ResolveAmmoType(ent, bullet)
 	end
 
 	local function GetCookoffBlastMass(bullet, roundType)
-		return ACE_GetAmmoCookoffBlastMass(roundType, bullet)
+		return ACE.GetAmmoCookoffBlastMass(roundType, bullet)
 	end
 
 	local function GetCookoffAmmoCount(roundType, ammo, isMissile)
-		return ACE_GetAmmoCookoffAmmoCount(roundType, ammo, isMissile)
+		return ACE.GetAmmoCookoffAmmoCount(roundType, ammo, isMissile)
 	end
 
 	local function GetCookoffExplosionClass(roundType, isMissile)
-		return ACE_GetAmmoCookoffClass(roundType, isMissile)
+		return ACE.GetAmmoCookoffClass(roundType, isMissile)
 	end
 
 	--converts what would be multiple simultaneous cache detonations into one large explosion
@@ -1264,8 +1264,8 @@ do
 			local IsMissile = IsMissileAmmoData(ent.BulletData)
 			local AmmoCount = GetCookoffAmmoCount(RoundTypeCook, Ammo, IsMissile)
 			local CookClass = GetCookoffExplosionClass(RoundTypeCook, IsMissile)
-			local PropScale = ACE_GetAmmoCookoffPropScale(CookClass)
-			local AmmoScale = ACE_GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
+			local PropScale = ACE.GetAmmoCookoffPropScale(CookClass)
+			local AmmoScale = ACE.GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
 
 			HEWeight = ( ( HE + Propel * PropScale * ( ACF.PBase / ACF.HEPower ) ) * AmmoCount ) * AmmoScale
 			DebugExplosion("AmmoCalc", "Type", RoundTypeCook, "HE", HE, "Propel", Propel, "Ammo", Ammo, "AmmoCount", AmmoCount, "PropScale", PropScale, "AmmoScale", AmmoScale, "HEWeight", HEWeight, "EntIndex", ent:EntIndex())
@@ -1294,7 +1294,7 @@ do
 			MaxGroup
 		)
 
-		local Radius    = ACE_CalculateHERadius( HEWeight )
+		local Radius    = ACE.CalculateHERadius( HEWeight )
 		local BasePos   = ent:LocalToWorld(ent:OBBCenter())
 		local Pos = BasePos
 
@@ -1422,8 +1422,8 @@ do
 							local IsMissile = IsMissileAmmoData(Found.BulletData)
 							local AmmoCount = GetCookoffAmmoCount(RoundTypeCook, Ammo, IsMissile)
 							local CookClass = GetCookoffExplosionClass(RoundTypeCook, IsMissile)
-							local PropScale = ACE_GetAmmoCookoffPropScale(CookClass)
-							local AmmoScale = ACE_GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
+							local PropScale = ACE.GetAmmoCookoffPropScale(CookClass)
+							local AmmoScale = ACE.GetAmmoCookoffStorageScale(CookClass, AmmoExplosionScale, MissileExplosionScale)
 
 							local AmmoHEWeight = ( HE + Propel * PropScale * ACF.APAmmoDetonateFactor * ( ACF.PBase / ACF.HEPower))
 							if AmmoHEWeight > HighestHEWeight then
@@ -1489,7 +1489,7 @@ do
 						DebugExplosion("ExplodePos:Add", "Found", Found:EntIndex(), "Pos", tostring(FoundPos), "FoundHE", FoundHEWeight, "TotalHE", HEWeight + FoundHEWeight)
 
 						HEWeight = HEWeight + FoundHEWeight
-						DebugExplosion("ExplodePos:Accum", "TotalHE", HEWeight, "Radius", ACE_CalculateHERadius(HEWeight))
+						DebugExplosion("ExplodePos:Accum", "TotalHE", HEWeight, "Radius", ACE.CalculateHERadius(HEWeight))
 
 						Found.IsExplosive   = false
 						Found.DamageAction  = false
@@ -1518,7 +1518,7 @@ do
 			if HEWeight > LastHE then
 				Search = true
 				LastHE = HEWeight
-				Radius = ACE_CalculateHERadius( HEWeight )
+				Radius = ACE.CalculateHERadius( HEWeight )
 				DebugExplosion("ExplodePos:RadiusUpdate", "TotalHE", HEWeight, "Radius", Radius)
 			else
 				Search = false
@@ -1555,7 +1555,7 @@ do
 			HEWeight = MaxHE
 		end
 
-		Radius	= ACE_CalculateHERadius( HEWeight )
+		Radius	= ACE.CalculateHERadius( HEWeight )
 
 		--Sets the ratio of HE blast pen so it no longer pens 300mm when 10 shells cookoff.
 		--Blastpen will use the HEpower of 2 of the biggest HE detonations or 1/10th the HE power. Whichever is bigger.
@@ -1603,7 +1603,7 @@ function ACF_GetHitAngle( HitNormal , HitVector )
 
 end
 
-function ACE_CalculateHERadius( HEWeight )
+function ACE.CalculateHERadius( HEWeight )
 	local Radius = HEWeight ^ 0.33 * 8 * 39.37
 	return Radius
 end
@@ -1614,7 +1614,7 @@ end
 --Calculates the effective armor between two points
 --Effangle, Type(1 = KE, 2 = HEAT), Filter
 --Might make for a nice e2 function if people probably wouldn't eat the server with it
-function ACE_LOSMultiTrace(StartVec, EndVec, PenetrationMax)
+function ACE.LOSMultiTrace(StartVec, EndVec, PenetrationMax)
 
 	debugoverlay.Line( StartVec, EndVec, 30 , Color(255,0,0), true )
 
@@ -1645,7 +1645,7 @@ function ACE_LOSMultiTrace(StartVec, EndVec, PenetrationMax)
 				else
 					local Angle		= ACF_GetHitAngle( TraceLine.HitNormal , Normal )
 					local Mat			= TraceEnt.ACF.Material or "RHA"	--very important thing
-					local MatData		= ACE_GetMaterialData( Mat )
+					local MatData		= ACE.GetMaterialData( Mat )
 					local armor = TraceEnt.ACF.Armour
 					local losArmor		= armor / math.abs( math.cos(math.rad(Angle)) ^ ACF.SlopeEffectFactor ) * MatData["effectiveness"]
 					TotalArmor = TotalArmor + losArmor

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -715,12 +715,12 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 				ACE.Spall[Index] = {}
 				ACE.Spall[Index].start  = SpallRes.HitPos
-				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+				ACE.Spall[Index].endpos = SpallRes.HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
 
@@ -764,7 +764,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 			local Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
 			if IsValid(Debris) then
 				table.insert( ACE.Spall[Index].filter , Debris )
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			end
 		end
 
@@ -779,7 +779,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
-			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+			ACE.Spall[Index].endpos = SpallRes.HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
@@ -790,7 +790,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 			-- Blue trace means spall trace that overpenned and killed something.
 
 			-- Retry
-			ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+			ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
 		else
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -696,6 +696,9 @@ end
 
 --Spall trace core. For HESH and normal spalling
 function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallVelocity )
+	-- Each fragment needs its own mutable penetration budget. Recursive retries keep this copy,
+	-- while later fragments must start from the original energy.
+	SpallEnergy = table.Copy(SpallEnergy)
 
 	local Entity_Crit_Hit_Factor = 1.01
 

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -762,23 +762,28 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		-- Applies the damage to the impacted entity
 		local HitRes = ACF_Damage( SpallRes.Entity , SpallEnergy , SpallArea , Angle , Inflictor, 0, nil, "Spall") --Angle replaced with 0 for inconsistent spall
 
-		-- If it's able to destroy it, kill it and filter it
+		-- If it's able to destroy it, kill it. Any debris is added to the single
+		-- continuation filter below so this impact cannot spawn a second retry.
+		local Debris
 		if HitRes.Kill then
-			local Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
-			if IsValid(Debris) then
-				table.insert( ACE.Spall[Index].filter , Debris )
-				ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
-			end
+			Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
 		end
 
 		-- Applies a decal
 		util.Decal("GunShot1",SpallRes.StartPos, SpallRes.HitPos, ACE.Spall[Index].filter )
 
-		-- The entity was penetrated --Disabled since penetration values are not real
-		if HitRes.Overkill > 0 then
+		-- Continue once with the standard armor resolver's remaining-energy fraction.
+		-- This is fragment-local because SpallEnergy was copied at function entry.
+		local Remaining = math.Clamp(1 - (HitRes.Loss or 1), 0, 1)
+		if HitRes.Overkill > 0 and Remaining > 0 then
+			SpallEnergy.Penetration = SpallEnergy.Penetration * Remaining
+			SpallEnergy.Kinetic = SpallEnergy.Kinetic * Remaining
 
 			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
+			if IsValid(Debris) then
+				table.insert( Temp_Filter , Debris )
+			end
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
@@ -787,10 +792,8 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-			SpallRes = util.TraceLine(ACE.Spall[Index])
-
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
-			-- Blue trace means spall trace that overpenned and killed something.
+			-- Blue trace means spall penetrated and will continue.
 
 			-- Retry
 			ACF_SpallTrace( HitVec , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )

--- a/lua/acf/server/sv_acfpermission.lua
+++ b/lua/acf/server/sv_acfpermission.lua
@@ -136,7 +136,7 @@ function this.visualizeSafeZones()
 	for _, szpts in pairs(this.Safezones) do
 		szmin = szpts[1]
 		szmax = szpts[2]
-		ACE_VisualizeSZ(szmin, szmax)
+		ACE.VisualizeSZ(szmin, szmax)
 	end
 
 	return false
@@ -152,7 +152,7 @@ end )
 hook.Add("ACF_PlayerChangedZone", "ACF_TellPlyAboutSafezoneBattle", function(ply, zone)
 	if not this.NotifySafezones[table.KeyFromValue(this.Modes, this.DamagePermission)] then return end
 
-	ACE_SendMsg(ply, zone and Color(0, 255, 0) or Color(255, 0, 0), "You have entered the " .. (zone and zone .. " safezone." or "battlefield!"))
+	ACE.SendMsg(ply, zone and Color(0, 255, 0) or Color(255, 0, 0), "You have entered the " .. (zone and zone .. " safezone." or "battlefield!"))
 end)
 
 local plyzones = {}
@@ -383,7 +383,7 @@ concommand.Add( "ACF_SetDefaultPermissionMode", function(ply, _, args)
 
 		for _, v in pairs(player.GetAll()) do
 			if v:IsAdmin() then
-				ACE_SendMsg(v, Color(255, 0, 0), "Default permission mode for " .. game.GetMap() .. " has been set to " .. mode .. "!")
+				ACE.SendMsg(v, Color(255, 0, 0), "Default permission mode for " .. game.GetMap() .. " has been set to " .. mode .. "!")
 			end
 		end
 
@@ -428,7 +428,7 @@ local function tellPlysAboutDPMode(mode, oldmode)
 	if mode == oldmode then return end
 
 	for _, v in pairs(player.GetAll()) do
-		ACE_SendMsg(v, Color(255,0,0), "Damage protection has been changed to " .. mode .. " mode!")
+		ACE.SendMsg(v, Color(255,0,0), "Damage protection has been changed to " .. mode .. " mode!")
 	end
 end
 hook.Add("ACF_ProtectionModeChanged", "ACF_TellPlysAboutDPMode", tellPlysAboutDPMode)
@@ -627,7 +627,7 @@ net.Receive("ACF_dmgfriends", function(_, ply)
 				local note = v and "given you" or "removed your"
 				local MsgNote = v and "given" or "removed"
 
-				ACE_SendNotification(targ, ply:Nick() .. " has " .. note .. " permission to damage their objects with ACE!")
+				ACE.SendNotification(targ, ply:Nick() .. " has " .. note .. " permission to damage their objects with ACE!")
 				print("[ACE | INFO]- The user " .. ply:Nick() .. " has " .. MsgNote .. " permissions to damage objects with ACE " .. (v and "to" or "from") .. " " .. ((targ == ply) and "himself" or targ:Nick()))
 			end
 		end
@@ -671,7 +671,7 @@ function this.SendPermissionsState(ply)
 end
 util.AddNetworkString("ACF_refreshpermissions")
 net.Receive("ACF_refreshpermissions", function(_, ply)
-	ACE_SendDPStatus()
+	ACE.SendDPStatus()
 	this.SendPermissionsState(ply)
 end)
 

--- a/lua/acf/server/sv_contraption.lua
+++ b/lua/acf/server/sv_contraption.lua
@@ -285,7 +285,7 @@ hook.Add("EntityRemoved", "ACE_EntRemoval", function(Ent)
 end)
 
 -- Optimization resource, this will try to clean the main table just to reduce Ent count
-function ACE_refreshdata(Data)
+function ACE.refreshdata(Data)
 	--Not really perfect, but better than nothing. Cframepls
 	if istable(Data) and not table.IsEmpty(Data) then
 		local Entities = Data[1].CreatedEntities --wtf wire
@@ -321,7 +321,7 @@ function ACE_refreshdata(Data)
 	--print('Total Ents registered count: ' .. table.Count( ACE.contraptionEnts ))
 end
 
-timer.Create( "PeriodicCleanup", 3, 0, ACE_refreshdata )
+timer.Create( "PeriodicCleanup", 3, 0, ACE.refreshdata )
 
 hook.Add("AdvDupe_FinishPasting", "ACE_refresh", function(dupeInfo)
 	local dupe = istable(dupeInfo) and dupeInfo[1]
@@ -343,5 +343,5 @@ hook.Add("AdvDupe_FinishPasting", "ACE_refresh", function(dupeInfo)
 		end
 	end
 
-	ACE_refreshdata(dupeInfo)
+	ACE.refreshdata(dupeInfo)
 end)

--- a/lua/acf/server/sv_contraptionlegality.lua
+++ b/lua/acf/server/sv_contraptionlegality.lua
@@ -4,7 +4,7 @@ include("acf/shared/sh_ace_functions.lua")
 include("acf/server/sv_pointshandling.lua")
 
 
-local IsEnt = ACE_IsEnt
+local IsEnt = ACE.IsEnt
 ACE.CacheVersion = ACE.CacheVersion or 1
 local POINTS_STATE_VERSION = 2
 ACE.PointsStateVersion = POINTS_STATE_VERSION
@@ -63,7 +63,7 @@ end
 -- ------------------------------------------------------------
 
 -- Run a legality scan for a contraption.
-function ACE_DoContraptionLegalCheck(checkEnt)
+function ACE.DoContraptionLegalCheck(checkEnt)
 	checkEnt.CanLegalCheck = checkEnt.CanLegalCheck or false
 	if not checkEnt.CanLegalCheck then return end
 
@@ -75,7 +75,7 @@ function ACE_DoContraptionLegalCheck(checkEnt)
 	local con = checkEnt:CFW_GetContraption() or {}
 	if table.IsEmpty(con) then return end
 
-	ACE_CheckLegalCont(con)
+	ACE.CheckLegalCont(con)
 end
 
 -- ------------------------------------------------------------
@@ -83,16 +83,16 @@ end
 -- ------------------------------------------------------------
 
 -- Evaluate legality for a contraption.
-function ACE_CheckLegalCont(con)
+function ACE.CheckLegalCont(con)
 	con.OTWarnings = con.OTWarnings or {}
 
-	if ACE_EnsureContraptionPoints then
-		ACE_EnsureContraptionPoints(con, nil, false)
+	if ACE.EnsureContraptionPoints then
+		ACE.EnsureContraptionPoints(con, nil, false)
 	end
 
 	local points = con.ACEPoints or 0
 	if points > ACF.PointsLimit and not con.OTWarnings.WarnedOverPoints then
-		local name  = ACE_GetOwnerName(ACE_GetContraptionOwner(con))
+		local name  = ACE.GetOwnerName(ACE.GetContraptionOwner(con))
 		local above = points - ACF.PointsLimit
 		chatMessageGlobal(
 			"[ACE] " .. name .. " has a vehicle [" .. math.ceil(above) .. "pts] over the limit costing [" ..
@@ -103,7 +103,7 @@ function ACE_CheckLegalCont(con)
 	end
 
 	if con.totalMass > ACF.MaxWeight and not con.OTWarnings.WarnedOverWeight then
-		local name  = ACE_GetOwnerName(ACE_GetContraptionOwner(con))
+		local name  = ACE.GetOwnerName(ACE.GetContraptionOwner(con))
 		local above = con.totalMass - ACF.MaxWeight
 		chatMessageGlobal(
 			"[ACE] " .. name .. " has a vehicle [" .. math.ceil(above) .. "kg] over the limit, weighing [" ..
@@ -120,19 +120,19 @@ end
 
 do
 	-- Sync per-contraption cache version and invalidate stale local caches.
-	function ACE_EnsureCacheVersion(con)
+	function ACE.EnsureCacheVersion(con)
 		if not con then return false end
 
 		if con.ACECacheVersion == ACE.CacheVersion then return false end
 
 		con.ACECacheVersion = ACE.CacheVersion
-		ACE_MarkContraptionPointsDirty(con, nil, true, true, "cache-version-changed")
+		ACE.MarkContraptionPointsDirty(con, nil, true, true, "cache-version-changed")
 
 		return true
 	end
 
 	-- Initialize per-contraption points state.
-	function ACE_EnsurePointsState(con)
+	function ACE.EnsurePointsState(con)
 		if not con then return false end
 		if con.ACEInitDone and con.ACEPointsStateVersion == POINTS_STATE_VERSION then return false end
 
@@ -163,22 +163,22 @@ do
 		end
 
 		con.ACEPointsRevision = 0
-		ACE_MarkContraptionPointsDirty(con, nil, true, true, "contraption-created")
+		ACE.MarkContraptionPointsDirty(con, nil, true, true, "contraption-created")
 
 		return true
 	end
 
-	local ACE_InitPts = ACE_EnsurePointsState
+	local ACE_InitPts = ACE.EnsurePointsState
 
 	-- Mark a contraption's derived point totals dirty.
-	function ACE_MarkContraptionPointsDirty(con, ent, armorDirty, nonArmorDirty, reason)
+	function ACE.MarkContraptionPointsDirty(con, ent, armorDirty, nonArmorDirty, reason)
 		if not con then return end
 
 		if armorDirty == nil then armorDirty = true end
 		if nonArmorDirty == nil then nonArmorDirty = true end
 
-		if armorDirty and ACE_ClearArmorPointCache and IsEnt(ent) then
-			ACE_ClearArmorPointCache(ent)
+		if armorDirty and ACE.ClearArmorPointCache and IsEnt(ent) then
+			ACE.ClearArmorPointCache(ent)
 		end
 
 		con.ACEPointsDirty = true
@@ -189,23 +189,23 @@ do
 			con.ACEArmorCalculated = false
 		end
 
-		ACE_NotifyContraptionPointsInvalidated(con, ent, reason, armorDirty, nonArmorDirty)
+		ACE.NotifyContraptionPointsInvalidated(con, ent, reason, armorDirty, nonArmorDirty)
 	end
 
 	-- Orphan weapons invalidate the link-anchor contraption that owns their cost.
-	function ACE_PointsInputChanged(ent, reason)
+	function ACE.PointsInputChanged(ent, reason)
 		if not IsEnt(ent) then return end
 
 		local previous = ent._ACEPointsOwnerConRef
-		local con = ACE_GetContraptionFromEntity and ACE_GetContraptionFromEntity(ent)
-		if not con and ACE_GetWeaponAnchorContraption then con = ACE_GetWeaponAnchorContraption(ent) end
+		local con = ACE.GetContraptionFromEntity and ACE.GetContraptionFromEntity(ent)
+		if not con and ACE.GetWeaponAnchorContraption then con = ACE.GetWeaponAnchorContraption(ent) end
 
 		ent._ACEPointsOwnerConRef = con
 
 		if previous and previous ~= con then
-			ACE_MarkContraptionPointsDirty(previous, ent, false, true, "weapon-owner-changed")
+			ACE.MarkContraptionPointsDirty(previous, ent, false, true, "weapon-owner-changed")
 		end
-		if con then ACE_MarkContraptionPointsDirty(con, ent, false, true, reason or "entity-updated") end
+		if con then ACE.MarkContraptionPointsDirty(con, ent, false, true, reason or "entity-updated") end
 	end
 
 	-- Initialize point tracking when a contraption is created.
@@ -252,17 +252,17 @@ do
 	end)
 
 	-- Refresh orphan-weapon ownership after a linked crate changes contraptions.
-	function ACE_NotifyCrateWeapons(ent, reason)
+	function ACE.NotifyCrateWeapons(ent, reason)
 		if not ent or not ent.GetClass or ent:GetClass() ~= "acf_ammo" then return end
 		if type(ent.Master) ~= "table" then return end
 
 		for _, weapon in pairs(ent.Master or {}) do
-			if IsEnt(weapon) then ACE_PointsInputChanged(weapon, reason or "linked-crate-moved") end
+			if IsEnt(weapon) then ACE.PointsInputChanged(weapon, reason or "linked-crate-moved") end
 		end
 	end
 
 	-- Handle entity addition and update point totals.
-	function ACE_AddPts(con, ent)
+	function ACE.AddPts(con, ent)
 		if not IsEnt(ent) then return end
 		ACE_EnsureCFWMassTotal(con, con.ents, nil, ent)
 
@@ -270,20 +270,20 @@ do
 		local previousOwner = ent._ACEPointsOwnerConRef
 
 		if previous and previous ~= con then
-			ACE_MarkContraptionPointsDirty(previous, ent, true, true, "entity-moved")
+			ACE.MarkContraptionPointsDirty(previous, ent, true, true, "entity-moved")
 		end
 		if previousOwner and previousOwner ~= con and previousOwner ~= previous then
-			ACE_MarkContraptionPointsDirty(previousOwner, ent, false, true, "weapon-owner-changed")
+			ACE.MarkContraptionPointsDirty(previousOwner, ent, false, true, "weapon-owner-changed")
 		end
 
 		ent._ACEPointsConRef = con
 		ent._ACEPointsOwnerConRef = con
-		ACE_MarkContraptionPointsDirty(con, ent, true, true, "entity-added")
-		ACE_NotifyCrateWeapons(ent)
+		ACE.MarkContraptionPointsDirty(con, ent, true, true, "entity-added")
+		ACE.NotifyCrateWeapons(ent)
 	end
 
 	-- Handle entity removal and update point totals.
-	function ACE_RemPts(con, ent)
+	function ACE.RemPts(con, ent)
 		if not con then return end
 		ACE_EnsureCFWMassTotal(con, con.ents, ent)
 
@@ -294,21 +294,21 @@ do
 		if valid and ent._ACEPointsConRef == con then ent._ACEPointsConRef = nil end
 		if valid and previous == con then ent._ACEPointsOwnerConRef = nil end
 
-		ACE_MarkContraptionPointsDirty(con, ent, true, true, "entity-removed")
+		ACE.MarkContraptionPointsDirty(con, ent, true, true, "entity-removed")
 
 		if previous and previous ~= con then
-			ACE_MarkContraptionPointsDirty(previous, ent, false, true, "weapon-owner-changed")
+			ACE.MarkContraptionPointsDirty(previous, ent, false, true, "weapon-owner-changed")
 		end
 
-		ACE_NotifyCrateWeapons(ent)
-		if valid and not removing then ACE_PointsInputChanged(ent, "entity-detached") end
+		ACE.NotifyCrateWeapons(ent)
+		if valid and not removing then ACE.PointsInputChanged(ent, "entity-detached") end
 	end
 
 	-- Track point totals when entities are added.
-	hook.Add("cfw.contraption.entityAdded", "ACE_AddPoints", ACE_AddPts)
+	hook.Add("cfw.contraption.entityAdded", "ACE_AddPoints", ACE.AddPts)
 
 	-- Track point totals when entities are removed.
-	hook.Add("cfw.contraption.entityRemoved", "ACE_RemPoints", ACE_RemPts)
+	hook.Add("cfw.contraption.entityRemoved", "ACE_RemPoints", ACE.RemPts)
 end
 
 -- ------------------------------------------------------------
@@ -339,8 +339,8 @@ do
 			return result
 		end
 
-		if ent.IsPrimitive and ACE_PrimitivePropertiesApplied then
-			ACE_PrimitivePropertiesApplied(ent)
+		if ent.IsPrimitive and ACE.PrimitivePropertiesApplied then
+			ACE.PrimitivePropertiesApplied(ent)
 		end
 
 		if math.abs(mass - currentMass) < 0.01 then
@@ -349,8 +349,8 @@ do
 
 		if ent:GetClass() ~= "prop_physics" and not ent.IsPrimitive then return result end
 
-		local con = ACE_GetContraptionFromEntity and ACE_GetContraptionFromEntity(ent)
-		ACE_MarkArmorDirty(con, ent, "mass-changed")
+		local con = ACE.GetContraptionFromEntity and ACE.GetContraptionFromEntity(ent)
+		ACE.MarkArmorDirty(con, ent, "mass-changed")
 
 		return result
 	end
@@ -371,21 +371,21 @@ concommand.Add("ace_cache_clear_all", function()
 end)
 
 -- Mark armor points dirty for callers that know only armor changed.
-function ACE_MarkArmorDirty(con, ent, reason)
+function ACE.MarkArmorDirty(con, ent, reason)
 	if not con then
-		if ACE_ClearArmorPointCache and IsEnt(ent) then ACE_ClearArmorPointCache(ent) end
+		if ACE.ClearArmorPointCache and IsEnt(ent) then ACE.ClearArmorPointCache(ent) end
 		return
 	end
 
-	ACE_MarkContraptionPointsDirty(con, ent, true, false, reason or "armor-updated")
+	ACE.MarkContraptionPointsDirty(con, ent, true, false, reason or "armor-updated")
 end
 
 -- Reprice clipped armor after Proper Clipping replaces its physics object.
 local function ACE_ProperClippingPhysicsChanged(ent)
 	if not IsEnt(ent) then return end
 
-	local con = ACE_GetContraptionFromEntity and ACE_GetContraptionFromEntity(ent)
-	ACE_MarkArmorDirty(con, ent, "armor-clipped")
+	local con = ACE.GetContraptionFromEntity and ACE.GetContraptionFromEntity(ent)
+	ACE.MarkArmorDirty(con, ent, "armor-clipped")
 end
 
 hook.Add("ProperClippingPhysicsClipped", "ACE_ProperClippingArmorChanged", ACE_ProperClippingPhysicsChanged)

--- a/lua/acf/server/sv_crewseat_base.lua
+++ b/lua/acf/server/sv_crewseat_base.lua
@@ -9,7 +9,7 @@ include("acf/shared/sh_crewseat_base.lua")
 local crewseatDebug = CreateConVar("acf_debug_crewseat_models", "0", FCVAR_ARCHIVE, "Log crewseat model/type changes during dupe paste")
 
 -- Resolve a crewseat model type from dupe data or the current model path.
-function ACE_CrewseatResolveModelType(ent, info)
+function ACE.CrewseatResolveModelType(ent, info)
 	if not IsValid(ent) then return nil end
 
 	local modelPath = (info and info.Model) or ent:GetModel()
@@ -34,13 +34,13 @@ function ACE_CrewseatResolveModelType(ent, info)
 end
 
 -- Check whether crewseat model debugging is enabled.
-function ACE_CrewseatDebugEnabled()
+function ACE.CrewseatDebugEnabled()
 	return crewseatDebug:GetBool()
 end
 
 -- Print a crewseat debug line when enabled.
-function ACE_CrewseatDebugLog(ent, stage, info, extra)
-	if not ACE_CrewseatDebugEnabled() then return end
+function ACE.CrewseatDebugLog(ent, stage, info, extra)
+	if not ACE.CrewseatDebugEnabled() then return end
 
 	local owner = "Unknown"
 	if ent.CPPIGetOwner then
@@ -60,7 +60,7 @@ function ACE_CrewseatDebugLog(ent, stage, info, extra)
 end
 
 -- Apply dupe model data with a fallback model type and optional legacy override.
-function ACE_CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitting)
+function ACE.CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitting)
 	local modelType = info.ModelType
 	local legacyLocked = false
 	local reason = "preserved"
@@ -101,18 +101,18 @@ function ACE_CrewseatApplyDupeModel(ent, info, defaultModelType, legacyForceSitt
 end
 
 -- Defer model sync so the duplicator can finish applying model data.
-function ACE_CrewseatDeferredModelSync(ent, info)
+function ACE.CrewseatDeferredModelSync(ent, info)
 	timer.Simple(0, function()
 		if not IsValid(ent) then return end
 		if ent.ACE_LegacyCrewseatModelLocked then return end
 		local beforeModel = ent:GetModel()
 		local beforeType = ent.ModelType
-		local modelType = ACE_CrewseatResolveModelType(ent, info)
+		local modelType = ACE.CrewseatResolveModelType(ent, info)
 		if modelType and (beforeModel ~= ent:GetModel() or beforeType ~= ent.ModelType) then
 			ent.ACE_DupeDeferredModel = ent:GetModel()
 			ent.ACE_DupeDeferredModelType = ent.ModelType
 			ent.ACE_DupeDeferredResolved = modelType
-			ACE_CrewseatDebugLog(ent, "DeferredSync", info, "resolved=" .. tostring(modelType))
+			ACE.CrewseatDebugLog(ent, "DeferredSync", info, "resolved=" .. tostring(modelType))
 		end
 	end)
 end
@@ -180,7 +180,7 @@ local randomSuffixes = {
 	"Garcia", "", "Russel", "King", "Musk", "Popov"
 }
 
-function ACE_GenerateCrewName()
+function ACE.GenerateCrewName()
 	local randomNum = math.random(1, 100)
 
 	if randomNum <= 2 then
@@ -223,7 +223,7 @@ end
 -- Returns:
 --  gMag: number (includes gravity, so resting ~= 1)
 --  gVec: Vector (local-space felt acceleration in Gs; resting ~= (0,0,1))
-function ACE_CalcEntityGForce(ent)
+function ACE.CalcEntityGForce(ent)
 	if not IsValid(ent) then
 		return 1, Vector(0, 0, 1)
 	end
@@ -292,7 +292,7 @@ end
 -- =========================================================
 
 -- Shared initialization for crewseats
-function ACE_InitializeCrewseat(ent, modelType)
+function ACE.InitializeCrewseat(ent, modelType)
 	local class = ent:GetClass()
 
 	-- Validate model type, fallback to default if invalid
@@ -322,7 +322,7 @@ function ACE_InitializeCrewseat(ent, modelType)
 	ent.ACF.MaxHealth = ent.ACF.MaxHealth or 1
 	ent.ACF.Armour = ent.ACF.Armour or 1
 
-	ent.Name = ent.Name or ACE_GenerateCrewName()
+	ent.Name = ent.Name or ACE.GenerateCrewName()
 	ent.Weight = weight
 	ent.AnglePenalty = 0
 	ent.GForcePenalty = 0
@@ -354,7 +354,7 @@ end
 local startPenalty = 45
 local maxPenalty = 90
 
-function ACE_UpdateCrewseatAnglePenalty(ent)
+function ACE.UpdateCrewseatAnglePenalty(ent)
 	-- Clamp dot to avoid NaN from acos
 	local dot = math.Clamp(ent:GetUp():Dot(vec_up), -1, 1)
 	local curSeatAngle = math.deg(math.acos(dot))
@@ -365,8 +365,8 @@ end
 
 -- G-force penalty calculation (0..1)
 -- Penalties start at 2G and max out at 6G
-function ACE_UpdateGForcePenalty(ent)
-	local gTotal, gVec = ACE_CalcEntityGForce(ent) -- gVec is local-space felt G vector; rest ~= (0,0,1)
+function ACE.UpdateGForcePenalty(ent)
+	local gTotal, gVec = ACE.CalcEntityGForce(ent) -- gVec is local-space felt G vector; rest ~= (0,0,1)
 	ent.CurrentGForce = gTotal
 	ent.GForceVector = gVec
 
@@ -379,7 +379,7 @@ function ACE_UpdateGForcePenalty(ent)
 end
 
 -- Crewseat-specific legal check (includes model validation)
-function ACE_CrewseatLegalCheck(ent)
+function ACE.CrewseatLegalCheck(ent)
 	if ACF.CurTime > ent.NextLegalCheck then
 		local currentModel = ent:GetModel()
 		if ent.Model ~= currentModel then
@@ -388,7 +388,7 @@ function ACE_CrewseatLegalCheck(ent)
 
 		ent.Legal, ent.LegalIssues = ACF_CheckLegal(ent, ent.Model, math.Round(ent.Weight, 2), nil, true, true)
 
-		if ent.Legal and not (ACE_IsValidCrewseatModel and ACE_IsValidCrewseatModel(currentModel)) then
+		if ent.Legal and not (ACE.IsValidCrewseatModel and ACE.IsValidCrewseatModel(currentModel)) then
 			ent.Legal = false
 			ent.LegalIssues = "Invalid crewseat model"
 		end
@@ -400,7 +400,7 @@ function ACE_CrewseatLegalCheck(ent)
 end
 
 -- Shared OnRemove
-function ACE_CrewseatOnRemove(ent)
+function ACE.CrewseatOnRemove(ent)
 	for Key in pairs(ent.Master or {}) do
 		if ent.Master[Key] and ent.Master[Key]:IsValid() then
 			ent.Master[Key]:Unlink(ent)
@@ -409,19 +409,19 @@ function ACE_CrewseatOnRemove(ent)
 end
 
 -- Shared damage function
-function ACE_CrewseatDamage(ent, Entity, Energy, FrArea, Inflictor)
+function ACE.CrewseatDamage(ent, Entity, Energy, FrArea, Inflictor)
 	ent.ACF.Armour = 3
 	local HitRes = ACF_PropDamage(Entity, Energy, FrArea, 0, Inflictor)
 	return HitRes
 end
 
 -- Play death sound
-function ACE_CrewseatDeathSound(ent)
+function ACE.CrewseatDeathSound(ent)
 	EmitSound(ent.Sound, ent:GetPos(), 50, CHAN_AUTO, 1, 75, 0, ent.SoundPitch)
 end
 
 -- Find replacement loader seat
-function ACE_FindReplacementLoader(ent, maxDistSqr)
+function ACE.FindReplacementLoader(ent, maxDistSqr)
 	maxDistSqr = maxDistSqr or 624100 -- 20m squared
 
 	local closestDist = math.huge

--- a/lua/acf/server/sv_heat.lua
+++ b/lua/acf/server/sv_heat.lua
@@ -16,7 +16,7 @@
 ----------------------------------------------------------------------------------------/
 
 --[[-------------------------------------------------------------------------------------
-	ACE_InfraredHeatFromProp( self, Target , dist )  --used mostly by infrared guidance
+	ACE.InfraredHeatFromProp( self, Target , dist )  --used mostly by infrared guidance
 
 ->  Input information:
 
@@ -25,7 +25,7 @@
 	dist - distance between the missile and the Target
 
 ]]---------------------------------------------------------------------------------------
-function ACE_InfraredHeatFromProp( Target, dist )
+function ACE.InfraredHeatFromProp( Target, dist )
 
 	if not IsValid(Target) then print("[ACE | WARN]- Unable to track Heat. Target Entity not valid!") return 0 end
 	if not dist then print("[ACE | WARN]- Unable to track Heat. dist not valid!") return end
@@ -53,7 +53,7 @@ function ACE_InfraredHeatFromProp( Target, dist )
 end
 
 --[[-------------------------------------------------------------------------------------
-	ACE_HeatFromGun( Gun, Heat, DeltaTime )  --used by Guns
+	ACE.HeatFromGun( Gun, Heat, DeltaTime )  --used by Guns
 
 ->  Input information:
 
@@ -62,7 +62,7 @@ end
 	DeltaTime - Delta time of this gun
 
 ]]---------------------------------------------------------------------------------------
-function ACE_HeatFromGun( Gun , Heat, DeltaTime )
+function ACE.HeatFromGun( Gun , Heat, DeltaTime )
 
 	local phys = Gun:GetPhysicsObject()
 	local Mass = phys:GetMass()
@@ -90,14 +90,14 @@ function ACE_HeatFromGun( Gun , Heat, DeltaTime )
 end
 
 --[[-------------------------------------------------------------------------------------
-	ACE_HeatFromEngine( Engine , Radiator )  --used mostly by engines
+	ACE.HeatFromEngine( Engine , Radiator )  --used mostly by engines
 
 ->  Input information:
 
 	Engine - The Engine Entity
 
 ]]---------------------------------------------------------------------------------------
-function ACE_HeatFromEngine( Engine )
+function ACE.HeatFromEngine( Engine )
 
 	--bullshiet code below, better using tables next time
 
@@ -170,7 +170,7 @@ function ACE_HeatFromEngine( Engine )
 
 end
 
-function ACE_HeatFromRadar(Radar, Delta)
+function ACE.HeatFromRadar(Radar, Delta)
 	local CurHeat = Radar.Heat
 	local AmbientTemp = ACE.AmbientTemp
 
@@ -195,7 +195,7 @@ end
 
 
 --[[-------------------------------------------------------------------------------------
-	ACE_HeatFromGearbox( Gearbox )  --used mostly by gearboxes. Not used atm
+	ACE.HeatFromGearbox( Gearbox )  --used mostly by gearboxes. Not used atm
 
 ->  Input information:
 
@@ -203,7 +203,7 @@ end
 
 ]]---------------------------------------------------------------------------------------
 --NOTE: disabled until i compile more information about gearbox code. the code works though
-function ACE_HeatFromGearbox( Gearbox , InputRPM )
+function ACE.HeatFromGearbox( Gearbox , InputRPM )
 
 	if not Gearbox:IsValid() then
 		print("Missing Gearbox")
@@ -232,7 +232,7 @@ end
 
 --THIS CODE NEEDS A REWRITE, USELESS ATM BUT I WILL KEEP IT HERE
 --[[
-function ACE_HeatFromEngine( Engine , Radiator )  --radiator?!? woooo
+function ACE.HeatFromEngine( Engine , Radiator )  --radiator?!? woooo
 
 	--print(Engine.EngineType)
 

--- a/lua/acf/server/sv_pointshandling.lua
+++ b/lua/acf/server/sv_pointshandling.lua
@@ -3,7 +3,7 @@ ACE = ACE or {}
 
 include("acf/shared/sh_ace_functions.lua")
 
-local IsEnt = ACE_IsEnt
+local IsEnt = ACE.IsEnt
 
 local function CopyPointTotals(totals)
 	local result = {}
@@ -14,11 +14,11 @@ end
 -- Public point lifecycle hooks:
 -- ACE_OnContraptionPointsInvalidated(con, change) reports every known pricing-input mutation,
 -- even when the cache is already dirty or the resulting point delta is zero. change contains
--- Revision, Entity, Reason, Armor, and NonArmor. Consumers can call ACE_EnsureContraptionPoints
+-- Revision, Entity, Reason, Armor, and NonArmor. Consumers can call ACE.EnsureContraptionPoints
 -- from this hook when they need the updated total immediately.
 -- ACE_OnContraptionPointsRecalculated(con, change) reports Revision, OldTotal, Total, OldByType,
 -- ByType, Armor, and NonArmor as detached snapshots after a rebuild.
-function ACE_NotifyContraptionPointsInvalidated(con, ent, reason, armorDirty, nonArmorDirty)
+function ACE.NotifyContraptionPointsInvalidated(con, ent, reason, armorDirty, nonArmorDirty)
 	if not con then return end
 
 	con.ACEPointsRevision = (con.ACEPointsRevision or 0) + 1
@@ -38,15 +38,15 @@ local function ACE_CalcSubsystem(ents, subsystem)
 	for _, ent in ipairs(ents) do
 		if IsEnt(ent) then
 			local cls = ent:GetClass()
-			if ACE_GetPtsType(cls) == subsystem then
+			if ACE.GetPtsType(cls) == subsystem then
 				local pts
 				if subsystem == "Crew" then
-					pts = ACE_GetCrewSeatPointCost(ent)
+					pts = ACE.GetCrewSeatPointCost(ent)
 				elseif subsystem == "Firepower" and (cls == "acf_gun" or cls == "acf_rack") then
 					-- Never collapse by class or round ID: identical weapons bill independently.
-					pts = ACE_GetGunFirepowerPointsFor(ent, ents)
+					pts = ACE.GetGunFirepowerPointsFor(ent, ents)
 				else
-					pts = ACE_GetEntPoints(ent)
+					pts = ACE.GetEntPoints(ent)
 				end
 
 				if pts ~= 0 then
@@ -66,14 +66,14 @@ end
 -- Calculate non-armor points and readout details. Ammo is free (crates contribute nothing),
 -- so the categories are Engines, Firepower (guns AND racks), Crew and Electronics. The
 -- contraption entity list is resolved ONCE and shared across guns.
-function ACE_CalcNonArmorPoints(con, baseEnt)
+function ACE.CalcNonArmorPoints(con, baseEnt)
 	if not con then
 		return 0, { Engines = 0, Firepower = 0, Crew = 0, Electronics = 0 }
 	end
 
 	local totals = { Engines = 0, Firepower = 0, Crew = 0, Electronics = 0 }
 
-	local ents = ACE_GetContraptionEntities(con, baseEnt)
+	local ents = ACE.GetContraptionEntities(con, baseEnt)
 
 	local subsystems = ACE.PointSubsystems or {
 		"Engines",
@@ -94,13 +94,13 @@ function ACE_CalcNonArmorPoints(con, baseEnt)
 	return nonArmor, totals
 end
 
-function ACE_CalcContraptionArmorPoints(con, baseEnt)
+function ACE.CalcContraptionArmorPoints(con, baseEnt)
 	local total = 0
-	local ents = ACE_GetContraptionEntities(con, baseEnt)
+	local ents = ACE.GetContraptionEntities(con, baseEnt)
 
 	for _, ent in ipairs(ents) do
 		if IsEnt(ent) then
-			local pts = ACE_GetArmorPoints(ent)
+			local pts = ACE.GetArmorPoints(ent)
 			if pts > 0 then
 				total = total + pts
 			end
@@ -111,7 +111,7 @@ function ACE_CalcContraptionArmorPoints(con, baseEnt)
 end
 
 -- Rebuild requested point totals for a contraption from entity state.
-function ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
+function ACE.RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
 	if not con then return end
 
 	local oldPoints = con.ACEPoints or 0
@@ -122,7 +122,7 @@ function ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmo
 	local totals = con.ACEPointsPerType or {}
 
 	if rebuildNonArmor then
-		local nonArmor, nonArmorTotals = ACE_CalcNonArmorPoints(con, base)
+		local nonArmor, nonArmorTotals = ACE.CalcNonArmorPoints(con, base)
 		totals = nonArmorTotals or {}
 
 		con.ACEPointsNonArmor = nonArmor or 0
@@ -130,7 +130,7 @@ function ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmo
 	end
 
 	if rebuildArmor then
-		local armorPts = ACE_CalcContraptionArmorPoints(con, base)
+		local armorPts = ACE.CalcContraptionArmorPoints(con, base)
 
 		con.ACEArmorPoints = armorPts
 		con.ACEArmorDirty = false
@@ -155,14 +155,14 @@ function ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmo
 end
 
 -- Ensure point data is initialized and current.
-function ACE_EnsureContraptionPoints(con, baseEnt, force)
+function ACE.EnsureContraptionPoints(con, baseEnt, force)
 	if not con then return end
 	if con._ACEPointsEnsuring then return end
 
 	con._ACEPointsEnsuring = true
-	if ACE_EnsurePointsState then ACE_EnsurePointsState(con) end
+	if ACE.EnsurePointsState then ACE.EnsurePointsState(con) end
 
-	local cacheStale = ACE_EnsureCacheVersion and ACE_EnsureCacheVersion(con) or false
+	local cacheStale = ACE.EnsureCacheVersion and ACE.EnsureCacheVersion(con) or false
 	local needsInit = not con.ACEArmorCalculated
 	if not force and not needsInit and not con.ACEPointsDirty and not con.ACEArmorDirty
 		and not con.ACENonArmorDirty and not cacheStale then
@@ -173,8 +173,8 @@ function ACE_EnsureContraptionPoints(con, baseEnt, force)
 	local rebuildArmor = force or needsInit or con.ACEArmorDirty or cacheStale
 	local rebuildNonArmor = force or con.ACENonArmorDirty or cacheStale or not con.ACEPointsPerType
 
-	ACE_RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
+	ACE.RebuildContraptionPoints(con, baseEnt, rebuildArmor, rebuildNonArmor)
 	con._ACEPointsEnsuring = nil
 end
 
-_G.ACE_EnsureContraptionPoints = ACE_EnsureContraptionPoints
+_G.ACE.EnsureContraptionPoints = ACE.EnsureContraptionPoints

--- a/lua/acf/shared/ammocrates/acfcratelist.lua
+++ b/lua/acf/shared/ammocrates/acfcratelist.lua
@@ -649,7 +649,7 @@ AmmoTable["Shell170mm"] = Shell170mm
 ACF.Weapons.Ammo = AmmoTable --end ammo containers listing
 
 --Cube
-ACE_DefineModelData("Box",{
+ACE.DefineModelData("Box",{
 
 	Shape = "Box",
 	Model = "models/holograms/rcube_thin.mdl", --Note: The model can be used as ID if needed.
@@ -674,7 +674,7 @@ ACE_DefineModelData("Box",{
 })
 
 --Triangle / Wedge
-ACE_DefineModelData("Wedge",{
+ACE.DefineModelData("Wedge",{
 
 	Shape = "Wedge",
 	Model = "models/holograms/right_prism.mdl",
@@ -697,7 +697,7 @@ ACE_DefineModelData("Wedge",{
 })
 
 --Another type of wedge.
-ACE_DefineModelData("Prism",{
+ACE.DefineModelData("Prism",{
 
 	Shape = "Prism",
 	Model = "models/holograms/prism.mdl",
@@ -722,7 +722,7 @@ ACE_DefineModelData("Prism",{
 local PI = math.pi
 
 --Cylinder
-ACE_DefineModelData("Cylinder",{
+ACE.DefineModelData("Cylinder",{
 
 	Shape = "Cylinder",
 	Model = "models/holograms/hq_rcylinder_thin.mdl",
@@ -758,7 +758,7 @@ ACE_DefineModelData("Cylinder",{
 })
 
 -- The sphere. Dont ask how i got its vertex.
-ACE_DefineModelData("Sphere",{
+ACE.DefineModelData("Sphere",{
 
 	Shape = "Sphere",
 	Model = "models/holograms/hq_sphere.mdl", --Note: The model can be used as ID if needed.
@@ -833,7 +833,7 @@ ACE_DefineModelData("Sphere",{
 })
 
 --Cone
-ACE_DefineModelData("Cone",{
+ACE.DefineModelData("Cone",{
 
 	Shape = "Cone",
 	Model = "models/holograms/hq_cone.mdl",

--- a/lua/acf/shared/ammocrates/ammocrates.lua
+++ b/lua/acf/shared/ammocrates/ammocrates.lua
@@ -3,7 +3,7 @@
 --Ammocrate Shells 75mm -> 170mm
 ------------------------------
 
-ACE_DefineAmmoCrate( "Shell75mm", {
+ACE.DefineAmmoCrate( "Shell75mm", {
 
 	name = "Modular Ammo Crate",
 	desc = "A single 75mm Shell. As an alternative to the bulky ammocrates.\n",
@@ -15,7 +15,7 @@ ACE_DefineAmmoCrate( "Shell75mm", {
 
 })
 
-ACE_DefineAmmoCrate("Shell100mm", {
+ACE.DefineAmmoCrate("Shell100mm", {
 	name = "Modular Ammo Crate",
 	desc = "A single 100mm Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_100mm.mdl",
@@ -25,7 +25,7 @@ ACE_DefineAmmoCrate("Shell100mm", {
 	Height = 36.7,
 })
 
-ACE_DefineAmmoCrate("Shell120mm", {
+ACE.DefineAmmoCrate("Shell120mm", {
 	name = "Modular Ammo Crate",
 	desc = "A single 120mm Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_120mm.mdl",
@@ -35,7 +35,7 @@ ACE_DefineAmmoCrate("Shell120mm", {
 	Height = 44,
 })
 
-ACE_DefineAmmoCrate("Shell120mmAP", {
+ACE.DefineAmmoCrate("Shell120mmAP", {
 	name = "Modular Ammo Crate",
 	desc = "A single 120mm AP Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_120mm_ap.mdl",
@@ -45,7 +45,7 @@ ACE_DefineAmmoCrate("Shell120mmAP", {
 	Height = 44,
 })
 
-ACE_DefineAmmoCrate("Shell140mm", {
+ACE.DefineAmmoCrate("Shell140mm", {
 	name = "Modular Ammo Crate",
 	desc = "A single 140mm Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_130mm.mdl",
@@ -55,7 +55,7 @@ ACE_DefineAmmoCrate("Shell140mm", {
 	Height = 50,
 })
 
-ACE_DefineAmmoCrate("Shell170mm", {
+ACE.DefineAmmoCrate("Shell170mm", {
 	name = "Modular Ammo Crate",
 	desc = "A single 170mm Shell. As an alternative to the bulky ammocrates.\n",
 	model = "models/munitions/round_200mm.mdl",
@@ -66,7 +66,7 @@ ACE_DefineAmmoCrate("Shell170mm", {
 })
 
 --Cube
-ACE_DefineModelData("Box",{
+ACE.DefineModelData("Box",{
 
 	Shape = "Box",
 	Model = "models/holograms/rcube_thin.mdl", --Note: The model can be used as ID if needed.
@@ -91,7 +91,7 @@ ACE_DefineModelData("Box",{
 })
 
 --Triangle / Wedge
-ACE_DefineModelData("Wedge",{
+ACE.DefineModelData("Wedge",{
 
 	Shape = "Wedge",
 	Model = "models/holograms/right_prism.mdl",
@@ -114,7 +114,7 @@ ACE_DefineModelData("Wedge",{
 })
 
 --Another type of wedge.
-ACE_DefineModelData("Prism",{
+ACE.DefineModelData("Prism",{
 
 	Shape = "Prism",
 	Model = "models/holograms/prism.mdl",
@@ -139,7 +139,7 @@ ACE_DefineModelData("Prism",{
 local PI = math.pi
 
 --Cylinder
-ACE_DefineModelData("Cylinder",{
+ACE.DefineModelData("Cylinder",{
 
 	Shape = "Cylinder",
 	Model = "models/holograms/hq_rcylinder_thin.mdl",
@@ -175,7 +175,7 @@ ACE_DefineModelData("Cylinder",{
 })
 
 -- The sphere. Dont ask how i got its vertex.
-ACE_DefineModelData("Sphere",{
+ACE.DefineModelData("Sphere",{
 
 	Shape = "Sphere",
 	Model = "models/holograms/hq_sphere.mdl", --Note: The model can be used as ID if needed.
@@ -250,7 +250,7 @@ ACE_DefineModelData("Sphere",{
 })
 
 --Cone
-ACE_DefineModelData("Cone",{
+ACE.DefineModelData("Cone",{
 
 	Shape = "Cone",
 	Model = "models/holograms/hq_cone.mdl",

--- a/lua/acf/shared/ammocrates/ammocrates_legacy.lua
+++ b/lua/acf/shared/ammocrates/ammocrates_legacy.lua
@@ -1,34 +1,34 @@
 -- A list of legacy crates, used to replace their removed legacy counterparts.
 
-ACE_DefineLegacyAmmoCrate("AmmoSmall", {
+ACE.DefineLegacyAmmoCrate("AmmoSmall", {
 	Length = 22.955019,
 	Width = 8.370775,
 	Height = 14.521590,
 	Offset = 14.521590 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("AmmoMedCube", {
+ACE.DefineLegacyAmmoCrate("AmmoMedCube", {
 	Length = 26.913317,
 	Width = 28.773201,
 	Height = 26.708260,
 	Offset = 26.708260 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("AmmoMedium", {
+ACE.DefineLegacyAmmoCrate("AmmoMedium", {
 	Length = 52.339195,
 	Width = 28.773201,
 	Height = 26.708260,
 	Offset = 26.708260 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("AmmoLarge", {
+ACE.DefineLegacyAmmoCrate("AmmoLarge", {
 	Length = 53.150623,
 	Width = 55.965065,
 	Height = 52.612392,
 	Offset = 52.612392 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("AmmoSuperLarge", {
+ACE.DefineLegacyAmmoCrate("AmmoSuperLarge", {
 	Length = 103.710205,
 	Width = 103.988159,
 	Height = 104.474785,
@@ -38,28 +38,28 @@ ACE_DefineLegacyAmmoCrate("AmmoSuperLarge", {
 ------------------------------
 --Ammocrate 1x1x8 -> 1x1x2
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo1x1x8", {
+ACE.DefineLegacyAmmoCrate("Ammo1x1x8", {
 	Length = 14.416653,
 	Width = 89.584518,
 	Height = 12.141979,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo1x1x6", {
+ACE.DefineLegacyAmmoCrate("Ammo1x1x6", {
 	Length = 14.416653,
 	Width = 66.942780,
 	Height = 12.175970,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo1x1x4", {
+ACE.DefineLegacyAmmoCrate("Ammo1x1x4", {
 	Length = 14.416653,
 	Width = 45.500008,
 	Height = 12.225470,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo1x1x2", {
+ACE.DefineLegacyAmmoCrate("Ammo1x1x2", {
 	Length = 14.416653,
 	Width = 22.871534,
 	Height = 12.225470,
@@ -68,35 +68,35 @@ ACE_DefineLegacyAmmoCrate("Ammo1x1x2", {
 ------------------------------
 --Ammocrate 2x2x1 -> 2x2x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo2x2x1", {
+ACE.DefineLegacyAmmoCrate("Ammo2x2x1", {
 	Length = 22.960443,
 	Width = 8.500000,
 	Height = 20.889492,
 	Offset = 20.889492 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x2x2", {
+ACE.DefineLegacyAmmoCrate("Ammo2x2x2", {
 	Length = 20.500000,
 	Width = 24.781265,
 	Height = 21.528004,
 	Offset = 21.528004 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x2x4", {
+ACE.DefineLegacyAmmoCrate("Ammo2x2x4", {
 	Length = 23.381264,
 	Width = 45.500000,
 	Height = 20.861338,
 	Offset = 20.861338 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x2x6", {
+ACE.DefineLegacyAmmoCrate("Ammo2x2x6", {
 	Length = 25.906490,
 	Width = 68.293823,
 	Height = 22.772511,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x2x8", {
+ACE.DefineLegacyAmmoCrate("Ammo2x2x8", {
 	Length = 25.906490,
 	Width = 91.321205,
 	Height = 22.898911,
@@ -105,35 +105,35 @@ ACE_DefineLegacyAmmoCrate("Ammo2x2x8", {
 ------------------------------
 --Ammocrate 2x3x1 -> 2x3x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo2x3x1", {
+ACE.DefineLegacyAmmoCrate("Ammo2x3x1", {
 	Length = 34.883530,
 	Width = 8.500000,
 	Height = 20.889492,
 	Offset = 20.889492 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x3x2", {
+ACE.DefineLegacyAmmoCrate("Ammo2x3x2", {
 	Length = 34.883530,
 	Width = 20.500000,
 	Height = 20.889492,
 	Offset = 20.889492 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x3x4", {
+ACE.DefineLegacyAmmoCrate("Ammo2x3x4", {
 	Length = 35.227417,
 	Width = 46.708878,
 	Height = 20.500000,
 	Offset = 20.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x3x6", {
+ACE.DefineLegacyAmmoCrate("Ammo2x3x6", {
 	Length = 35.227402,
 	Width = 69.478600,
 	Height = 20.535498,
 	Offset = 20.535498 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x3x8", {
+ACE.DefineLegacyAmmoCrate("Ammo2x3x8", {
 	Length = 35.227402,
 	Width = 91.384796,
 	Height = 20.535498,
@@ -142,35 +142,35 @@ ACE_DefineLegacyAmmoCrate("Ammo2x3x8", {
 ------------------------------
 --Ammocrate 2x4x1 -> 2x4x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo2x4x1", {
+ACE.DefineLegacyAmmoCrate("Ammo2x4x1", {
 	Length = 47.994637,
 	Width = 8.500000,
 	Height = 20.889492,
 	Offset = 20.889492 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x4x2", {
+ACE.DefineLegacyAmmoCrate("Ammo2x4x2", {
 	Length = 45.500000,
 	Width = 23.381268,
 	Height = 20.861338,
 	Offset = 20.861338 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x4x4", {
+ACE.DefineLegacyAmmoCrate("Ammo2x4x4", {
 	Length = 48.338524,
 	Width = 46.708878,
 	Height = 20.500000,
 	Offset = 20.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x4x6", {
+ACE.DefineLegacyAmmoCrate("Ammo2x4x6", {
 	Length = 48.338524,
 	Width = 69.375534,
 	Height = 20.500000,
 	Offset = 20.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo2x4x8", {
+ACE.DefineLegacyAmmoCrate("Ammo2x4x8", {
 	Length = 48.338524,
 	Width = 91.375534,
 	Height = 20.500000,
@@ -179,35 +179,35 @@ ACE_DefineLegacyAmmoCrate("Ammo2x4x8", {
 ------------------------------
 --Ammocrate 3x4x1 -> 3x4x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo3x4x1", {
+ACE.DefineLegacyAmmoCrate("Ammo3x4x1", {
 	Length = 47.994637,
 	Width = 8.500000,
 	Height = 33.000607,
 	Offset = 33.000607 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo3x4x2", {
+ACE.DefineLegacyAmmoCrate("Ammo3x4x2", {
 	Length = 45.500000,
 	Width = 23.381268,
 	Height = 33.013718,
 	Offset = 33.013718 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo3x4x4", {
+ACE.DefineLegacyAmmoCrate("Ammo3x4x4", {
 	Length = 48.338524,
 	Width = 46.708878,
 	Height = 32.500000,
 	Offset = 32.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo3x4x6", {
+ACE.DefineLegacyAmmoCrate("Ammo3x4x6", {
 	Length = 48.338524,
 	Width = 69.375534,
 	Height = 32.500000,
 	Offset = 32.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo3x4x8", {
+ACE.DefineLegacyAmmoCrate("Ammo3x4x8", {
 	Length = 50.202568,
 	Width = 91.375534,
 	Height = 32.500000,
@@ -216,35 +216,35 @@ ACE_DefineLegacyAmmoCrate("Ammo3x4x8", {
 ------------------------------
 --Ammocrate 4x4x1 -> 4x4x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo4x4x1", {
+ACE.DefineLegacyAmmoCrate("Ammo4x4x1", {
 	Length = 48.334381,
 	Width = 46.244804,
 	Height = 11.950006,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo4x4x2", {
+ACE.DefineLegacyAmmoCrate("Ammo4x4x2", {
 	Length = 46.298180,
 	Width = 23.381268,
 	Height = 45.500000,
 	Offset = 45.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo4x4x4", {
+ACE.DefineLegacyAmmoCrate("Ammo4x4x4", {
 	Length = 50.202568,
 	Width = 46.708878,
 	Height = 45.500000,
 	Offset = 45.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo4x4x6", {
+ACE.DefineLegacyAmmoCrate("Ammo4x4x6", {
 	Length = 50.202568,
 	Width = 69.486656,
 	Height = 45.500000,
 	Offset = 45.500000 / 2,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo4x4x8", {
+ACE.DefineLegacyAmmoCrate("Ammo4x4x8", {
 	Length = 50.202568,
 	Width = 91.361649,
 	Height = 45.500000,
@@ -253,14 +253,14 @@ ACE_DefineLegacyAmmoCrate("Ammo4x4x8", {
 ------------------------------
 --Ammocrate 4x6x8 -> 4x6x6
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo4x6x8", {
+ACE.DefineLegacyAmmoCrate("Ammo4x6x8", {
 	Length = 73.274414,
 	Width = 91.361649,
 	Height = 45.424000,
 	Offset = 0,
 })
 
-ACE_DefineLegacyAmmoCrate("Ammo4x6x6", {
+ACE.DefineLegacyAmmoCrate("Ammo4x6x6", {
 	Length = 73.274414,
 	Width = 69.360962,
 	Height = 45.440872,
@@ -269,7 +269,7 @@ ACE_DefineLegacyAmmoCrate("Ammo4x6x6", {
 ------------------------------
 --Ammocrate 4x8x8 -> 4x8x8
 ------------------------------
-ACE_DefineLegacyAmmoCrate("Ammo4x8x8", {
+ACE.DefineLegacyAmmoCrate("Ammo4x8x8", {
 	Length = 95.190125,
 	Width = 91.361649,
 	Height = 45.627903,

--- a/lua/acf/shared/armor/du.lua
+++ b/lua/acf/shared/armor/du.lua
@@ -57,7 +57,7 @@ if SERVER then
 		if breachProb > math.random() and maxPenetration > armor then
 
 			local HEWeight  = math.Min(maxPenetration * 0.001, 30) -- #nonukespls
-			local Radius	= ACE_CalculateHERadius( HEWeight )
+			local Radius	= ACE.CalculateHERadius( HEWeight )
 			local Owner	= (CPPI and Entity:CPPIGetOwner()) or NULL
 			local EntPos	= Entity:GetPos()
 
@@ -86,7 +86,7 @@ if SERVER then
 			if maxPenetration > losArmor * effectiveness then
 
 				local HEWeight  = math.Min(maxPenetration * 0.001, 30) -- #nonukespls
-				local Radius	= ACE_CalculateHERadius( HEWeight )
+				local Radius	= ACE.CalculateHERadius( HEWeight )
 				local Owner	= (CPPI and Entity:CPPIGetOwner()) or NULL
 				local EntPos	= Entity:GetPos()
 

--- a/lua/acf/shared/armor/era.lua
+++ b/lua/acf/shared/armor/era.lua
@@ -114,7 +114,7 @@ if SERVER then
 			--print("----------------------------------------Boom")
 
 			local HEWeight  = math.Min(armor * 0.2, 200) -- #nonukespls
-			local Radius	= ACE_CalculateHERadius( HEWeight )
+			local Radius	= ACE.CalculateHERadius( HEWeight )
 			local Owner	= (CPPI and Entity:CPPIGetOwner()) or NULL
 			local EntPos	= Entity:GetPos()
 

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -10,7 +10,7 @@ Material.year		= 1955
 Material.massMod		= 0.2
 Material.curve		= 0.93
 
-Material.specialeffect  = 20 --Caliber to divide HEAT and spall caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
+Material.specialeffect  = 20 --Caliber to divide HEAT caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
 
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -4,7 +4,7 @@ local Material		= {}
 Material.id			= "Rub"
 Material.name		= "Rubber"
 Material.sname		= "Rubber"
-Material.desc		= "Another material that while useless against kinetic rounds, excels at stopping shaped charges and spall"
+Material.desc		= "Another material that while useless against kinetic rounds, excels at stopping shaped charges"
 Material.year		= 1955
 
 Material.massMod		= 0.2
@@ -25,7 +25,9 @@ Material.HEATresiliance = 2
 
 Material.HEresiliance	= 6
 
-Material.spallresist = 0.75
+-- Spall uses the ordinary kinetic resolver below. This keeps rubber's response thickness-based
+-- and lets ACF_SpallTrace carry the resolver's remaining energy through layered armor.
+Material.spallresist = 0.15
 
 Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
 Material.ArmorMul	= 0.05
@@ -42,6 +44,10 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		if Type == "Spall" then
+			effectiveness = Material.spallresist
+		end
+
 		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
 		local ductilitymult    = 2 / (2 + ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
 
@@ -50,26 +56,19 @@ if SERVER then
 
 
 		--=========================================================================================================\
-		--------------------------------------------------------- For HEAT shells & Spall -------------------------->
+		--------------------------------------------------------- For HEAT shells ---------------------------------->
 		--=========================================================================================================/
 		local validTypes = {
 			["HEAT"] = true,
 			["THEAT"] = true,
 			["HEATFS"] = true,
-			["THEATFS"] = true,
-			["Spall"] = true
+			["THEATFS"] = true
 		}
 
 		if validTypes[Type] then
 
 			local specialeffectiveness  = Material.HEATeffectiveness
 			local specialresiliance	= Material.HEATresiliance
-
-
-			if Type == "Spall" then --Overrides effectiveness values if deflecting spall
-				specialeffectiveness = Material.spallresist
-				specialresiliance = Material.spallresist
-			end
 
 			local DmgResist = 0.01 + math.min(caliber * 10 / Material.specialeffect, 5) * 10 --Caliber in mm / specialeffect. Makes HEAT shells with a larger jet shred rubber more.
 
@@ -169,9 +168,12 @@ if SERVER then
 		--------------------------------------------------------- For AP shells -------------------------->
 		--===============================================================================================/
 		else
+			-- Preserve rubber's existing kinetic overmatch behavior while matching the default
+			-- RHA/spall caliber convention for fragments.
+			local breachCaliber = Type == "Spall" and caliber or caliber * 10
 
 			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
-			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
+			local breachProb = math.Clamp( (breachCaliber / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 
 			-- Penetration probability

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -4,13 +4,13 @@ local Material		= {}
 Material.id			= "Rub"
 Material.name		= "Rubber"
 Material.sname		= "Rubber"
-Material.desc		= "Another material that while useless against kinetic rounds, excels at stopping shaped charges"
+Material.desc		= "Another material that while useless against kinetic rounds, excels at stopping shaped charges and spall"
 Material.year		= 1955
 
 Material.massMod		= 0.2
 Material.curve		= 0.93
 
-Material.specialeffect  = 20 --Caliber to divide HEAT and spall caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
+Material.specialeffect  = 20 --Caliber to divide HEAT caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
 
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.

--- a/lua/acf/shared/crewseats/crewseats.lua
+++ b/lua/acf/shared/crewseats/crewseats.lua
@@ -1,4 +1,4 @@
-ACE_DefineCrewseat("Crewseat_Driver", {
+ACE.DefineCrewseat("Crewseat_Driver", {
 	name = "Driver Seat",
 	ent = "ace_crewseat_driver",
 	desc = "A driver seat for your vehicle. Link to an engine to enable crew functionality.\n\nThe driver can be replaced by a nearby loader if killed.",
@@ -7,7 +7,7 @@ ACE_DefineCrewseat("Crewseat_Driver", {
 	defaultModel = "Sitting",
 })
 
-ACE_DefineCrewseat("Crewseat_Gunner", {
+ACE.DefineCrewseat("Crewseat_Gunner", {
 	name = "Gunner Seat",
 	ent = "ace_crewseat_gunner",
 	desc = "A gunner seat for your vehicle. Link to a gun to enable crew functionality.\n\nHigh G-forces will reduce gunner effectiveness.\nThe gunner can be replaced by a nearby loader if killed.",
@@ -16,7 +16,7 @@ ACE_DefineCrewseat("Crewseat_Gunner", {
 	defaultModel = "Sitting",
 })
 
-ACE_DefineCrewseat("Crewseat_Loader", {
+ACE.DefineCrewseat("Crewseat_Loader", {
 	name = "Loader Seat",
 	ent = "ace_crewseat_loader",
 	desc = "A loader seat for your vehicle. Link to a gun to enable crew functionality.\n\nThe loader has stamina that affects reload speed.\nHigh G-forces will reduce stamina regeneration.\nLoaders can replace dead drivers or gunners.",

--- a/lua/acf/shared/explosives/ace_explosives.lua
+++ b/lua/acf/shared/explosives/ace_explosives.lua
@@ -6,7 +6,7 @@
 -- Pre-built, model-based charges (satchel / aerial bomb / barrel) live in the
 -- spawn (Q) menu under "ACE - Explosives" instead - those are fixed-size props.
 
-ACE_DefineExplosive("ACE Explosive Charge", {
+ACE.DefineExplosive("ACE Explosive Charge", {
 	name = "Explosive Charge",
 	ent  = "ace_explosive",
 	category = "Explosives",

--- a/lua/acf/shared/extras/extras.lua
+++ b/lua/acf/shared/extras/extras.lua
@@ -1,4 +1,4 @@
-ACE_DefineExtras("WindSensor", {
+ACE.DefineExtras("WindSensor", {
 	name = "Wind Sensor",
 	ent = "ace_wind_sensor",
 	category = "Misc",
@@ -8,7 +8,7 @@ ACE_DefineExtras("WindSensor", {
 	acepoints = 0,
 })
 
-ACE_DefineExtras("GForceMeter", {
+ACE.DefineExtras("GForceMeter", {
 	name = "G-Force Meter",
 	ent = "ace_gforce_meter",
 	category = "Misc",

--- a/lua/acf/shared/guidances/b_wire.lua
+++ b/lua/acf/shared/guidances/b_wire.lua
@@ -44,7 +44,7 @@ function this:Configure(missile)
 			local _, LauncherBoundsMax = missile.Launcher:GetCollisionBounds()
 			local OffsetLength = LauncherBoundsMax.x
 
-			self.GuidanceWire = ACE_CreateLinkRope( missile:GetPos(), missile, MissileOffset, launcher, Vector(OffsetLength,0,0) )
+			self.GuidanceWire = ACE.CreateLinkRope( missile:GetPos(), missile, MissileOffset, launcher, Vector(OffsetLength,0,0) )
 			end
 		end
 end

--- a/lua/acf/shared/guidances/d_infrared.lua
+++ b/lua/acf/shared/guidances/d_infrared.lua
@@ -268,7 +268,7 @@ function this:AcquireLock(missile)
 		physEnt = classifyent:GetPhysicsObject()
 
 		if IsValid(physEnt) and physEnt:IsMoveable() then
-			BaseTemp = ACE_InfraredHeatFromProp( classifyent , dist )
+			BaseTemp = ACE.InfraredHeatFromProp( classifyent , dist )
 		end
 
 

--- a/lua/acf/shared/guidances/j_topattackir.lua
+++ b/lua/acf/shared/guidances/j_topattackir.lua
@@ -283,7 +283,7 @@ function this:AcquireLock(missile)
 		physEnt = classifyent:GetPhysicsObject()
 
 		if IsValid(physEnt) and physEnt:IsMoveable() then
-			BaseTemp = ACE_InfraredHeatFromProp( classifyent , dist )
+			BaseTemp = ACE.InfraredHeatFromProp( classifyent , dist )
 		end
 
 

--- a/lua/acf/shared/guns/autocannon.lua
+++ b/lua/acf/shared/guns/autocannon.lua
@@ -136,7 +136,7 @@ do
 end
 
 do
-	ACE_DefineMuzzleFlash("AC", {
+	ACE.DefineMuzzleFlash("AC", {
 
 		muzzlefunc = function( Effect )
 			if not Effect.Emitter then return end

--- a/lua/acf/shared/guns/cannon.lua
+++ b/lua/acf/shared/guns/cannon.lua
@@ -142,7 +142,7 @@ ACF_defineGun("170mmC", {
 } )
 
 do
-	ACE_DefineMuzzleFlash("C", {
+	ACE.DefineMuzzleFlash("C", {
 
 		muzzlefunc = function( Effect )
 			if not Effect.Emitter then return end
@@ -541,7 +541,7 @@ do
 		end,
 	})
 
-	ACE_DefineMuzzleFlash("Default", {
+	ACE.DefineMuzzleFlash("Default", {
 
 		muzzlefunc = function( Effect )
 			if not Effect.Emitter then return end

--- a/lua/acf/shared/guns/machinegun.lua
+++ b/lua/acf/shared/guns/machinegun.lua
@@ -83,7 +83,7 @@ ACF_defineGun("20mmMG", {
 } )
 
 do
-	ACE_DefineMuzzleFlash("MG", {
+	ACE.DefineMuzzleFlash("MG", {
 
 		muzzlefunc = function( Effect )
 

--- a/lua/acf/shared/guns/mortar.lua
+++ b/lua/acf/shared/guns/mortar.lua
@@ -149,7 +149,7 @@ ACF_defineGun("380mmM", {
 } )
 
 do
-	ACE_DefineMuzzleFlash("MO", {
+	ACE.DefineMuzzleFlash("MO", {
 
 		muzzlefunc = function( Effect )
 			if not Effect.Emitter then return end

--- a/lua/acf/shared/guns/rotaryautocannon.lua
+++ b/lua/acf/shared/guns/rotaryautocannon.lua
@@ -64,7 +64,7 @@ do
 end
 
 do
-	ACE_DefineMuzzleFlash("RAC", {
+	ACE.DefineMuzzleFlash("RAC", {
 
 		muzzlefunc = function( Effect )
 			if not Effect.Emitter then return end

--- a/lua/acf/shared/mines/mine_apl.lua
+++ b/lua/acf/shared/mines/mine_apl.lua
@@ -1,6 +1,6 @@
 --[[
 
-    ACE_DefineMine( "Example-ID", {
+    ACE.DefineMine( "Example-ID", {
 
         name               = "Im a Mine", --The full name of the mine.
         model              = "models/cyborgmatt/capacitor_small.mdl", -- The in-game model
@@ -30,7 +30,7 @@
     } )
 ]]
 
-ACE_DefineMine( "APL", {
+ACE.DefineMine( "APL", {
 
     name           = "Conventional Anti-Personnel Landmine",
     model          = "models/jaanus/wiretool/wiretool_range.mdl",
@@ -50,7 +50,7 @@ ACE_DefineMine( "APL", {
     digdepth       = 1.05,
 
 } )
-ACE_DefineMine( "Bounding-APL", {
+ACE.DefineMine( "Bounding-APL", {
 
     name               = "Bounding Anti-Personnel Landmine",
     model              = "models/cyborgmatt/capacitor_small.mdl",

--- a/lua/acf/shared/mines/mine_at.lua
+++ b/lua/acf/shared/mines/mine_at.lua
@@ -1,4 +1,4 @@
-ACE_DefineMine( "ATL", {
+ACE.DefineMine( "ATL", {
 
     name           = "Conventional Anti-Tank Landmine",
     model          = "models/maxofs2d/button_02.mdl",

--- a/lua/acf/shared/rounds/ace_roundfunctions.lua
+++ b/lua/acf/shared/rounds/ace_roundfunctions.lua
@@ -91,7 +91,7 @@ do
 		local D0 = DragCoef * V0 ^ 2 / ACF.DragDiv -- initial drag
 		local K1 = (D0 / (V0 ^ (3 / 2))) ^ -1 -- estimated drag coefficient
 		local Vel = math.max(math.sqrt(V0) - ((Range * 39.37) / (2 * K1)), 0) ^ 2
-		local Pen = ACE_CalcPenetration(ACF_Kinetic(Vel, ProjMass, LimitVel), PenArea)
+		local Pen = ACE.CalcPenetration(ACF_Kinetic(Vel, ProjMass, LimitVel), PenArea)
 
 		return Vel * 0.0254, Pen
 	end
@@ -137,7 +137,7 @@ do
 
 		local toInche = 2.54		--Number used for cm -> inche conversion
 
-		function ACE_AmmoCapacity( Data )
+		function ACE.AmmoCapacity( Data )
 
 			local GunId	= acfmenupanel.AmmoData.Data.id
 			local AmmoGunData = ACF.Weapons.Guns[GunId]
@@ -161,7 +161,7 @@ do
 			local Id		= acfmenupanel.AmmoData.Id
 			local Dimensions = vector_origin
 
-			if not ACE_CheckAmmo( Id ) then
+			if not ACE.CheckAmmo( Id ) then
 				Dimensions = CreateRealScale(Id)
 			else
 				local AmmoData	= ACF.Weapons.Ammo[Id]
@@ -194,9 +194,9 @@ do
 		end
 
 		--General Ammo Capacity diplay shown on ammo config
-		function ACE_AmmoCapacityDisplay(Data)
+		function ACE.AmmoCapacityDisplay(Data)
 
-			local Cap, RoFNerf, TwoPiece = ACE_AmmoCapacity( Data )
+			local Cap, RoFNerf, TwoPiece = ACE.AmmoCapacity( Data )
 
 			local plur = "" .. Cap .. " " .. (Cap > 1 and "rounds" or "round")
 
@@ -210,7 +210,7 @@ do
 
 	end
 
-	function ACE_AmmoRangeStats( MuzzleVel, DragCoef, ProjMass, PenArea, LimitVel )
+	function ACE.AmmoRangeStats( MuzzleVel, DragCoef, ProjMass, PenArea, LimitVel )
 
 		local Range	= {}
 		Range.Vel		= {}
@@ -231,7 +231,7 @@ do
 
 	end
 
-	function ACE_AmmoStats(RoundLenght, MaxTotalLenght, MuzzleVel, MaxPen)
+	function ACE.AmmoStats(RoundLenght, MaxTotalLenght, MuzzleVel, MaxPen)
 	acfmenupanel:CPanelText("BoldAmmoStats", "Round information: ", "DermaDefaultBold")
 	acfmenupanel:CPanelText("AmmoStats", "Round Length: " .. RoundLenght .. "/" .. MaxTotalLenght .. " cms (" .. math.Round(RoundLenght / 2.54, 2) .. " inches)\nMuzzle Velocity: " .. MuzzleVel .. " m\\s\nMax penetration: " .. MaxPen .. " mm RHA") --Total round length (Name, Desc)
 
@@ -239,7 +239,7 @@ do
 
 	do
 
-		function ACE_UpperCommonDataDisplay( Data, PlayerData )
+		function ACE.UpperCommonDataDisplay( Data, PlayerData )
 
 			if not acfmenupanel then return end
 
@@ -248,14 +248,14 @@ do
 
 				acfmenupanel:CPanelText("BonusDisplay", "\n")
 				acfmenupanel:CPanelText("Desc", "")
-				ACE_AmmoStats( 0, 0, 0, 0 )
+				ACE.AmmoStats( 0, 0, 0, 0 )
 
 			else
 				acfmenupanel:CPanelText("CrateInfoBold", "Crate information:", "DermaDefaultBold")
 
-				ACE_AmmoCapacityDisplay( Data )
+				ACE.AmmoCapacityDisplay( Data )
 				acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc)
-				ACE_AmmoStats(Floor((Data.PropLength + Data.ProjLength + (Floor(Data.Tracer * 5) / 10)) * 100) / 100, Data.MaxTotalLength, Floor(Data.MuzzleVel * ACF.VelScale), Floor(Data.MaxPen))
+				ACE.AmmoStats(Floor((Data.PropLength + Data.ProjLength + (Floor(Data.Tracer * 5) / 10)) * 100) / 100, Data.MaxTotalLength, Floor(Data.MuzzleVel * ACF.VelScale), Floor(Data.MaxPen))
 			end
 
 		end
@@ -264,7 +264,7 @@ do
 		local TPtip = "Attempts to increase the ammo capacity by dividing the round in 2 pieces, at the cost of more reload time.\n\nWorks with rounds above 50mm and does nothing for missiles/bombs or when the cap cannot be increased."
 		local Trtip = "Adds a trail to the shell, which will be seen during the flight. \nUseful for cases when you want to correct trayectories.\n\nProTip: Apply a color to the crate to change the tracer color."
 
-		function ACE_CommonDataDisplay( Data )
+		function ACE.CommonDataDisplay( Data )
 
 			if not acfmenupanel then return end
 
@@ -282,12 +282,12 @@ do
 				local None, Mean, Max = ACF_RicoProbability(Data.Ricochet, Data.MuzzleVel * ACF.VelScale)
 				acfmenupanel:CPanelText("RicoDisplay", "0% chance of ricochet at: " .. None .. "°\n50% chance of ricochet at: " .. Mean .. "°\n100% chance of ricochet at: " .. Max .. "°")
 
-				ACE_AmmoRangeStats( Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel )
+				ACE.AmmoRangeStats( Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel )
 			end
 		end
 
 		--Because HE/Shaped rounds are different. Intented not to be merged into main function above, as its temporal.
-		function ACE_Checkboxes( Data )
+		function ACE.Checkboxes( Data )
 
 			if not acfmenupanel then return end
 

--- a/lua/acf/shared/rounds/roundap.lua
+++ b/lua/acf/shared/rounds/roundap.lua
@@ -61,7 +61,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
-	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 
@@ -190,12 +190,12 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.AP )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_CommonDataDisplay()
+	ACE.CommonDataDisplay()
 
 	Round.guiupdate( Panel, Table )
 
@@ -223,8 +223,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.PropMass, 1)) .. " kg" )  --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 
 end
 

--- a/lua/acf/shared/rounds/roundapds.lua
+++ b/lua/acf/shared/rounds/roundapds.lua
@@ -122,7 +122,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
-	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 
@@ -251,7 +251,7 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.APDS )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
@@ -292,8 +292,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("SCalMult",Data.SCalMult,Data.MinCalMult,Data.MaxCalMult,2, "Subcaliber Size Multiplier", "Caliber : " .. math.floor(Data.Caliber * math.min(PlayerData.Data5,Data.MaxCalMult) * 10) .. " mm") --Subcaliber round slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 
 end
 

--- a/lua/acf/shared/rounds/roundapfsds.lua
+++ b/lua/acf/shared/rounds/roundapfsds.lua
@@ -101,7 +101,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
-	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(Energy, Data.PenArea)
 	return GUIData
 end
 
@@ -229,7 +229,7 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.APFSDS )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
@@ -270,8 +270,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("SCalMult",Data.SCalMult,Data.MinCalMult,Data.MaxCalMult,2, "Subcaliber Size Multiplier", "Caliber : " .. math.floor(Data.Caliber * math.min(PlayerData.Data5,Data.MaxCalMult) * 10) .. " mm") --Subcaliber round slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 
 end
 

--- a/lua/acf/shared/rounds/roundaphe.lua
+++ b/lua/acf/shared/rounds/roundaphe.lua
@@ -80,7 +80,7 @@ function Round.getDisplayData(Data)
 	local Energy		= ACF_Kinetic( Data.MuzzleVel * 39.37 , Data.ProjMass, Data.LimitVel )
 	local FragMass	= Data.ProjMass - Data.FillerMass
 
-	GUIData.MaxPen	= ACE_CalcPenetration(Energy, Data.PenArea)
+	GUIData.MaxPen	= ACE.CalcPenetration(Energy, Data.PenArea)
 	GUIData.BlastRadius = Data.FillerMass ^ 0.33 * 8
 	GUIData.Fragments	= math.max(math.floor((Data.FillerMass / FragMass) * ACF.HEFrag),2)
 	GUIData.FragMass	= FragMass / GUIData.Fragments
@@ -219,7 +219,7 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.APHE )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
@@ -270,8 +270,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:CPanelText("BlastDisplay", "Blast Radius : " .. (math.floor(Data.BlastRadius * 100) / 100) .. " m")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("FragDisplay", "Fragments : " .. Data.Fragments .. "\n Average Fragment Weight : " .. (math.floor(Data.FragMass * 10000) / 10) .. " g \n Average Fragment Velocity : " .. math.floor(Data.FragVel) .. " m/s") --Proj muzzle penetration (Name, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 
 end
 

--- a/lua/acf/shared/rounds/roundchaff.lua
+++ b/lua/acf/shared/rounds/roundchaff.lua
@@ -236,7 +236,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength,Data.MinPropLength,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)

--- a/lua/acf/shared/rounds/roundclusterap.lua
+++ b/lua/acf/shared/rounds/roundclusterap.lua
@@ -333,7 +333,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ClusterMult",0,0,100,1, "Cluster Multiplier (%)", "")
 	acfmenupanel:AmmoSlider("FuseDistance",0,500,6000,2, "Cluster Fuse Distance", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	Round.guiupdate( Panel, Table )
 
@@ -363,7 +363,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:CPanelText("VelocityDisplay", "Muzzle Velocity : " .. math.floor(Data.MuzzleVel * ACF.VelScale) .. " m/s") --Proj muzzle velocity (Name, Desc)
 
@@ -373,7 +373,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ClusterMult",Data.ClusterMult,10,100,1, "Cluster Multiplier (%)", "Bomblets: " .. Data.BombletCount)	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FuseDistance",Data.FuseDistance,500,6000,2, "Cluster Fuse Distance", "")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundclusterhe.lua
+++ b/lua/acf/shared/rounds/roundclusterhe.lua
@@ -355,7 +355,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ClusterMult",0,0,100,1, "Cluster Multiplier (%)", "")
 	acfmenupanel:AmmoSlider("FuseDistance",0,500,6000,2, "Cluster Fuse Distance", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
 	acfmenupanel:CPanelText("FragDisplay", "")  --HE Fragmentation data (Name, Desc)
@@ -390,7 +390,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:CPanelText("VelocityDisplay", "Muzzle Velocity : " .. math.floor(Data.MuzzleVel * ACF.VelScale) .. " m/s") --Proj muzzle velocity (Name, Desc)
 
@@ -401,7 +401,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ClusterMult",Data.ClusterMult,10,100,1, "Cluster Multiplier (%)", "Bomblets: " .. Data.BombletCount)	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FuseDistance",Data.FuseDistance,500,6000,2, "Cluster Fuse Distance", "")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundclusterheat.lua
+++ b/lua/acf/shared/rounds/roundclusterheat.lua
@@ -426,7 +426,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ClusterMult",0,0,100,1, "Cluster Multiplier (%)", "")
 	acfmenupanel:AmmoSlider("FuseDistance",0,500,6000,2, "Cluster Fuse Distance", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
 	acfmenupanel:CPanelText("FragDisplay", "")  --HE Fragmentation data (Name, Desc)
@@ -463,7 +463,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:CPanelText("VelocityDisplay", "Muzzle Velocity : " .. math.floor(Data.MuzzleVel * ACF.VelScale) .. " m/s") --Proj muzzle velocity (Name, Desc)
 
@@ -475,7 +475,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ClusterMult",Data.ClusterMult,10,100,1, "Cluster Multiplier (%)", "Bomblets: " .. Data.BombletCount)	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FuseDistance",Data.FuseDistance,500,6000,2, "Cluster Fuse Distance", "")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundfl.lua
+++ b/lua/acf/shared/rounds/roundfl.lua
@@ -136,7 +136,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic( Data["MuzzleVel"] * 39.37 , Data["FlechetteMass"], Data["LimitVel"] )
-	GUIData["MaxPen"] = ACE_CalcPenetration(Energy, Data["FlechettePenArea"])
+	GUIData["MaxPen"] = ACE.CalcPenetration(Energy, Data["FlechettePenArea"])
 	return GUIData
 end
 
@@ -278,14 +278,14 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist["FL"] )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("Flechettes",2,3,128,0, "Flechettes", "")	--flechette count Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FlechetteSpread",10,5,60,1, "Flechette Spread", "")	--flechette spread Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_CommonDataDisplay()
+	ACE.CommonDataDisplay()
 
 	Round.guiupdate( Panel, Table )
 
@@ -320,8 +320,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("Flechettes",Data.Flechettes,Data.MinFlechettes,Data.MaxFlechettes,0, "Flechettes", "Flechette Radius: " .. math.Round(Data["FlechetteRadius"] * 10,2) .. " mm")
 	acfmenupanel:AmmoSlider("FlechetteSpread",Data.FlechetteSpread,Data.MinSpread,Data.MaxSpread,1, "Flechette Spread", "")
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 end
 
 list.Set( "APRoundTypes", "FL", Round )

--- a/lua/acf/shared/rounds/roundflare.lua
+++ b/lua/acf/shared/rounds/roundflare.lua
@@ -236,7 +236,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength,Data.MinPropLength,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)

--- a/lua/acf/shared/rounds/roundglgm.lua
+++ b/lua/acf/shared/rounds/roundglgm.lua
@@ -70,7 +70,7 @@ function Round.create( Gun, BulletData )
 	local BData = table.Copy( BulletData ) --Done so we don't accidentally write to the original crate bulletdata
 	BData.BulletData = nil
 
-	BData.Type = ACE_GetMissileWarheadType(BulletData.Type or "GLATGM")
+	BData.Type = ACE.GetMissileWarheadType(BulletData.Type or "GLATGM")
 	--BData.Id = 2	
 
 	BData.FakeCrate = ents.Create("acf_fakecrate2")
@@ -186,7 +186,7 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
-	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	local EffectiveFragMass = math.max(Data.CasingMass or 0, (Data.BoomFillerMass or 0) * 40)
@@ -395,7 +395,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ConeAng",0,0,1000,3, "HEAT Cone Angle", "")
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "Total HEAT Warhead volume", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "")	--HE Blast data (Name, Desc)
@@ -432,14 +432,14 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength,Data.MinPropLength,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ConeAng",Data.ConeAng,Data.MinConeAng,Data.MaxConeAng,0, "Crush Cone Angle", "")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc)	--Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + Data.Tracer) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm")	--Total round length (Name, Desc)
 	acfmenupanel:CPanelText("VelocityDisplay", "Relative Thrust: " .. math.Round((15 / Data.Caliber * Data.MuzzleVel / 200) * 44, 1) .. " m/s^2")	--Proj muzzle velocity (Name, Desc)
@@ -453,13 +453,13 @@ function Round.guiupdate( Panel )
 	-------------------------------------------------------------------------------
 
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R1P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R2P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R3P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R4P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.Round(R1P,0) .. "mm @ " .. math.Round(R1V,0) .. " m\\s\n200m pen: " .. math.Round(R2P,0) .. "mm @ " .. math.Round(R2V,0) .. " m\\s\n400m pen: " .. math.Round(R3P,0) .. "mm @ " .. math.Round(R3V,0) .. " m\\s\n800m pen: " .. math.Round(R4P,0) .. "mm @ " .. math.Round(R4V,0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n")	--Proj muzzle penetration (Name, Desc)
 

--- a/lua/acf/shared/rounds/roundglgmhe.lua
+++ b/lua/acf/shared/rounds/roundglgmhe.lua
@@ -69,7 +69,7 @@ function Round.create( Gun, BulletData )
 	local BData = table.Copy( BulletData ) --Done so we don't accidentally write to the original crate bulletdata
 	BData.BulletData = nil
 
-	BData.Type = ACE_GetMissileWarheadType(BulletData.Type or "GLATGM-HE")
+	BData.Type = ACE.GetMissileWarheadType(BulletData.Type or "GLATGM-HE")
 	--BData.Id = 2	
 
 	BData.FakeCrate = ents.Create("acf_fakecrate2")
@@ -266,7 +266,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:CPanelText("BlastPenDisplay", "")  							--HE Fragmentation data (Name, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "HE Filler", "")			--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")  --Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
@@ -298,14 +298,14 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.PropMass, 1)) .. " kg" )  --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:CPanelText("BlastPenDisplay", "Max Blast Penetration: " .. math.floor(Data.FillerMass * ACF.HEPower / ACF.HEBlastPenetration,1) .. " mm")
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundhe.lua
+++ b/lua/acf/shared/rounds/roundhe.lua
@@ -205,7 +205,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:CPanelText("BlastPenDisplay", "")  							--HE Fragmentation data (Name, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "HE Filler", "")			--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")  --Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
@@ -237,14 +237,14 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.PropMass, 1)) .. " kg" )  --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:CPanelText("BlastPenDisplay", "Max Blast Penetration: " .. math.floor(Data.FillerMass * ACF.HEPower / ACF.HEBlastPenetration,1) .. " mm")
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.FillerMass, 1)) .. " kg")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundheat.lua
+++ b/lua/acf/shared/rounds/roundheat.lua
@@ -133,7 +133,7 @@ function Round.getDisplayData(Data)
 
 	local SlugEnergy	= ACF_Kinetic( Data.SlugMV * 39.37 , Data.SlugMass, 999999 )
 
-	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
 	GUIData.FragMass = Data.CasingMass / GUIData.Fragments
@@ -364,7 +364,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ConeAng",0,0,1000,3, "HEAT Cone Angle", "")
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "Total HEAT Warhead volume", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")  --Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
@@ -401,14 +401,14 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. math.floor(Data.PropMass * 1000) .. " g" .. "/ " .. math.Round(Data.PropMass, 1) .. " kg") --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. math.floor(Data.ProjMass * 1000) .. " g" .. "/ " .. math.Round(Data.ProjMass, 1) .. " kg") --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ConeAng", Data.ConeAng, Data.MinConeAng, Data.MaxConeAng, 0, "Crush Cone Angle", "") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FillerVol", Data.FillerVol, Data.MinFillerVol, Data.MaxFillerVol, 3, "HE Filler Volume", "HE Filler Mass : " .. math.floor(Data.FillerMass * 1000) .. " g") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)
@@ -425,15 +425,15 @@ function Round.guiupdate( Panel )
 	--HEAT doesnt lose Pen by distance, so its ok to say MaxPen on every value below
 
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R1P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R2P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R3P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R4P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R5V, R5P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea * ACF.HEATPlungingReduction, Data.LimitVel, 100)
-	R5P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea * ACF.HEATPlungingReduction)
+	R5P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea * ACF.HEATPlungingReduction)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.floor(R1P, 0) .. "mm @ " .. math.floor(R1V, 0) .. " m\\s\n200m pen: " .. math.floor(R2P, 0) .. "mm @ " .. math.floor(R2V, 0) .. " m\\s\n400m pen: " .. math.floor(R3P, 0) .. "mm @ " .. math.floor(R3V, 0) .. " m\\s\n800m pen: " .. math.floor(R4P, 0) .. "mm @" .. math.floor(R4V, 0) .. " m\\s\n\nIf using Plunging Fuse: " .. math.floor(R5P, 0) .. "mm @ " .. math.floor(R5V, 0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n") --Proj muzzle penetration (Name, Desc)
 end

--- a/lua/acf/shared/rounds/roundheatfs.lua
+++ b/lua/acf/shared/rounds/roundheatfs.lua
@@ -135,7 +135,7 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
-	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(SlugEnergy, Data.SlugPenArea)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
@@ -363,7 +363,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ConeAng",0,0,1000,3, "HEAT Cone Angle", "")
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "Total HEAT Warhead volume", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "")	--HE Blast data (Name, Desc)
@@ -400,7 +400,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength, Data.MinPropLength + (Data.Caliber * 3.9) ,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
@@ -408,7 +408,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ConeAng",Data.ConeAng,Data.MinConeAng,Data.MaxConeAng,0, "Crush Cone Angle", "")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)
@@ -422,13 +422,13 @@ function Round.guiupdate( Panel )
 
 	-------------------------------------------------------------------------------
 	local R1V, R1P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 100)
-	R1P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R1P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R2V, R2P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 200)
-	R2P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R2P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R3V, R3P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 400)
-	R3P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R3P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 	local R4V, R4P = ACF_PenRanging(Data.MuzzleVel, Data.DragCoef, Data.ProjMass, Data.PenArea, Data.LimitVel, 800)
-	R4P = ACE_CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
+	R4P = ACE.CalcPenetration(ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999), Data.SlugPenArea)
 
 	acfmenupanel:CPanelText("SlugDisplay", "Penetrator Mass : " .. (math.floor(Data.SlugMass * 10000) / 10) .. " g \nPenetrator Caliber : " .. (math.floor(Data.SlugCaliber * 100) / 10) .. " mm \nPenetrator Velocity : " .. math.floor(Data.MuzzleVel + Data.SlugMV) .. " m/s \nMax Penetration : " .. math.floor(Data.MaxPen) .. " mm RHA\n\n100m pen: " .. math.floor(R1P, 0) .. "mm @ " .. math.floor(R1V, 0) .. " m\\s\n200m pen: " .. math.floor(R2P, 0) .. "mm @ " .. math.floor(R2V, 0) .. " m\\s\n400m pen: " .. math.floor(R3P, 0) .. "mm @ " .. math.floor(R3V, 0) .. " m\\s\n800m pen: " .. math.floor(R4P, 0) .. "mm @ " .. math.floor(R4V, 0) .. " m\\s\n\nThe range data is an approximation and may not be entirely accurate.\n") --Proj muzzle penetration (Name, Desc)
 end

--- a/lua/acf/shared/rounds/roundhefs.lua
+++ b/lua/acf/shared/rounds/roundhefs.lua
@@ -209,7 +209,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:CPanelText("BlastPenDisplay", "")  							--HE Fragmentation data (Name, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "HE Filler", "")			--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "")	--HE Blast data (Name, Desc)
@@ -242,14 +242,14 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.PropMass, 1)) .. " kg" )  --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g" .. "/ " .. (math.Round(Data.ProjMass, 1)) .. " kg")  --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:CPanelText("BlastPenDisplay", "Max Blast Penetration: " .. math.floor(Data.FillerMass * ACF.HEPower / ACF.HEBlastPenetration,1) .. " mm")
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundhesh.lua
+++ b/lua/acf/shared/rounds/roundhesh.lua
@@ -129,7 +129,7 @@ function Round.propimpact( _, Bullet, Target, _, HitPos, Bone ) --Hitnormal not 
 		local Energy = ACF_Kinetic(Speed, ImpactMass, Bullet.LimitVel)
 
 		local Mat		= Target.ACF.Material or "RHA"
-		local MatData	= ACE_GetMaterialData( Mat )
+		local MatData	= ACE.GetMaterialData( Mat )
 
 		local Pen = Bullet.FillerMass / 300 * ACF.HEPower
 		if ( Pen * 1.25 ) > ( Target.ACF.Armour * (MatData.ArmorMul or 1) ) then
@@ -228,7 +228,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "HE Filler", "")			--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "")	--HE Blast data (Name, Desc)
@@ -261,13 +261,13 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength,Data.MinPropLength,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FillerVol",Data.FillerVol,Data.MinFillerVol,Data.MaxFillerVol,3, "HE Filler Volume", "HE Filler Mass : " .. (math.floor(Data.FillerMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundhp.lua
+++ b/lua/acf/shared/rounds/roundhp.lua
@@ -70,7 +70,7 @@ function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
 	GUIData.MaxKETransfert = Energy.Kinetic * Data.ShovePower
-	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea)
+	GUIData.MaxPen = ACE.CalcPenetration(Energy, Data.PenArea)
 
 	return GUIData
 end
@@ -113,7 +113,7 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.HP )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
@@ -155,8 +155,8 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("CavVol",Data.CavVol,Data.MinCavVol,Data.MaxCavVol,2, "Hollow Point Cavity Volume", "Expanded caliber : " .. (math.floor(Data.ExpCaliber * 10)) .. " mm") --Hollow Point Cavity Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 end
 
 list.Set( "APRoundTypes", "HP", Round )

--- a/lua/acf/shared/rounds/roundhvap.lua
+++ b/lua/acf/shared/rounds/roundhvap.lua
@@ -75,7 +75,7 @@ end
 function Round.getDisplayData(Data)
 	local GUIData = {}
 	local Energy = ACF_Kinetic(Data.MuzzleVel * 39.37, Data.ProjMass, Data.LimitVel)
-	GUIData.MaxPen = ACE_CalcPenetration(Energy, Data.PenArea, 1.055)
+	GUIData.MaxPen = ACE.CalcPenetration(Energy, Data.PenArea, 1.055)
 
 	return GUIData
 end
@@ -219,7 +219,7 @@ function Round.guicreate( Panel, Table )
 
 	acfmenupanel:AmmoSelect( ACF.AmmoBlacklist.HVAP )
 
-	ACE_UpperCommonDataDisplay()
+	ACE.UpperCommonDataDisplay()
 
 	acfmenupanel:AmmoSlider("PropLength",0,0,1000,3, "Propellant Length", "")	--Propellant Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",0,0,1000,3, "Projectile Length", "")	--Projectile Length Slider (Name, Value, Min, Max, Decimals, Title, Desc)
@@ -260,8 +260,8 @@ function Round.guiupdate( Panel )
 
 	acfmenupanel:AmmoSlider("SCalMult",Data.SCalMult,Data.MinCalMult,Data.MaxCalMult,2, "Subcaliber Size Multiplier", "Caliber : " .. math.floor(Data.Caliber * math.min(PlayerData.Data5,Data.MaxCalMult) * 10) .. " mm") --Subcaliber round slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_UpperCommonDataDisplay( Data, PlayerData )
-	ACE_CommonDataDisplay( Data )
+	ACE.UpperCommonDataDisplay( Data, PlayerData )
+	ACE.CommonDataDisplay( Data )
 
 end
 

--- a/lua/acf/shared/rounds/roundsmoke.lua
+++ b/lua/acf/shared/rounds/roundsmoke.lua
@@ -267,7 +267,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("WPVol",0,0,1000,3, "WP Filler", "")			--Slider (Name, Value, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FuseLength",0,0,1000,3, "Timed Fuse", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")	--Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "")	--HE Blast data (Name, Desc)
@@ -303,7 +303,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength",Data.PropLength,Data.MinPropLength,Data.MaxTotalLength,3, "Propellant Length", "Propellant Mass : " .. (math.floor(Data.PropMass * 1000)) .. " g" )	--Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength",Data.ProjLength,Data.MinProjLength,Data.MaxTotalLength,3, "Projectile Length", "Projectile Mass : " .. (math.floor(Data.ProjMass * 1000)) .. " g")	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
@@ -311,7 +311,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("WPVol",Data.WPVol,Data.MinFillerVol,Data.MaxFillerVol,3, "WP Filler Volume", "WP Filler Mass : " .. (math.floor(Data.WPMass * 1000)) .. " g")	--HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("FuseLength",Data.FuseLength,0,10,1, "Fuse Time", Data.FuseLength .. " s")
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc)	--Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm")	--Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundtheat.lua
+++ b/lua/acf/shared/rounds/roundtheat.lua
@@ -159,8 +159,8 @@ function Round.getDisplayData(Data)
 	local SlugEnergy	= ACF_Kinetic( Data.SlugMV * 39.37 , Data.SlugMass, 999999 )
 	local SlugEnergy2	= ACF_Kinetic( Data.SlugMV2 * 39.37 , Data.SlugMass2, 999999 )
 
-	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
-	GUIData.MaxPen2 = ACE_CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
+	GUIData.MaxPen = ACE.CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen2 = ACE.CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
 
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
@@ -457,7 +457,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("HEAllocation",0,0,1000,2, "HE Filler Allocation", "")
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "Total HEAT Warhead volume", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")  --Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
@@ -499,7 +499,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength, Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. math.floor(Data.PropMass * 1000) .. " g" .. "/ " .. math.Round(Data.PropMass, 1) .. " kg") --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. math.floor(Data.ProjMass * 1000) .. " g" .. "/ " .. math.Round(Data.ProjMass, 1) .. " kg") --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)	--Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
@@ -508,7 +508,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("FillerVol", Data.FillerVol, Data.MinFillerVol, Data.MaxFillerVol, 3, "HE Filler Volume", "HE Filler Mass : " .. math.floor(Data.FillerMass * 1000) .. " g") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("HEAllocation", Data.HEAllocation, 0.05, 0.95, 2, "HE Filler Distribution", "HE Filler Ratio : " .. math.floor((1 - Data.HEAllocation) * 100) .. "% (1st), " .. math.floor(Data.HEAllocation * 100) .. "% (2nd)") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/rounds/roundtheatfs.lua
+++ b/lua/acf/shared/rounds/roundtheatfs.lua
@@ -145,8 +145,8 @@ function Round.getDisplayData(Data)
 
 	local SlugEnergy = ACF_Kinetic(Data.SlugMV * 39.37, Data.SlugMass, 999999)
 	local SlugEnergy2 = ACF_Kinetic(Data.SlugMV2 * 39.37, Data.SlugMass2, 999999)
-	GUIData.MaxPen = ACE_CalcPenetration(SlugEnergy, Data.SlugPenArea)
-	GUIData.MaxPen2 = ACE_CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
+	GUIData.MaxPen = ACE.CalcPenetration(SlugEnergy, Data.SlugPenArea)
+	GUIData.MaxPen2 = ACE.CalcPenetration(SlugEnergy2, Data.SlugPenArea2)
 	--GUIData.BlastRadius = (Data.FillerMass/2) ^ 0.33 * 5*10
 	GUIData.BlastRadius = Data.BoomFillerMass ^ 0.33 * 8 -- * 39.37
 	GUIData.Fragments = math.max(math.floor((Data.BoomFillerMass / Data.CasingMass) * ACF.HEFrag), 2)
@@ -410,7 +410,7 @@ function Round.guicreate( Panel, Table )
 	acfmenupanel:AmmoSlider("HEAllocation",0,0,1000,2, "HE Filler Allocation", "")
 	acfmenupanel:AmmoSlider("FillerVol",0,0,1000,3, "Total HEAT Warhead volume", "")
 
-	ACE_Checkboxes()
+	ACE.Checkboxes()
 
 	acfmenupanel:CPanelText("VelocityDisplay", "")  --Proj muzzle velocity (Name, Desc)
 	acfmenupanel:CPanelText("BlastDisplay", "") --HE Blast data (Name, Desc)
@@ -452,7 +452,7 @@ function Round.guiupdate( Panel )
 	RunConsoleCommand( "acfmenu_data11", Data.TwoPiece )
 
 	---------------------------Ammo Capacity-------------------------------------
-	ACE_AmmoCapacityDisplay( Data )
+	ACE.AmmoCapacityDisplay( Data )
 	-------------------------------------------------------------------------------
 	acfmenupanel:AmmoSlider("PropLength", Data.PropLength, Data.MinPropLength + (Data.Caliber * 3.9), Data.MaxTotalLength, 3, "Propellant Length", "Propellant Mass : " .. math.floor(Data.PropMass * 1000) .. " g") --Propellant Length Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("ProjLength", Data.ProjLength, Data.MinProjLength, Data.MaxTotalLength, 3, "Projectile Length", "Projectile Mass : " .. math.floor(Data.ProjMass * 1000) .. " g") --Projectile Length Slider (Name, Min, Max, Decimals, Title, Desc)
@@ -461,7 +461,7 @@ function Round.guiupdate( Panel )
 	acfmenupanel:AmmoSlider("FillerVol", Data.FillerVol, Data.MinFillerVol, Data.MaxFillerVol, 3, "HE Filler Volume", "HE Filler Mass : " .. math.floor(Data.FillerMass * 1000) .. " g") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 	acfmenupanel:AmmoSlider("HEAllocation", Data.HEAllocation, 0.05, 0.95, 2, "HE Filler Distribution", "HE Filler Ratio : " .. math.floor((1 - Data.HEAllocation) * 100) .. "% (1st), " .. math.floor(Data.HEAllocation * 100) .. "% (2nd)") --HE Filler Slider (Name, Min, Max, Decimals, Title, Desc)
 
-	ACE_Checkboxes( Data )
+	ACE.Checkboxes( Data )
 
 	acfmenupanel:CPanelText("Desc", ACF.RoundTypes[PlayerData.Type].desc) --Description (Name, Desc)
 	acfmenupanel:CPanelText("LengthDisplay", "Round Length : " .. (math.floor((Data.PropLength + Data.ProjLength + (math.floor(Data.Tracer * 5) / 10)) * 100) / 100) .. "/" .. Data.MaxTotalLength .. " cm") --Total round length (Name, Desc)

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -112,7 +112,7 @@ function ACF_CalcEnginePerformanceData(curve, maxTq, idle, redline)
 end
 
 -- A cheap way to check if the distance between 2 points is within a target distance.
-function ACE_InDist( Pos1, Pos2, Distance )
+function ACE.InDist( Pos1, Pos2, Distance )
 	return (Pos2 - Pos1):LengthSqr() < Distance ^ 2
 end
 
@@ -136,7 +136,7 @@ end
 	-- 87 WOOD
 	-- 89 GLASS
 
-function ACE_GetMaterialName( Mat )
+function ACE.GetMaterialName( Mat )
 	--concrete
 	local GroundMat = "Concrete"
 
@@ -205,7 +205,7 @@ function ACF_Kinetic( Speed , Mass, LimitVel )
 end
 
 -- Convert kinetic penetration energy and projectile area to RHA penetration in mm.
-function ACE_CalcPenetration(Energy, PenArea, PenMul)
+function ACE.CalcPenetration(Energy, PenArea, PenMul)
 	local EnergyPen = istable(Energy) and tonumber(Energy.Penetration) or tonumber(Energy)
 	local Area = tonumber(PenArea)
 
@@ -411,11 +411,11 @@ do
 
 				notification.AddLegacy( "Dupe files were reloaded!", NOTIFY_GENERIC, 7)
 				file.Delete("acf/ace_dupespawn.txt")
-				ACE_Dupes_Refresh()
+				ACE.Dupes_Refresh()
 			end
 		end )
 
-		function ACE_Dupes_Refresh()
+		function ACE.Dupes_Refresh()
 
 			local files = file.Find("scripts/vehicles/acedupe_*.txt", "GAME")
 
@@ -473,7 +473,7 @@ do
 				return
 			end
 
-			ACE_Dupes_Refresh()
+			ACE.Dupes_Refresh()
 		end)
 
 	end
@@ -498,13 +498,13 @@ do
 	}
 
 	--Dedicated function to get the material due to old numeric ids must be passed to the new string indexing now. Could change in a future.
-	function ACE_GetMaterialData( Mat )
+	function ACE.GetMaterialData( Mat )
 
-		if not ACE_CheckMaterial( Mat ) then
+		if not ACE.CheckMaterial( Mat ) then
 
 			Mat = not isstring(Mat) and ACE.BackCompMat[Mat] or "RHA"
 
-			if not ACE_CheckMaterial( Mat ) then
+			if not ACE.CheckMaterial( Mat ) then
 				print("[ACE|ERROR]- No Armor material data found! Have the armor folder been renamed or removed? Unexpected results could occur!")
 				return nil
 			end
@@ -517,7 +517,7 @@ do
 end
 
 --TODO: Use a universal function
-function ACE_CheckMaterial( MatId )
+function ACE.CheckMaterial( MatId )
 
 	local matdata = ACE.ArmorTypes[ MatId ]
 
@@ -527,7 +527,7 @@ function ACE_CheckMaterial( MatId )
 
 end
 
-function ACE_CheckRound( id )
+function ACE.CheckRound( id )
 
 	local rounddata = ACF.RoundTypes[ id ]
 
@@ -536,7 +536,7 @@ function ACE_CheckRound( id )
 	return true
 end
 
-function ACE_CheckGun( gunid )
+function ACE.CheckGun( gunid )
 
 	local gundata = ACF.Weapons.Guns[ gunid ]
 
@@ -545,7 +545,7 @@ function ACE_CheckGun( gunid )
 	return true
 end
 
-function ACE_CheckRack( rackid )
+function ACE.CheckRack( rackid )
 
 	local rackdata = ACF.Weapons.Racks[ rackid ]
 
@@ -554,7 +554,7 @@ function ACE_CheckRack( rackid )
 	return true
 end
 
-function ACE_CheckAmmo( ammoid )
+function ACE.CheckAmmo( ammoid )
 
 	local Ammodata = ACF.Weapons.Ammo[ ammoid ]
 
@@ -563,7 +563,7 @@ function ACE_CheckAmmo( ammoid )
 	return true
 end
 
-function ACE_CheckEngine( engineid )
+function ACE.CheckEngine( engineid )
 
 	local enginedata = ACF.Weapons.Engines[ engineid ]
 
@@ -572,7 +572,7 @@ function ACE_CheckEngine( engineid )
 	return true
 end
 
-function ACE_CheckGearbox( gearid )
+function ACE.CheckGearbox( gearid )
 
 	local geardata = ACF.Weapons.Gearboxes[ gearid ]
 
@@ -581,7 +581,7 @@ function ACE_CheckGearbox( gearid )
 	return true
 end
 
-function ACE_CheckFuelTank( fueltankid )
+function ACE.CheckFuelTank( fueltankid )
 
 	local fueltankid = ACF.Weapons.FuelTanksSize[ fueltankid ]
 
@@ -591,14 +591,14 @@ function ACE_CheckFuelTank( fueltankid )
 end
 
 if SERVER then
-	function ACE_SendMsg(ply, ...)
+	function ACE.SendMsg(ply, ...)
 		net.Start("ACE_SendMessage")
 		net.WriteBool(false)
 		net.WriteTable({...})
 		net.Send(ply)
 	end
 
-	function ACE_SendNotification(ply, hint, duration)
+	function ACE.SendNotification(ply, hint, duration)
 		net.Start("ACE_SendMessage")
 		net.WriteBool(true)
 		net.WriteString(hint)
@@ -606,7 +606,7 @@ if SERVER then
 		net.Send(ply)
 	end
 
-	function ACE_BroadcastMsg(...)
+	function ACE.BroadcastMsg(...)
 		net.Start("ACE_SendMessage")
 		net.WriteBool(false)
 		net.WriteTable({...})
@@ -666,7 +666,7 @@ end
 ]]
 
 -- Helper function to check if a value exists in a table
-function ACE_table_contains(table, element)
+function ACE.table_contains(table, element)
 	for _, value in pairs(table) do
 		if value == element then
 			return true
@@ -717,7 +717,7 @@ if SERVER then
 	--- Gets a unique ID for a contraption object
 	---@param Contraption any
 	---@return number ID The contraption's unique ID
-	function ACE_GetContraptionIndex(Contraption)
+	function ACE.GetContraptionIndex(Contraption)
 		if Indexes[Contraption] then return Indexes[Contraption] end
 
 		if next(Unused) then
@@ -736,7 +736,7 @@ if SERVER then
 		return EntID
 	end
 
-	function ACE_ClearContraptionIndex(Contraption)
+	function ACE.ClearContraptionIndex(Contraption)
 		local Index = Indexes[Contraption]
 
 		if Index then
@@ -745,14 +745,14 @@ if SERVER then
 		end
 	end
 
-	hook.Add("cfw.contraption.removed", "ACE_IndexTracking_ContraptionRemoved", ACE_ClearContraptionIndex)
-	hook.Add("cfw.contraption.merged", "ACE_IndexTracking_ContraptionMerged", ACE_ClearContraptionIndex)
+	hook.Add("cfw.contraption.removed", "ACE_IndexTracking_ContraptionRemoved", ACE.ClearContraptionIndex)
+	hook.Add("cfw.contraption.merged", "ACE_IndexTracking_ContraptionMerged", ACE.ClearContraptionIndex)
 
 	--- Efficiently find the index to insert a value into a sorted table
 	---@param Tbl table
 	---@param Value number
 	---@return number Index The index to insert the value at
-	function ACE_GetBinaryInsertIndex(Tbl, Value)
+	function ACE.GetBinaryInsertIndex(Tbl, Value)
 		local Start = 1
 		local Finish = #Tbl
 
@@ -782,26 +782,26 @@ end
 -- ============================================================
 
 -- Build a consistent description for ACE convars.
-function ACE_ConVarHelp(desc)
+function ACE.ConVarHelp(desc)
 	return "ACE - " .. desc
 end
 
 -- Helper: short IsValid wrapper for entities.
-function ACE_IsEnt(ent)
+function ACE.IsEnt(ent)
 	return IsValid(ent)
 end
 
 -- Check whether an entity is a Wiremod class.
-function ACE_IsWireEntity(ent)
-	if not ACE_IsEnt(ent) then return false end
+function ACE.IsWireEntity(ent)
+	if not ACE.IsEnt(ent) then return false end
 	local cls = ent:GetClass()
 	if not isstring(cls) then return false end
 	return cls:sub(1, 10) == "gmod_wire_"
 end
 
 -- Check whether an entity is a missile entity.
-function ACE_IsMissileEntity(ent)
-	if not ACE_IsEnt(ent) then return false end
+function ACE.IsMissileEntity(ent)
+	if not ACE.IsEnt(ent) then return false end
 	local cls = ent:GetClass()
 	return cls == "ace_missile" or cls == "acf_missile"
 end
@@ -825,7 +825,7 @@ ACE.ClassToType = ACE.ClassToType or {
 	acf_ammo = "Ignore",   -- Ammo is free: crates contribute zero points.
 	-- Scalable explosives / bombs: MOUNTED ordnance costs points, stored ammo stays free. A
 	-- charge bolted to an airframe is independently droppable, so it prices as one rack tube of
-	-- itself (ACE_Points_ChargeEntCost, off its filler mass) rather than being free.
+	-- itself (ACE.Points_ChargeEntCost, off its filler mass) rather than being free.
 	ace_explosive = "Firepower",
 	ace_explosive_prebuilt = "Firepower",
 	ace_bomb_satchel = "Firepower",
@@ -861,22 +861,22 @@ ACE.PointSubsystems = ACE.PointSubsystems or {
 }
 
 -- Resolve point category for an entity class.
-function ACE_GetPtsType(className)
+function ACE.GetPtsType(className)
 	if ACE.ArmorClasses[className] then return "Armor" end
 	return ACE.ClassToType[className] or "Ignore"
 end
 
-function ACE_GetSurvivabilityIndex(ent)
-	if not ACE_IsEnt(ent) then return 0 end
+function ACE.GetSurvivabilityIndex(ent)
+	if not ACE.IsEnt(ent) then return 0 end
 
-	local effMm, maxHealth = ACE_Points_PropArmor(ent)
+	local effMm, maxHealth = ACE.Points_PropArmor(ent)
 	if not effMm or not maxHealth then return 0 end
 
-	return math.max(ACE_Points_ArmorProp(effMm, maxHealth), 0)
+	return math.max(ACE.Points_ArmorProp(effMm, maxHealth), 0)
 end
 
-function ACE_GetArmorPoints(ent)
-	if not ACE_IsEnt(ent) then return 0 end
+function ACE.GetArmorPoints(ent)
+	if not ACE.IsEnt(ent) then return 0 end
 
 	local previousACF = ent.ACF
 	local previousMaxArmour = previousACF and previousACF.MaxArmour
@@ -906,31 +906,31 @@ function ACE_GetArmorPoints(ent)
 		return ACE.ArmorPointCache[cacheKey]
 	end
 
-	local points = ACE_GetSurvivabilityIndex(ent)
+	local points = ACE.GetSurvivabilityIndex(ent)
 	ACE.ArmorPointCache[cacheKey] = points
 
 	return points
 end
 
-function ACE_GetCrewSeatPointCost(ent)
-	local isLoader = ACE_IsEnt(ent) and ent:GetClass() == "ace_crewseat_loader"
-	return ACE_Points_CrewCost(isLoader)
+function ACE.GetCrewSeatPointCost(ent)
+	local isLoader = ACE.IsEnt(ent) and ent:GetClass() == "ace_crewseat_loader"
+	return ACE.Points_CrewCost(isLoader)
 end
 
-function ACE_ClearArmorPointCache(ent)
-	if not ACE_IsEnt(ent) then return end
+function ACE.ClearArmorPointCache(ent)
+	if not ACE.IsEnt(ent) then return end
 	if ACE.ArmorPointCache then
 		ACE.ArmorPointCache[ent:EntIndex()] = nil
 	end
 end
 
 hook.Add("EntityRemoved", "ACE_ClearArmorPointCache", function(ent)
-	ACE_ClearArmorPointCache(ent)
+	ACE.ClearArmorPointCache(ent)
 end)
 
 
 -- Extract configurable class name from "Name:arg=val" serialized strings.
-function ACE_GetConfigurableName(value, fallback)
+function ACE.GetConfigurableName(value, fallback)
 	if type(value) ~= "string" or value == "" then return fallback end
 
 	local name = string.match(value, "^[^:]+")
@@ -940,7 +940,7 @@ function ACE_GetConfigurableName(value, fallback)
 end
 
 -- Resolve the gun class string for ammo bullet data.
-function ACE_GetAmmoGunClass(bdata)
+function ACE.GetAmmoGunClass(bdata)
 	if not bdata then return nil end
 
 	local gunClass = bdata.GunClass
@@ -951,13 +951,13 @@ function ACE_GetAmmoGunClass(bdata)
 end
 
 -- Determine whether an ammo type is a GLATGM family type.
-function ACE_IsGLATGMAmmoType(ammoType)
+function ACE.IsGLATGMAmmoType(ammoType)
 	return ammoType == "GLATGM" or ammoType == "GLATGM-HE"
 end
 
 -- Resolve the most authoritative ammo type for an entity/bullet pair.
-function ACE_ResolveAmmoType(ent, bdata)
-	if ACE_IsEnt(ent) then
+function ACE.ResolveAmmoType(ent, bdata)
+	if ACE.IsEnt(ent) then
 		local entType = ent.RoundType
 		if isstring(entType) and entType ~= "" then return entType end
 
@@ -976,20 +976,20 @@ function ACE_ResolveAmmoType(ent, bdata)
 end
 
 -- Resolve missile warhead behavior from ammo type.
-function ACE_GetMissileWarheadType(ammoType)
+function ACE.GetMissileWarheadType(ammoType)
 	if ammoType == "GLATGM" then return "HEAT" end
 	if ammoType == "GLATGM-HE" then return "HE" end
 	return ammoType
 end
 
 -- Resolve explosion class used by ammo cookoff logic.
-function ACE_GetAmmoCookoffClass(_, isMissile)
+function ACE.GetAmmoCookoffClass(_, isMissile)
 	if isMissile then return "MISSILE" end
 	return "AMMO"
 end
 
 -- Resolve blast filler used by ammo cookoff logic.
-function ACE_GetAmmoCookoffBlastMass(_, bdata)
+function ACE.GetAmmoCookoffBlastMass(_, bdata)
 	if not bdata then return 0 end
 
 	local boom = tonumber(bdata.BoomFillerMass)
@@ -1002,7 +1002,7 @@ function ACE_GetAmmoCookoffBlastMass(_, bdata)
 end
 
 -- Resolve how many rounds are assumed to sympathetically detonate.
-function ACE_GetAmmoCookoffAmmoCount(_, ammoCount, isMissile)
+function ACE.GetAmmoCookoffAmmoCount(_, ammoCount, isMissile)
 	local count = tonumber(ammoCount) or 0
 	if count <= 0 then return 0 end
 
@@ -1014,14 +1014,14 @@ function ACE_GetAmmoCookoffAmmoCount(_, ammoCount, isMissile)
 end
 
 -- Resolve propellant contribution multiplier by cookoff class.
-function ACE_GetAmmoCookoffPropScale(cookClass)
+function ACE.GetAmmoCookoffPropScale(cookClass)
 	if cookClass == "HEAT" then return 0 end
 	if cookClass == "MISSILE" then return 0.08 end
 	return 1
 end
 
 -- Resolve storage scaling by cookoff class.
-function ACE_GetAmmoCookoffStorageScale(cookClass, ammoScale, missileScale)
+function ACE.GetAmmoCookoffStorageScale(cookClass, ammoScale, missileScale)
 	local defaultAmmoScale = tonumber(ammoScale) or 0.55
 	local defaultMissileScale = tonumber(missileScale) or 0.35
 
@@ -1030,11 +1030,11 @@ function ACE_GetAmmoCookoffStorageScale(cookClass, ammoScale, missileScale)
 end
 
 -- Determine whether bullet data should be treated as missile ammo.
-function ACE_IsAmmoMissileType(bdata)
+function ACE.IsAmmoMissileType(bdata)
 	if not bdata then return false end
-	if ACE_IsGLATGMAmmoType(bdata.Type) then return true end
+	if ACE.IsGLATGMAmmoType(bdata.Type) then return true end
 
-	local gunClass = ACE_GetAmmoGunClass(bdata)
+	local gunClass = ACE.GetAmmoGunClass(bdata)
 	if not gunClass then return false end
 
 	local classes = ACF and ACF.Classes and ACF.Classes.GunClass
@@ -1044,8 +1044,8 @@ function ACE_IsAmmoMissileType(bdata)
 end
 
 -- Compute a gun's sustained RPS for one explicit ammo configuration.
-function ACE_GetGunConfiguredRps(ent, rofLimit, bdata, crate)
-	if not ACE_IsEnt(ent) or ent:GetClass() ~= "acf_gun" then return 0 end
+function ACE.GetGunConfiguredRps(ent, rofLimit, bdata, crate)
+	if not ACE.IsEnt(ent) or ent:GetClass() ~= "acf_gun" then return 0 end
 
 	bdata = bdata or {}
 
@@ -1068,7 +1068,7 @@ function ACE_GetGunConfiguredRps(ent, rofLimit, bdata, crate)
 
 	local fireRateModifier = (tonumber(ent.RoFmod) or 1) * (tonumber(ent.PGRoFmod) or 1)
 
-	if ACE_IsEnt(crate) and crate.RoFMul then
+	if ACE.IsEnt(crate) and crate.RoFMul then
 		fireRateModifier = fireRateModifier * (crate.RoFMul + 1)
 	end
 
@@ -1095,8 +1095,8 @@ function ACE_GetGunConfiguredRps(ent, rofLimit, bdata, crate)
 end
 
 -- Resolve the reload time attached to a rack ammo candidate, never its live tube state.
-function ACE_GetRackConfiguredReloadTime(rack, bdata)
-	if not ACE_IsEnt(rack) or rack:GetClass() ~= "acf_rack" then return 1 end
+function ACE.GetRackConfiguredReloadTime(rack, bdata)
+	if not ACE.IsEnt(rack) or rack:GetClass() ~= "acf_rack" then return 1 end
 
 	local reload
 	if istable(bdata) then
@@ -1110,28 +1110,28 @@ function ACE_GetRackConfiguredReloadTime(rack, bdata)
 
 -- Resolve the complete linked gun configuration with the highest final rate x round score.
 local function ACE_ResolveGunPricingCandidate(gun)
-	if not ACE_IsEnt(gun) then return end
+	if not ACE.IsEnt(gun) then return end
 
 	local best
 	local function consider(bdata, crate)
-		local round = ACE_Points_RoundFromBullet(bdata)
+		local round = ACE.Points_RoundFromBullet(bdata)
 		if not round then return end
 
-		local rate = ACE_Points_GunSustainedRps(gun, bdata, crate)
-		local roundScore = ACE_Points_RoundScore(round)
+		local rate = ACE.Points_GunSustainedRps(gun, bdata, crate)
+		local roundScore = ACE.Points_RoundScore(round)
 		local candidate = {
 			Round = round,
 			Rate = rate,
 			RoundScore = roundScore,
 			FinalScore = rate * roundScore,
-			SourceIndex = ACE_IsEnt(crate) and crate:EntIndex() or math.huge,
+			SourceIndex = ACE.IsEnt(crate) and crate:EntIndex() or math.huge,
 		}
 
-		if ACE_Points_IsBetterCandidate(candidate, best) then best = candidate end
+		if ACE.Points_IsBetterCandidate(candidate, best) then best = candidate end
 	end
 
 	for _, crate in pairs(gun.AmmoLink or {}) do
-		if ACE_IsEnt(crate) and istable(crate.BulletData) then consider(crate.BulletData, crate) end
+		if ACE.IsEnt(crate) and istable(crate.BulletData) then consider(crate.BulletData, crate) end
 end
 
 	return best
@@ -1139,16 +1139,16 @@ end
 
 -- Resolve the complete rack configuration with the highest final rate x round score.
 local function ACE_ResolveRackPricingCandidate(rack)
-	if not ACE_IsEnt(rack) then return end
+	if not ACE.IsEnt(rack) then return end
 
 	local best
 	for _, crate in pairs(rack.AmmoLink or {}) do
-		if ACE_IsEnt(crate) and istable(crate.BulletData) then
-			local round = ACE_Points_RoundFromBullet(crate.BulletData)
+		if ACE.IsEnt(crate) and istable(crate.BulletData) then
+			local round = ACE.Points_RoundFromBullet(crate.BulletData)
 			if round then
-				local reload = ACE_GetRackConfiguredReloadTime(rack, crate.BulletData)
-				local rate = ACE_Points_RackRate(reload, rack.MaxMissile)
-				local roundScore = ACE_Points_RoundScore(round)
+				local reload = ACE.GetRackConfiguredReloadTime(rack, crate.BulletData)
+				local rate = ACE.Points_RackRate(reload, rack.MaxMissile)
+				local roundScore = ACE.Points_RoundScore(round)
 				local candidate = {
 					Round = round,
 					Rate = rate,
@@ -1157,7 +1157,7 @@ local function ACE_ResolveRackPricingCandidate(rack)
 					SourceIndex = crate:EntIndex(),
 				}
 
-				if ACE_Points_IsBetterCandidate(candidate, best) then best = candidate end
+				if ACE.Points_IsBetterCandidate(candidate, best) then best = candidate end
 			end
 		end
 	end
@@ -1166,7 +1166,7 @@ local function ACE_ResolveRackPricingCandidate(rack)
 end
 
 local function ACE_ResolveWeaponPricingInputs(ent)
-	if not ACE_IsEnt(ent) then return end
+	if not ACE.IsEnt(ent) then return end
 
 	local class = ent:GetClass()
 	if class ~= "acf_gun" and class ~= "acf_rack" then return end
@@ -1176,16 +1176,16 @@ local function ACE_ResolveWeaponPricingInputs(ent)
 		or ACE_ResolveRackPricingCandidate(ent)
 	local round = candidate and candidate.Round
 	local rate = candidate and candidate.Rate or 0
-	local threat = round and ACE_Points_Gate(ACE_Points_GatePen(round)) or 0
-	local baseRoundCost = round and ACE_Points_BaseRoundCost(round) or 0
+	local threat = round and ACE.Points_Gate(ACE.Points_GatePen(round)) or 0
+	local baseRoundCost = round and ACE.Points_BaseRoundCost(round) or 0
 	local roundScore = threat * baseRoundCost
 	local points = class == "acf_gun"
-		and ACE_Points_GunCost(rate, baseRoundCost, threat)
-		or ACE_Points_RackCostFromRate(rate, roundScore)
+		and ACE.Points_GunCost(rate, baseRoundCost, threat)
+		or ACE.Points_RackCostFromRate(rate, roundScore)
 	local model = ACE.PointsModel or {}
 	local firepowerScale = (tonumber(model.kGun) or 0) * (tonumber(model.Scale) or 0)
 	local rawPoints = rate * roundScore * firepowerScale
-	local rateFloor = ACE_Points_RateFloor and ACE_Points_RateFloor() or 0
+	local rateFloor = ACE.Points_RateFloor and ACE.Points_RateFloor() or 0
 	-- Compare against the FLOORED rate's raw product, not the true rate's -- otherwise every
 	-- floor-affected weapon falsely reads as having hit the flat weapon minimum instead.
 	local flooredRate = (rateFloor > 0) and math.max(rate, rateFloor) or rate
@@ -1210,20 +1210,20 @@ local function ACE_ResolveWeaponPricingInputs(ent)
 	}
 end
 
-function ACE_GetGunFirepowerPointsFor(ent, _)
+function ACE.GetGunFirepowerPointsFor(ent, _)
 	local readout = ACE_ResolveWeaponPricingInputs(ent)
 	return readout and readout.Points or 0
 end
 
-function ACE_GetGunFirepowerPoints(ent)
-	return ACE_GetGunFirepowerPointsFor(ent, nil)
+function ACE.GetGunFirepowerPoints(ent)
+	return ACE.GetGunFirepowerPointsFor(ent, nil)
 end
 
-function ACE_GetGunFirepowerReadout(ent, _)
+function ACE.GetGunFirepowerReadout(ent, _)
 	return ACE_ResolveWeaponPricingInputs(ent)
 end
 
-function ACE_GetGunFirepowerPricingLine(readout, menuFormat)
+function ACE.GetGunFirepowerPricingLine(readout, menuFormat)
 	if not istable(readout) then return end
 	if not readout.Rate or not readout.Threat or not readout.BaseRoundCost then return end
 
@@ -1245,7 +1245,7 @@ end
 
 -- Tells a player when their weapon priced off the delivery-rate floor instead of its true,
 -- slower rate -- distinct from the flat weapon minimum, and can fire well above it.
-function ACE_GetRateFloorLine(readout, menuFormat)
+function ACE.GetRateFloorLine(readout, menuFormat)
 	if not istable(readout) or not readout.RateFloorApplied then return end
 
 	if not menuFormat then
@@ -1259,15 +1259,15 @@ function ACE_GetRateFloorLine(readout, menuFormat)
 end
 
 -- Formats the lethality factors used by the points model.
-function ACE_GetRoundLethalityLine(round, menuFormat)
+function ACE.GetRoundLethalityLine(round, menuFormat)
 	if not istable(round) then return nil end
 
-	local base, hole, blast = ACE_Points_PostPenParts(round)
+	local base, hole, blast = ACE.Points_PostPenParts(round)
 	local dmg = base + hole + blast
 	if dmg <= 0 then return string.format("%s utility round", round.Type or "Unspecified") end
 
 	local rawPen = tonumber(round.maxPen) or 0
-	local pen = ACE_Points_LethalityPen(round)
+	local pen = ACE.Points_LethalityPen(round)
 	local penLabel = (pen > rawPen + 0.5) and "mm HE-equiv" or "mm pen"
 
 	local line
@@ -1279,11 +1279,11 @@ function ACE_GetRoundLethalityLine(round, menuFormat)
 			round.Type or "Round", math.Round(pen), penLabel, dmg, base, hole, blast)
 	end
 
-	local guid = ACE_Points_GuidanceMul(round)
+	local guid = ACE.Points_GuidanceMul(round)
 	if guid ~= 1.0 then
 		line = line .. string.format(" x %.1f guidance", guid)
 	end
-	local intrinsicValue = ACE_Points_IntrinsicValueMul(round)
+	local intrinsicValue = ACE.Points_IntrinsicValueMul(round)
 	if intrinsicValue ~= 1.0 then
 		line = line .. string.format(" x %.1f HE utility", intrinsicValue)
 	end
@@ -1292,13 +1292,13 @@ function ACE_GetRoundLethalityLine(round, menuFormat)
 end
 
 -- Extract HE filler mass from bullet data.
-function ACE_GetAmmoBlastMass(bdata)
+function ACE.GetAmmoBlastMass(bdata)
 	if not bdata then return 0 end
 	return tonumber(bdata.BoomFillerMass) or tonumber(bdata.FillerMass) or 0
 end
 
 -- Resolve maximum penetration from bullet data.
-function ACE_GetAmmoMaxPen(bdata)
+function ACE.GetAmmoMaxPen(bdata)
 	if not bdata then return 0 end
 
 	local maxPen = tonumber(bdata.MaxPen) or 0
@@ -1328,15 +1328,15 @@ end
 -- Link anchor of a weapon with no CFW contraption of its own: the valid linked crate with the
 -- lowest EntIndex that has a contraption. Exactly one contraption adopts (and bills) such a
 -- weapon, independently of the order in which crates were linked.
-function ACE_GetWeaponAnchorContraption(weapon)
-	if not ACE_IsEnt(weapon) then return end
+function ACE.GetWeaponAnchorContraption(weapon)
+	if not ACE.IsEnt(weapon) then return end
 
 	local anchor
 	local anchorIndex
 
 	for _, crate in pairs(weapon.AmmoLink or {}) do
-		if ACE_IsEnt(crate) then
-			local con = ACE_GetContraptionFromEntity(crate)
+		if ACE.IsEnt(crate) then
+			local con = ACE.GetContraptionFromEntity(crate)
 			if con then
 				local crateIndex = crate:EntIndex()
 				if not anchorIndex or crateIndex < anchorIndex then
@@ -1357,12 +1357,12 @@ end
 -- (its own turret + the hull holding its crates) must bill to exactly one contraption, not both.
 -- Do NOT walk the AmmoLink/Master graph outward to gather members -- that reaches such a weapon
 -- from both fragments and prices it in each, inflating Firepower and Engine totals.
-function ACE_GetContraptionEntities(con, fallbackEnt)
+function ACE.GetContraptionEntities(con, fallbackEnt)
 	local ents = {}
 	local visited = {}
 
 	local function add(ent)
-		if not ACE_IsEnt(ent) then return end
+		if not ACE.IsEnt(ent) then return end
 		if visited[ent] then return end
 
 		visited[ent] = true
@@ -1379,9 +1379,9 @@ function ACE_GetContraptionEntities(con, fallbackEnt)
 			local cur = ents[i]
 			if cur:GetClass() == "acf_ammo" and istable(cur.Master) then
 				for _, weapon in pairs(cur.Master) do
-					if ACE_IsEnt(weapon) and not visited[weapon]
-						and not ACE_GetContraptionFromEntity(weapon)
-						and ACE_GetWeaponAnchorContraption(weapon) == con then
+					if ACE.IsEnt(weapon) and not visited[weapon]
+						and not ACE.GetContraptionFromEntity(weapon)
+						and ACE.GetWeaponAnchorContraption(weapon) == con then
 						add(weapon)
 					end
 				end
@@ -1389,7 +1389,7 @@ function ACE_GetContraptionEntities(con, fallbackEnt)
 		end
 	end
 
-	if #ents == 0 and ACE_IsEnt(fallbackEnt) then
+	if #ents == 0 and ACE.IsEnt(fallbackEnt) then
 		add(fallbackEnt)
 	end
 
@@ -1405,31 +1405,31 @@ end
 -- ============================================================
 
 -- Resolve a contraption wrapper for an entity.
-function ACE_GetContraptionFromEntity(ent)
-	if not ACE_IsEnt(ent) or not ent.CFW_GetContraption then return end
+function ACE.GetContraptionFromEntity(ent)
+	if not ACE.IsEnt(ent) or not ent.CFW_GetContraption then return end
 	local con = ent:CFW_GetContraption()
 	if not con or not con.ents or table.IsEmpty(con.ents) then return end
 	return con
 end
 
 -- Resolve contraption owner for messages.
-function ACE_GetContraptionOwner(con)
+function ACE.GetContraptionOwner(con)
 	if not con then return nil end
 	local base = con.GetACEBaseplate and con:GetACEBaseplate()
-	if not ACE_IsEnt(base) or not base.CPPIGetOwner then return nil end
+	if not ACE.IsEnt(base) or not base.CPPIGetOwner then return nil end
 	local owner = base:CPPIGetOwner()
-	return ACE_IsEnt(owner) and owner or nil
+	return ACE.IsEnt(owner) and owner or nil
 end
 
 -- Safely format an owner name.
-function ACE_GetOwnerName(owner)
-	return ACE_IsEnt(owner) and owner:Nick() or "Unknown"
+function ACE.GetOwnerName(owner)
+	return ACE.IsEnt(owner) and owner:Nick() or "Unknown"
 end
 
 -- Armor and firepower are priced by their dedicated passes; ammo is free. Remaining
 -- component ACEPoints values are treated as electronics tiers and scaled with the model.
-function ACE_GetEntPoints(ent)
-	if not ACE_IsEnt(ent) then return 0 end
+function ACE.GetEntPoints(ent)
+	if not ACE.IsEnt(ent) then return 0 end
 
 	local class = ent:GetClass()
 	if (ACE.ArmorClasses and ACE.ArmorClasses[class])
@@ -1441,22 +1441,20 @@ function ACE_GetEntPoints(ent)
 	end
 
 	if class == "acf_engine" then
-		return ACE_Points_EngineCost((tonumber(ent.peakkw) or 0) / 0.7457, ent.FuelType)
+		return ACE.Points_EngineCost((tonumber(ent.peakkw) or 0) / 0.7457, ent.FuelType)
 	end
 
 	if class == "ace_crewseat_gunner" or class == "ace_crewseat_loader"
 		or class == "ace_crewseat_driver" then
-		return ACE_GetCrewSeatPointCost(ent)
+		return ACE.GetCrewSeatPointCost(ent)
 	end
 
 	if class == "ace_explosive" or class == "ace_explosive_prebuilt"
 		or class == "ace_bomb_satchel" or class == "ace_bomb_aerial"
 		or class == "ace_bomb_barrel" then
-		return ACE_Points_ChargeEntCost(ent)
+		return ACE.Points_ChargeEntCost(ent)
 	end
 
 	local scale = (ACE.PointsModel and ACE.PointsModel.Scale) or 1
 	return (tonumber(ent.ACEPoints) or 0) * scale
 end
-
-

--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -1458,3 +1458,5 @@ function ACE.GetEntPoints(ent)
 	local scale = (ACE.PointsModel and ACE.PointsModel.Scale) or 1
 	return (tonumber(ent.ACEPoints) or 0) * scale
 end
+
+

--- a/lua/acf/shared/sh_ace_loader.lua
+++ b/lua/acf/shared/sh_ace_loader.lua
@@ -99,7 +99,7 @@ if CLIENT then
 	gun_base.guicreate           = function( _, Table ) ACFGunGUICreate( Table )		end or nil
 	gun_base.guiupdate           = function() return end
 
-	engine_base.guicreate        = function( _, tbl ) ACE_EngineGUI_Update( tbl )		end or nil
+	engine_base.guicreate        = function( _, tbl ) ACE.EngineGUI_Update( tbl )		end or nil
 
 	gearbox_base.guicreate       = function( _, tbl ) ACFGearboxGUICreate( tbl )		end or nil
 	gearbox_base.guiupdate       = function() return end
@@ -144,14 +144,14 @@ function ACF_defineGunClass( id, data )
 end
 
 -- Crewseat definition
-function ACE_DefineCrewseat( id, data )
+function ACE.DefineCrewseat( id, data )
 	data.id = id
 	table.Inherit( data, crewseat_base )
 	Crewseats[ id ] = data
 end
 
 -- Extras definition (wind sensor, gforce meter, etc.)
-function ACE_DefineExtras( id, data )
+function ACE.DefineExtras( id, data )
 	data.id = id
 	table.Inherit( data, extras_base )
 	Extras[ id ] = data
@@ -168,12 +168,12 @@ function ACF_defineGun( id, data )
 end
 
 -- Muzzleflash definition. The definitions are likely to be placed at the same location as the gun itself
-function ACE_DefineMuzzleFlash(id, data)
+function ACE.DefineMuzzleFlash(id, data)
 	data.id = id
 	MuzzleFlashTable[ id ] = data
 end
 
-function ACE_DefineAmmoCrate( id, data )
+function ACE.DefineAmmoCrate( id, data )
 	data.id = id
 
 	-- Backwards/forwards compatibility for legacy typo key.
@@ -191,7 +191,7 @@ function ACE_DefineAmmoCrate( id, data )
 end
 
 -- Legacy Ammo crate definition
-function ACE_DefineLegacyAmmoCrate( id, data )
+function ACE.DefineLegacyAmmoCrate( id, data )
 	data.id = id
 	LegacyAmmoTable[ id ] = data
 end
@@ -259,7 +259,7 @@ function ACF_DefineRadar( id, data )
 end
 
 -- Explosive charge definition
-function ACE_DefineExplosive( id, data )
+function ACE.DefineExplosive( id, data )
 	data.id = id
 	table.Inherit( data, explosive_base )
 	ExplosiveTable[ id ] = data
@@ -319,20 +319,20 @@ function ACF_DefineVHeatSource( id, data )
 end
 
 --Step 2: gather specialized sounds. Normally sounds that have associated sounds into it. Literally using the string path as id.
-function ACE_DefineGunFireSound( id, data )
+function ACE.DefineGunFireSound( id, data )
 	data.id = id
 	GSoundData[id] = data
 end
 
 -- The model definition. This is where you can "add" scalable models.
-function ACE_DefineModelData( id, data )
+function ACE.DefineModelData( id, data )
 	data.id = id
 	ModelData[id] = data
 	ModelData[data.Model] = data -- I will allow both model or fast name as id.
 end
 
 -- Where you define a new Mine
-function ACE_DefineMine(id, data)
+function ACE.DefineMine(id, data)
 	data.id = id
 	MineData[id] = data
 end

--- a/lua/acf/shared/sh_ace_manufacturing.lua
+++ b/lua/acf/shared/sh_ace_manufacturing.lua
@@ -74,7 +74,7 @@ local TYPE_FAMILY = {
 -- Manufacturing $ for ONE round. Missiles (guidance present) = body $/kg + seeker cost;
 -- shells = round mass (Proj+Prop) x its family $/kg rate. Refill rounds are free here.
 -- round = { Type, ProjMass, PropMass, guidance }.
-function ACE_Manu_RoundCost(round)
+function ACE.Manu_RoundCost(round)
 	local t = round.Type
 	if not t or t == "" then t = "AP" end
 	local fam = TYPE_FAMILY[t] or "AP"
@@ -94,40 +94,40 @@ end
 
 -- Gun manufacturing $ = gun_cal_sq * caliber_mm^2 * class factor. caliberMm is millimetres
 -- (adapter passes Caliber_cm * 10). Unknown class -> factor 1.0.
-function ACE_Manu_GunCost(caliberMm, gunClass)
+function ACE.Manu_GunCost(caliberMm, gunClass)
 	local calMm = tonumber(caliberMm) or 0.0
 	local mul = M.gun_class_mul[gunClass] or 1.0
 	return M.gun_cal_sq * calMm ^ 2 * mul
 end
 
 -- Rack manufacturing $ = tube count x flat rail/tube hardware. 0/nil tubes default to 1.
-function ACE_Manu_RackCost(maxMissile)
+function ACE.Manu_RackCost(maxMissile)
 	local mm = tonumber(maxMissile) or 0
 	if mm == 0 then mm = 1 end
 	return mm * M.rack_flat
 end
 
 -- Armor manufacturing $ = mass (tonnes) x $/ton for the material. Unknown material -> RHA rate.
-function ACE_Manu_ArmorCost(massKg, material)
+function ACE.Manu_ArmorCost(massKg, material)
 	local mass = tonumber(massKg) or 0.0
 	return mass / 1000.0 * (M.armor_per_ton[material] or 14000.0)
 end
 
 -- Engine manufacturing $ = peak hp x $/hp for the fuel type. hp is peak power (peakkw/0.7457).
 -- nil fuel -> Petrol (250); a known-name-but-unmapped fuel -> 350.
-function ACE_Manu_EngineCost(hp, fuelType)
+function ACE.Manu_EngineCost(hp, fuelType)
 	return (tonumber(hp) or 0.0) * (M.engine_per_hp[fuelType or "Petrol"] or 350.0)
 end
 
-function ACE_Manu_ElectronicsCost(tierPoints)
+function ACE.Manu_ElectronicsCost(tierPoints)
 	return (tonumber(tierPoints) or 0.0) * M.electronics_per_tier
 end
 
-function ACE_Manu_CrewCost()
+function ACE.Manu_CrewCost()
 	return M.crew_seat
 end
 
-function ACE_Manu_RefillCost()
+function ACE.Manu_RefillCost()
 	return M.refill_crate
 end
 
@@ -137,39 +137,39 @@ end
 
 -- Ammo crate -> Ammo $. Refill crates take the flat refill cost; every other crate is
 -- round_cost x Capacity. Type/guidance come from the EXISTING public round adapter
--- (ACE_Points_RoundFromBullet resolves missile guidance from guidance/Guidance/Data7);
+-- (ACE.Points_RoundFromBullet resolves missile guidance from guidance/Guidance/Data7);
 -- masses come straight off BulletData. Returns 0 for a crate with no BulletData.
 local function manuCrateCost(ent)
 	local bdata = ent.BulletData
 	if not istable(bdata) then return 0 end
 
-	local round = ACE_Points_RoundFromBullet(bdata)
+	local round = ACE.Points_RoundFromBullet(bdata)
 	if not round then return 0 end
 
 	if round.Type == "Refill" then
-		return ACE_Manu_RefillCost()
+		return ACE.Manu_RefillCost()
 	end
 
 	round.ProjMass = tonumber(bdata.ProjMass)
 	round.PropMass = tonumber(bdata.PropMass)
-	return ACE_Manu_RoundCost(round) * (tonumber(ent.Capacity) or 0)
+	return ACE.Manu_RoundCost(round) * (tonumber(ent.Capacity) or 0)
 end
 
 -- Manufacturing $ for ONE entity, plus its category (one of Armor/Powerpack/Armament/Ammo/
 -- Electronics/Crew), routed by entity class.
 -- Returns 0, nil for unpriceable ents. Server-realm inputs (physics mass, BulletData) -- called
 -- from the armor tool's server-side popup path.
-function ACE_Manu_EntCost(ent)
-	if not ACE_IsEnt(ent) then return 0, nil end
+function ACE.Manu_EntCost(ent)
+	if not ACE.IsEnt(ent) then return 0, nil end
 
 	local cls = ent:GetClass() or ""
 
 	if cls == "acf_engine" then
-		return ACE_Manu_EngineCost((tonumber(ent.peakkw) or 0) / 0.7457, ent.FuelType), "Powerpack"
+		return ACE.Manu_EngineCost((tonumber(ent.peakkw) or 0) / 0.7457, ent.FuelType), "Powerpack"
 	elseif cls == "acf_gun" then
-		return ACE_Manu_GunCost((tonumber(ent.Caliber) or 0) * 10, ent.Class), "Armament"
+		return ACE.Manu_GunCost((tonumber(ent.Caliber) or 0) * 10, ent.Class), "Armament"
 	elseif cls == "acf_rack" then
-		return ACE_Manu_RackCost(ent.MaxMissile), "Armament"
+		return ACE.Manu_RackCost(ent.MaxMissile), "Armament"
 	elseif cls == "acf_ammo" then
 		return manuCrateCost(ent), "Ammo"
 	elseif cls == "ace_explosive" or cls == "ace_explosive_prebuilt"
@@ -178,10 +178,10 @@ function ACE_Manu_EntCost(ent)
 		-- Cast-explosive charge: filler mass x the HE ammo $/kg rate (it is bulk explosive fill).
 		return (tonumber(ent.FillerMass) or 0) * (M.round_per_kg.HE or 100.0), "Ammo"
 	elseif cls:find("crewseat", 1, true) then
-		return ACE_Manu_CrewCost(), "Crew"
+		return ACE.Manu_CrewCost(), "Crew"
 	end
 
-	-- Armor prop: same class-skip as ACE_Points_PropArmor (skip acf_/ace_/gmod_/pod). Priced
+	-- Armor prop: same class-skip as ACE.Points_PropArmor (skip acf_/ace_/gmod_/pod). Priced
 	-- by physics mass x the prop's armor-material $/ton.
 	if cls:sub(1, 4) ~= "acf_" and cls:sub(1, 4) ~= "ace_" and cls:sub(1, 5) ~= "gmod_"
 		and not cls:find("pod", 1, true) then
@@ -189,7 +189,7 @@ function ACE_Manu_EntCost(ent)
 		if istable(acf) and acf.Armour then
 			local phys = ent:GetPhysicsObject()
 			local mass = (IsValid(phys) and phys:GetMass()) or 0
-			return ACE_Manu_ArmorCost(mass, acf.Material or ent.ACF_Material), "Armor"
+			return ACE.Manu_ArmorCost(mass, acf.Material or ent.ACF_Material), "Armor"
 		end
 		return 0, nil
 	end
@@ -197,18 +197,18 @@ function ACE_Manu_EntCost(ent)
 	-- Any other ACF/ACE component carrying an ACEPoints tier prices as electronics.
 	local tier = tonumber(ent.ACEPoints) or 0
 	if tier > 0 then
-		return ACE_Manu_ElectronicsCost(tier), "Electronics"
+		return ACE.Manu_ElectronicsCost(tier), "Electronics"
 	end
 
 	return 0, nil
 end
 
-function ACE_Manu_ContraptionCost(conEnts)
+function ACE.Manu_ContraptionCost(conEnts)
 	local out = { Armor = 0, Powerpack = 0, Armament = 0, Ammo = 0, Electronics = 0, Crew = 0, Total = 0 }
 
 	if istable(conEnts) then
 		for _, ent in ipairs(conEnts) do
-			local cost, cat = ACE_Manu_EntCost(ent)
+			local cost, cat = ACE.Manu_EntCost(ent)
 			if cat and cost and cost > 0 then
 				out[cat] = (out[cat] or 0) + cost
 			end

--- a/lua/acf/shared/sh_ace_points_model.lua
+++ b/lua/acf/shared/sh_ace_points_model.lua
@@ -92,7 +92,7 @@ local GUIDANCE = {
 -- (frontal area x the type's damage multiplier, normalized so a 100mm AP shell = 1.0; HEAT
 -- uses its jet cross-section, not the shell body), plus the explosive payload it delivers
 -- (sqrt of filler kg vs a 6kg reference). Utility (smoke/refill) rounds return 0,0,0.
-function ACE_Points_PostPenParts(round)
+function ACE.Points_PostPenParts(round)
 	local t = round.Type
 	if not t or t == "" then t = "AP" end
 	local fam = TYPE_MAP[t] or "AP"
@@ -114,14 +114,14 @@ function ACE_Points_PostPenParts(round)
 end
 
 -- The three parts summed: the per-round "inside-armor damage" multiplier.
-function ACE_Points_PostPenMult(round)
-	local base, hole, blast = ACE_Points_PostPenParts(round)
+function ACE.Points_PostPenMult(round)
+	local base, hole, blast = ACE.Points_PostPenParts(round)
 	return base + hole + blast
 end
 
 -- Penetration used for lethality: raw maxPen, but HE/HESH floor it at a blast-equivalent so
 -- big fillers still register a threat even with token stated pen.
-function ACE_Points_LethalityPen(round)
+function ACE.Points_LethalityPen(round)
 	local pen = tonumber(round.maxPen) or 0.0
 	local fam = TYPE_MAP[round.Type or "AP"] or "AP"
 	if fam == "HE" or fam == "HESH" then
@@ -133,7 +133,7 @@ end
 
 -- Guidance multiplier for a round (1.0 for everything but guided missile ammo). Public so
 -- displays can show the "x 1.5 guidance" factor instead of hiding it inside baseRoundCost.
-function ACE_Points_GuidanceMul(round)
+function ACE.Points_GuidanceMul(round)
 	local g = round.guidance
 	if g and g ~= "" then
 		return GUIDANCE[g] or 1.0
@@ -142,21 +142,21 @@ function ACE_Points_GuidanceMul(round)
 end
 
 -- Intrinsic value beyond direct lethality terms; shared by billing and explanatory readouts.
-function ACE_Points_IntrinsicValueMul(round)
+function ACE.Points_IntrinsicValueMul(round)
 	local fam = TYPE_MAP[round and round.Type or "AP"] or "AP"
 	return fam == "HE" and HE_INTRINSIC_VALUE_MULT or 1.0
 end
 
 -- Intrinsic cost of one configured round. Inventory count is not billed, but every weapon
 -- multiplies this value by its own delivery rate and threat factor.
-function ACE_Points_BaseRoundCost(round)
-	local cost = ACE_Points_LethalityPen(round) * ACE_Points_PostPenMult(round)
-		* ACE_Points_GuidanceMul(round) * ACE_Points_IntrinsicValueMul(round)
+function ACE.Points_BaseRoundCost(round)
+	local cost = ACE.Points_LethalityPen(round) * ACE.Points_PostPenMult(round)
+		* ACE.Points_GuidanceMul(round) * ACE.Points_IntrinsicValueMul(round)
 	return max(cost, ROUND_COST_FLOOR)
 end
 
 -- Share of the meta this pen defeats. The curve is continuous from zero with no minimum share.
-function ACE_Points_Gate(pen)
+function ACE.Points_Gate(pen)
 	pen = tonumber(pen) or 0
 	if pen <= 0 then return 0 end
 	return pen / (pen + Model.P50)
@@ -165,11 +165,11 @@ end
 -- Penetration the GATE judges a round by. HE uses its blast lethality reach because splash,
 -- module damage, and soft-target effects create combat value without literal armor penetration;
 -- HESH retains only the damage code's literal blast-penetration channel.
-function ACE_Points_GatePen(round)
+function ACE.Points_GatePen(round)
 	local pen = tonumber(round.maxPen) or 0.0
 	local fam = TYPE_MAP[round.Type or "AP"] or "AP"
 	if fam == "HE" then
-		pen = max(pen, ACE_Points_LethalityPen(round))
+		pen = max(pen, ACE.Points_LethalityPen(round))
 		local blast = tonumber(round.blastMass) or 0.0
 		pen = max(pen, blast * HE_BLAST_PEN_PER_KG)
 	elseif fam == "HESH" then
@@ -180,12 +180,12 @@ function ACE_Points_GatePen(round)
 end
 
 -- Round score = threat * baseRoundCost.
-function ACE_Points_RoundScore(round)
-	return ACE_Points_Gate(ACE_Points_GatePen(round)) * ACE_Points_BaseRoundCost(round)
+function ACE.Points_RoundScore(round)
+	return ACE.Points_Gate(ACE.Points_GatePen(round)) * ACE.Points_BaseRoundCost(round)
 end
 
 -- Candidate ordering is final weapon output, then per-shot score, then stable source order.
-function ACE_Points_IsBetterCandidate(candidate, best)
+function ACE.Points_IsBetterCandidate(candidate, best)
 	if not best then return true end
 	if candidate.FinalScore ~= best.FinalScore then return candidate.FinalScore > best.FinalScore end
 	if candidate.RoundScore ~= best.RoundScore then return candidate.RoundScore > best.RoundScore end
@@ -194,9 +194,9 @@ end
 
 -- Static sustained cadence. Magazine-aware (burst then mag reload) and loader-aware for
 -- non-auto classes. baseRps already folds in the gun's current wire ROFLimit (the adapter
--- below applies it via ACE_GetGunConfiguredRps before calling here), so a low limit lengthens
+-- below applies it via ACE.GetGunConfiguredRps before calling here), so a low limit lengthens
 -- the effective cycle through this same math rather than being ignored.
-function ACE_Points_SustainedRps(baseRps, magSize, magReload, gunClass, loaders)
+function ACE.Points_SustainedRps(baseRps, magSize, magReload, gunClass, loaders)
 	local base   = tonumber(baseRps) or 0
 	local mag    = tonumber(magSize) or 0
 	local magrel = tonumber(magReload) or 0
@@ -213,7 +213,7 @@ end
 
 -- Gun firepower cost (scaled). This is called once per gun entity; identical guns therefore
 -- add linearly instead of sharing or deduplicating the round cost.
-function ACE_Points_GunCost(sustainedRps, baseRoundCost, threat)
+function ACE.Points_GunCost(sustainedRps, baseRoundCost, threat)
 	local pricedRps = max(tonumber(sustainedRps) or 0, 1.0 / RACK_WINDOW)
 	return max(Model.kGun
 		* pricedRps
@@ -221,7 +221,7 @@ function ACE_Points_GunCost(sustainedRps, baseRoundCost, threat)
 		* (tonumber(threat) or 0), GUN_FLAT) * Model.Scale
 end
 
-function ACE_Points_RackRate(reloadTime, maxMissile)
+function ACE.Points_RackRate(reloadTime, maxMissile)
 	local rt = tonumber(reloadTime) or 0
 	if rt == 0 then rt = 10.0 end
 	local mm = tonumber(maxMissile) or 0
@@ -229,7 +229,7 @@ function ACE_Points_RackRate(reloadTime, maxMissile)
 	return min(1.0 / max(rt, 0.5), mm / RACK_WINDOW)
 end
 
-function ACE_Points_RackCostFromRate(rate, bestScore)
+function ACE.Points_RackCostFromRate(rate, bestScore)
 	local pricedRate = max(tonumber(rate) or 0, 1.0 / RACK_WINDOW)
 	return max(Model.kGun * pricedRate
 		* (tonumber(bestScore) or 0), RACK_FLAT) * Model.Scale
@@ -237,29 +237,29 @@ end
 
 -- Public so readouts can tell a player when the priced-rate floor changed their bill, instead
 -- of leaving the window a silently duplicated magic number.
-function ACE_Points_RateFloor()
+function ACE.Points_RateFloor()
 	return 1.0 / RACK_WINDOW
 end
 
 -- Tube count caps sustained rack rate over the engagement window.
-function ACE_Points_RackCost(reloadTime, maxMissile, bestScore)
-	return ACE_Points_RackCostFromRate(ACE_Points_RackRate(reloadTime, maxMissile), bestScore)
+function ACE.Points_RackCost(reloadTime, maxMissile, bestScore)
+	return ACE.Points_RackCostFromRate(ACE.Points_RackRate(reloadTime, maxMissile), bestScore)
 end
 
 -- Mounted charges use one tube-window without the rack hardware floor. Stored ammo remains free.
-function ACE_Points_ChargeCost(fillerKg)
+function ACE.Points_ChargeCost(fillerKg)
 	fillerKg = tonumber(fillerKg) or 0
 	if fillerKg <= 0 then return 0 end
 	local round = { Type = "HE", maxPen = 0, FrArea = 0, blastMass = fillerKg, guidance = "Dumb" }
-	return Model.kGun * (1.0 / RACK_WINDOW) * ACE_Points_RoundScore(round) * Model.Scale
+	return Model.kGun * (1.0 / RACK_WINDOW) * ACE.Points_RoundScore(round) * Model.Scale
 end
 
-function ACE_Points_EffectiveMm(armourMm, ke, chem)
+function ACE.Points_EffectiveMm(armourMm, ke, chem)
 	return (tonumber(armourMm) or 0) * (0.7 * (tonumber(ke) or 1) + 0.3 * (tonumber(chem) or 1))
 end
 
 -- Per-prop armor survivability cost (scaled). mm is intensive (^1.4), HP is linear (^1.0).
-function ACE_Points_ArmorProp(effMm, maxHealth)
+function ACE.Points_ArmorProp(effMm, maxHealth)
 	return Model.kArmor * 100.0
 		* ((tonumber(effMm) or 0) / 50.0) ^ EXP_MM
 		* ((tonumber(maxHealth) or 0) / 75.0) ^ EXP_HP
@@ -267,12 +267,12 @@ function ACE_Points_ArmorProp(effMm, maxHealth)
 end
 
 -- Engine cost (scaled). hp is peak power (peakkw / 0.7457); fuel scales upkeep-ish value.
-function ACE_Points_EngineCost(hp, fuelType)
+function ACE.Points_EngineCost(hp, fuelType)
 	return Model.kEng * (tonumber(hp) or 0) * (FUEL_FACTOR[fuelType or "Petrol"] or 1.0) * Model.Scale
 end
 
 -- Crew seat cost (scaled). Loader seats cost more than generic seats.
-function ACE_Points_CrewCost(isLoader)
+function ACE.Points_CrewCost(isLoader)
 	return (isLoader and LOADER_SEAT or CREW_SEAT) * Model.Scale
 end
 
@@ -289,7 +289,7 @@ end
 -- Guidance may be a serialized string, keyed table, or ordered mode list.
 local function resolveGuidanceName(guidanceValue)
 	if isstring(guidanceValue) then
-		local name = ACE_GetConfigurableName(guidanceValue, "")
+		local name = ACE.GetConfigurableName(guidanceValue, "")
 		if name == "" then name = guidanceValue end
 		return normalizeGuidanceName(name)
 	elseif istable(guidanceValue) then
@@ -322,22 +322,22 @@ local function materialEff(mat)
 end
 
 -- Returns nil for unknown materials so display code can fall back to live material data.
-function ACE_Points_MaterialEff(mat)
+function ACE.Points_MaterialEff(mat)
 	local eff = MATERIAL_EFF[mat]
 	if not eff then return nil end
 	return eff[1], eff[2]
 end
 
 -- Build the plain pricing round from a gun/crate/rack BulletData table. nil if not a table.
-function ACE_Points_RoundFromBullet(bdata)
+function ACE.Points_RoundFromBullet(bdata)
 	if not istable(bdata) then return nil end
 
 	local round = {
-		Type        = ACE_ResolveAmmoType(nil, bdata),   -- bdata branch: bdata.Type or bdata.RoundType
-		maxPen      = ACE_GetAmmoMaxPen(bdata),
+		Type        = ACE.ResolveAmmoType(nil, bdata),   -- bdata branch: bdata.Type or bdata.RoundType
+		maxPen      = ACE.GetAmmoMaxPen(bdata),
 		FrArea      = tonumber(bdata.FrArea) or 0,
 		SlugCaliber = tonumber(bdata.SlugCaliber),       -- HEAT family only; nil otherwise
-		blastMass   = ACE_GetAmmoBlastMass(bdata),
+		blastMass   = ACE.GetAmmoBlastMass(bdata),
 	}
 
 	-- Guidance folds the old per-missile pricing premium into baseRoundCost. Candidates:
@@ -345,7 +345,7 @@ function ACE_Points_RoundFromBullet(bdata)
 	-- legacy pricing read). GLATGM (gun-launched grenade ammo) opts out, as it always has.
 	-- Non-missiles carry none, so guidance stays nil (1.0).
 	local guid = bdata.guidance or bdata.Guidance or bdata.Data7
-	if guid ~= nil and not ACE_IsGLATGMAmmoType(bdata.Type) then
+	if guid ~= nil and not ACE.IsGLATGMAmmoType(bdata.Type) then
 		round.guidance = resolveGuidanceName(guid)
 	end
 
@@ -354,25 +354,25 @@ end
 
 -- ROFLimit is a pricing input and its trigger path must dirty points. LoaderCount is local to
 -- the gun, including loaders linked across contraption fragments.
-function ACE_Points_GunSustainedRps(gun, bdata, crate)
-	if not ACE_IsEnt(gun) then return 0 end
-	local base = ACE_GetGunConfiguredRps(gun, tonumber(gun.ROFLimit) or 0, bdata, crate)
-	return ACE_Points_SustainedRps(base, gun.MagSize, gun.MagReload, gun.Class, gun.LoaderCount)
+function ACE.Points_GunSustainedRps(gun, bdata, crate)
+	if not ACE.IsEnt(gun) then return 0 end
+	local base = ACE.GetGunConfiguredRps(gun, tonumber(gun.ROFLimit) or 0, bdata, crate)
+	return ACE.Points_SustainedRps(base, gun.MagSize, gun.MagReload, gun.Class, gun.LoaderCount)
 end
 
 -- Mounted charge (scalable explosives / bombs family) -> scaled points. Prices the charge's
 -- REAL filler mass -- self.FillerMass, kg of HE, set once at spawn from the scaled charge
--- volume -- as mounted ordnance via ACE_Points_ChargeCost. 0 for a filler-less/invalid entity.
-function ACE_Points_ChargeEntCost(ent)
-	if not ACE_IsEnt(ent) then return 0 end
-	return ACE_Points_ChargeCost(tonumber(ent.FillerMass) or 0)
+-- volume -- as mounted ordnance via ACE.Points_ChargeCost. 0 for a filler-less/invalid entity.
+function ACE.Points_ChargeEntCost(ent)
+	if not ACE.IsEnt(ent) then return 0 end
+	return ACE.Points_ChargeCost(tonumber(ent.FillerMass) or 0)
 end
 
 -- Prop -> (effectiveMm, maxHealth) for the armor term, or nil to skip. Skips ACF/ACE
 -- components and pods (they price in their own categories) and props with no armour or HP.
 -- Uses MAX armour/health (static design). Material ke/chem via the curated MATERIAL_EFF above.
-function ACE_Points_PropArmor(ent)
-	if not ACE_IsEnt(ent) then return nil end
+function ACE.Points_PropArmor(ent)
+	if not ACE.IsEnt(ent) then return nil end
 
 	local cls = ent:GetClass() or ""
 	if cls:sub(1, 4) == "acf_" or cls:sub(1, 4) == "ace_" or cls:sub(1, 5) == "gmod_"
@@ -388,5 +388,5 @@ function ACE_Points_PropArmor(ent)
 	if armourMm <= 0 or hp <= 0 then return nil end
 
 	local ke, chem = materialEff(acf.Material or ent.ACF_Material)
-	return ACE_Points_EffectiveMm(armourMm, ke, chem), hp
+	return ACE.Points_EffectiveMm(armourMm, ke, chem), hp
 end

--- a/lua/acf/shared/sh_acfm_roundinject.lua
+++ b/lua/acf/shared/sh_acfm_roundinject.lua
@@ -8,7 +8,7 @@ include("acf/shared/sh_acfm_getters.lua")
 
 
 local function checkIfDataIsMissile(data)
-	return ACE_IsAmmoMissileType(data)
+	return ACE.IsAmmoMissileType(data)
 end
 
 

--- a/lua/acf/shared/sh_crewseat_base.lua
+++ b/lua/acf/shared/sh_crewseat_base.lua
@@ -83,17 +83,17 @@ ACE.CrewseatPoseModifiers = {
 }
 
 -- Helper function to check if pose is standing
-function ACE_IsStandingPose(modelType)
+function ACE.IsStandingPose(modelType)
 	return ACE.CrewseatStandingModels[modelType] or false
 end
 
 -- Helper function to get pose modifiers
-function ACE_GetPoseModifiers(ent)
+function ACE.GetPoseModifiers(ent)
 	if not IsValid(ent) then return nil end
 
 	local class = ent:GetClass()
 	local modelType = ent.ModelType or "Sitting"
-	local isStanding = ACE_IsStandingPose(modelType)
+	local isStanding = ACE.IsStandingPose(modelType)
 	local poseKey = isStanding and "standing" or "sitting"
 
 	local classModifiers = ACE.CrewseatPoseModifiers[class]
@@ -103,7 +103,7 @@ function ACE_GetPoseModifiers(ent)
 end
 
 -- Check if a model is a valid crewseat model
-function ACE_IsValidCrewseatModel(modelPath)
+function ACE.IsValidCrewseatModel(modelPath)
 	if not modelPath then return false end
 	return ACE.CrewseatModelLookup[modelPath] ~= nil
 end

--- a/lua/acf/shared/sounds/gunfire.lua
+++ b/lua/acf/shared/sounds/gunfire.lua
@@ -1,6 +1,6 @@
 --Little desc for every value here:
 
---ACE_DefineGunFireSound( id, data)
+--ACE.DefineGunFireSound( id, data)
 
 --id	: this will be the sound patch which this content is associated to. Make sure that every id is unique so we dont have colliding data
 --data	: here we will have 3 tables, which each one will edit the sounds to be played PER distance. So we will have main sounds (those you hear normally when standing close to the gun), mid sounds and far sounds.
@@ -14,7 +14,7 @@
 -- These sound packages will work for both sounds placed via sound replacer or generic ones, so feel free to create your own scripted sounds. Only works with GUNs.
 
 --7.62mm Machinegun gunfire
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/7_62mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/7_62mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -93,7 +93,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/7_62mm_multi.mp3",
 )
 
 --12.7mm Machinegun gunfire
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/12_7mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/12_7mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -169,7 +169,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/12_7mm_multi.mp3",
 )
 
 --20mm heavy machinegun gunfire.
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/20mm_hmg_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/20mm_hmg_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -250,7 +250,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/20mm_hmg_multi.mp3",
 )
 
 --30mm heavy machinegun gunfire.
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/30mm_hmg_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/30mm_hmg_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -293,7 +293,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/30mm_hmg_multi.mp3",
 )
 
 --20mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/20mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/20mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -348,7 +348,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/20mm_multi.mp3",
 )
 
 --30mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/30mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/30mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -391,7 +391,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/30mm_multi.mp3",
 )
 
 --40mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/40mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/40mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -435,7 +435,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/40mm_multi.mp3",
 )
 
 --50mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/50mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/50mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -471,7 +471,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/50mm_multi.mp3",
 )
 
 --75mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/75mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/75mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -508,7 +508,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/75mm_multi.mp3",
 )
 
 --100mm Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/100mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/100mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -545,7 +545,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/100mm_multi.mp3",
 )
 
 --120mm+ Cannon sound
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/120mm_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/120mm_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -584,7 +584,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/120mm_multi.mp3",
 )
 
 --Generic Howitzer gunfire
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/howitzer_multi.wav",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/howitzer_multi.wav",
 	{
 		main = {
 			Volume	= 10,
@@ -622,7 +622,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/howitzer_multi.wav",
 )
 --[[
 --Generic Mortar gunfire. Ik its empty, the structure is here just to avoid recreate it in the future.
-ACE_DefineGunFireSound( "weapons/ACF_Gun/mortar_new.wav",
+ACE.DefineGunFireSound( "weapons/ACF_Gun/mortar_new.wav",
 	{
 		main = {
 			Volume	= 1,
@@ -650,7 +650,7 @@ ACE_DefineGunFireSound( "weapons/ACF_Gun/mortar_new.wav",
 )
 ]]
 --Generic AT Rifle gunfire
-ACE_DefineGunFireSound( "acf_extra/tankfx/gnomefather/7mm1.wav",
+ACE.DefineGunFireSound( "acf_extra/tankfx/gnomefather/7mm1.wav",
 	{
 		main = {
 			Volume	= 1,
@@ -684,7 +684,7 @@ ACE_DefineGunFireSound( "acf_extra/tankfx/gnomefather/7mm1.wav",
 )
 --[[
 --generic rotary autocannon gunfire. Broken atm
-ACE_DefineGunFireSound( "weapons/acf_gun/mg_fire2.wav",
+ACE.DefineGunFireSound( "weapons/acf_gun/mg_fire2.wav",
 	{
 		main = {
 			Volume	= 0.9,
@@ -719,7 +719,7 @@ ACE_DefineGunFireSound( "weapons/acf_gun/mg_fire2.wav",
 ]]
 --[[
 --Generic GL gunfire
-ACE_DefineGunFireSound( "weapons/acf_gun/grenadelauncher.wav",
+ACE.DefineGunFireSound( "weapons/acf_gun/grenadelauncher.wav",
 	{
 		main = {
 			Volume	= 1,
@@ -747,7 +747,7 @@ ACE_DefineGunFireSound( "weapons/acf_gun/grenadelauncher.wav",
 )
 
 --Generic SL gunfire
-ACE_DefineGunFireSound( "ace_weapons/multi_sound/smoke_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/multi_sound/smoke_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -775,7 +775,7 @@ ACE_DefineGunFireSound( "ace_weapons/multi_sound/smoke_multi.mp3",
 )
 
 --Generic FGL gunfire
-ACE_DefineGunFireSound( "acf_extra/tankfx/flare_launch.wav",
+ACE.DefineGunFireSound( "acf_extra/tankfx/flare_launch.wav",
 	{
 		main = {
 			Volume	= 1,
@@ -804,7 +804,7 @@ ACE_DefineGunFireSound( "acf_extra/tankfx/flare_launch.wav",
 ]]--
 --[[
 --Test sound definition. Meant to see if the core works as intended.
-ACE_DefineGunFireSound( "physics/metal/bts5_panels_impact_lg_01.wav",
+ACE.DefineGunFireSound( "physics/metal/bts5_panels_impact_lg_01.wav",
 	{
 		main = {
 			Volume	= 1,

--- a/lua/acf/shared/sounds/sweps.lua
+++ b/lua/acf/shared/sounds/sweps.lua
@@ -1,7 +1,7 @@
 if SERVER then
 	util.AddNetworkString("ACE_SWEPSounds")
 
-	function ACE_NetworkSPEffects(ent, propmass)
+	function ACE.NetworkSPEffects(ent, propmass)
 
 		net.Start("ACE_SWEPSounds", true)
 		net.WriteEntity(ent)
@@ -11,7 +11,7 @@ if SERVER then
 
 	-- The previous networking function. Removed owner from vars since ent (the swep) already has the owner and sounds networked in it. 
 	-- propmass is serverside so we must include it into client.
-	function ACE_NetworkMPEffects(sourcePly, ent, propmass)
+	function ACE.NetworkMPEffects(sourcePly, ent, propmass)
 		local targets = {}
 
 		for _, v in ipairs(player.GetAll()) do
@@ -38,14 +38,14 @@ else
 				swep.ACEPropmass = propmass
 				swep:DoSPClientEffects()
 			else
-				ACE_SGunFire(swep:GetOwner(), swep.Primary.Sound, 1, propmass)
+				ACE.SGunFire(swep:GetOwner(), swep.Primary.Sound, 1, propmass)
 			end
 		end
 	end)
 end
 
 --ak47mm gunfire
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/ak47_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/ak47_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -104,7 +104,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/ak47_multi.mp3",
 
 
 --amr
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/amr_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/amr_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -143,7 +143,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/amr_multi.mp3",
 
 
 --at4 Anti Tank
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -183,7 +183,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4_multi.mp3",
 
 
 --at4P Anti Tank Proto
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4p_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4p_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -219,7 +219,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/at4p_multi.mp3",
 )
 
 --aug
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/aug_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/aug_multi.mp3",
 	{
 		main = {
 			Volume	= 1,
@@ -274,7 +274,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/aug_multi.mp3",
 )
 
 --awp
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/awp_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/awp_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -314,7 +314,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/awp_multi.mp3",
 )
 
 --deagle
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/deagle_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/deagle_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -331,7 +331,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/deagle_multi.mp3",
 
 
 --deagle
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/elite_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/elite_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -347,7 +347,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/elite_multi.mp3",
 )
 
 --famas
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/famas_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/famas_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -402,7 +402,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/famas_multi.mp3",
 )
 
 --fiveseven
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/fiveseven_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/fiveseven_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -421,7 +421,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/fiveseven_multi.mp3",
 )
 
 --galil
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/galil_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/galil_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -476,7 +476,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/galil_multi.mp3",
 )
 
 --glock
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/glock_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/glock_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -494,7 +494,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/glock_multi.mp3",
 )
 
 --m3super90
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m3super90_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/m3super90_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -526,7 +526,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m3super90_multi.mp3",
 )
 
 --m16mm gunfire
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m16_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/m16_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -569,7 +569,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m16_multi.mp3",
 )
 
 --m249saw
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m249saw_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/m249saw_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -624,7 +624,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/m249saw_multi.mp3",
 )
 
 --mac10
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/mac10_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/mac10_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -677,7 +677,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/mac10_multi.mp3",
 )
 
 --mp5
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/mp5_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/mp5_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -730,7 +730,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/mp5_multi.mp3",
 )
 
 --p90
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/p90_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/p90_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -783,7 +783,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/p90_multi.mp3",
 )
 
 --p228
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/p228_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/p228_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -800,7 +800,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/p228_multi.mp3",
 )
 
 --scout
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/scout_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/scout_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -847,7 +847,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/scout_multi.mp3",
 )
 
 --sg552
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/sg552_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/sg552_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -902,7 +902,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/sg552_multi.mp3",
 )
 
 --tmp
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/tmp_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/tmp_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -924,7 +924,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/tmp_multi.mp3",
 )
 
 --ump45
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/ump45_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/ump45_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -977,7 +977,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/ump45_multi.mp3",
 )
 
 --usp
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/usp_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/usp_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -994,7 +994,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/usp_multi.mp3",
 )
 
 --xm25
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/xm25_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/xm25_multi.mp3",
 {
 	main = {
 		Volume	= 1,
@@ -1014,7 +1014,7 @@ ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/xm25_multi.mp3",
 )
 
 --xm1014mm gunfire
-ACE_DefineGunFireSound( "ace_weapons/sweps/multi_sound/xm1014_multi.mp3",
+ACE.DefineGunFireSound( "ace_weapons/sweps/multi_sound/xm1014_multi.mp3",
 {
 	main = {
 		Volume	= 1,

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -313,8 +313,8 @@ if SERVER then
         elseif CVar == "acf_legality_largegunthreshold" then
             ACF.LargeGunsThreshold = math.ceil(math.Clamp(New, 0, 10000))
         elseif CVar == "acf_enable_dp" then
-            if ACE_SendDPStatus then
-                ACE_SendDPStatus()
+            if ACE.SendDPStatus then
+                ACE.SendDPStatus()
             end
         end
     end
@@ -522,7 +522,7 @@ end )
 
 if SERVER then
 
-    function ACE_SendDPStatus()
+    function ACE.SendDPStatus()
 
         local Cvar = GetConVar("acf_enable_dp"):GetInt()
         local bool = tobool(Cvar)
@@ -597,5 +597,39 @@ cleanup.Register( "aceexplosives" )
 
 AddCSLuaFile("autorun/acf_missile/folder.lua")
 include("autorun/acf_missile/folder.lua")
+
+-- Keep only the former names of migrated functions available to older entities and extensions.
+local legacyACEFunctions = {
+    "AddPts", "AmmoCapacity", "AmmoCapacityDisplay", "AmmoRangeStats", "AmmoStats", "Approaching", "BroadcastMsg", "CalcContraptionArmorPoints",
+    "CalcEntityGForce", "CalcNonArmorPoints", "CalcPenetration", "CalcVehicleView", "CalculateHERadius", "CheckAmmo", "CheckEngine", "CheckFuelTank",
+    "CheckGearbox", "CheckGun", "CheckLegalCont", "CheckMaterial", "CheckRack", "CheckRound", "Checkboxes", "ClearArmorPointCache",
+    "ClearContraptionIndex", "CommonDataDisplay", "ConVarHelp", "CreateLinkRope", "CreateMine", "CreateSZRope", "CrewseatApplyDupeModel", "CrewseatDamage",
+    "CrewseatDeathSound", "CrewseatDebugEnabled", "CrewseatDebugLog", "CrewseatDeferredModelSync", "CrewseatLegalCheck", "CrewseatOnRemove", "CrewseatResolveModelType", "DefineAmmoCrate",
+    "DefineCrewseat", "DefineExplosive", "DefineExtras", "DefineGunFireSound", "DefineLegacyAmmoCrate", "DefineMine", "DefineModelData", "DefineMuzzleFlash",
+    "DoContraptionLegalCheck", "Dupes_Refresh", "EmitSound", "EngineGUI_Update", "EnsureCacheVersion", "EnsureContraptionPoints", "EnsurePointsState", "FindReplacementLoader",
+    "GenerateCrewName", "GetAmmoBlastMass", "GetAmmoCookoffAmmoCount", "GetAmmoCookoffBlastMass", "GetAmmoCookoffClass", "GetAmmoCookoffPropScale", "GetAmmoCookoffStorageScale", "GetAmmoGunClass",
+    "GetAmmoMaxPen", "GetArmorPoints", "GetBinaryInsertIndex", "GetConfigurableName", "GetContraptionEntities", "GetContraptionFromEntity", "GetContraptionIndex", "GetContraptionOwner",
+    "GetCrewSeatPointCost", "GetDistanceTime", "GetEntPoints", "GetExplosiveMasses", "GetGunConfiguredRps", "GetGunFirepowerPoints", "GetGunFirepowerPointsFor", "GetGunFirepowerPricingLine",
+    "GetGunFirepowerReadout", "GetMaterialData", "GetMaterialName", "GetMissileWarheadType", "GetOwnerName", "GetPoseModifiers", "GetPtsType", "GetRackConfiguredReloadTime",
+    "GetRateFloorLine", "GetRoundLethalityLine", "GetSurvivabilityIndex", "GetWeaponAnchorContraption", "GetWeaponUser", "HeatFromEngine", "HeatFromGearbox", "HeatFromGun",
+    "HeatFromRadar", "InDist", "InfraredHeatFromProp", "InitializeCrewseat", "IsAmmoMissileType", "IsEnt", "IsGLATGMAmmoType", "IsMissileEntity",
+    "IsStandingPose", "IsValidCrewseatModel", "IsWireEntity", "LOSMultiTrace", "MakePrebuiltExplosive", "Manu_ArmorCost", "Manu_ContraptionCost", "Manu_CrewCost",
+    "Manu_ElectronicsCost", "Manu_EngineCost", "Manu_EntCost", "Manu_GunCost", "Manu_RackCost", "Manu_RefillCost", "Manu_RoundCost", "MarkArmorDirty",
+    "MarkContraptionPointsDirty", "NetworkMPEffects", "NetworkSPEffects", "NotifyContraptionPointsInvalidated", "NotifyCrateWeapons", "PerformHitResolution", "PointsInputChanged",
+    "Points_ArmorProp", "Points_BaseRoundCost", "Points_ChargeCost", "Points_ChargeEntCost", "Points_CrewCost", "Points_EffectiveMm", "Points_EngineCost", "Points_Gate",
+    "Points_GatePen", "Points_GuidanceMul", "Points_GunCost", "Points_GunSustainedRps", "Points_IntrinsicValueMul", "Points_IsBetterCandidate", "Points_LethalityPen", "Points_MaterialEff",
+    "Points_PostPenMult", "Points_PostPenParts", "Points_PropArmor", "Points_RackCost", "Points_RackCostFromRate", "Points_RackRate", "Points_RateFloor", "Points_RoundFromBullet",
+    "Points_RoundScore", "Points_SustainedRps", "PrimitivePropertiesApplied", "RebuildContraptionPoints", "ReceiveDPStatus", "RemPts", "RemoveBulletClient", "ResolveAmmoType",
+    "SBlast", "SBulletCrack", "SBulletImpact", "SBulletWhistle", "SGetHearingEntity", "SGunFire", "SHasLOS", "SInDistance",
+    "SIsInDoor", "SPenetration", "SRicochet", "SendDPStatus", "SendMsg", "SendNotification", "SimpleSound", "UpdateCrewseatAnglePenalty",
+    "UpdateGForcePenalty", "UpperCommonDataDisplay", "VisualizeSZ", "refreshdata", "table_contains",
+}
+
+for _, name in ipairs(legacyACEFunctions) do
+    local func = ACE[name]
+    if type(func) == "function" then
+        _G["ACE_" .. name] = func
+    end
+end
 
 print("[ACE | INFO]- Done!")

--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -73,10 +73,10 @@ local function ClearPrimitiveArmorState(ent)
 end
 
 local function MarkPrimitiveArmorDirty(ent, reason)
-	if ACE_ClearArmorPointCache then ACE_ClearArmorPointCache(ent) end
+	if ACE.ClearArmorPointCache then ACE.ClearArmorPointCache(ent) end
 
 	local con = ent.CFW_GetContraption and ent:CFW_GetContraption()
-	if ACE_MarkArmorDirty then ACE_MarkArmorDirty(con, ent, reason) end
+	if ACE.MarkArmorDirty then ACE.MarkArmorDirty(con, ent, reason) end
 end
 
 local function ApplyPrimitiveArmor(ent, phys)
@@ -129,7 +129,7 @@ end
 -- Primitive_PostRebuildPhysics fires before Primitive restores its serialized mass/material props.
 -- The PhysObj:SetMass wrapper lets ACE finalize its mass-dependent armor state without a timer;
 -- ACE restores the serialized material in the same finalization path.
-function ACE_PrimitivePropertiesApplied(ent)
+function ACE.PrimitivePropertiesApplied(ent)
 	if not IsValid(ent) or ent.ACE_PrimitiveFinalizing or not ent.ACE_PrimitivePropertiesPending then return end
 	if HasPendingPhysicsClip(ent) and not ent.ACE_PrimitiveClippingHandled then return end
 
@@ -143,6 +143,8 @@ hook.Add("Primitive_PreRebuildPhysics", "ACE_RememberPrimitiveCollisionGroup", f
 	ent.ACE_PrimitivePropertiesPending = nil
 	ent.ACE_PrimitiveClippingHandled = nil
 end)
+
+ACE_PrimitivePropertiesApplied = ACE.PrimitivePropertiesApplied
 
 hook.Add("Primitive_PostRebuildPhysics", "ACE_PrimitiveArmorRecalc", function(ent, props)
 	if not IsValid(ent) then return end

--- a/lua/autorun/sh_ace_workarounds.lua
+++ b/lua/autorun/sh_ace_workarounds.lua
@@ -3,7 +3,7 @@
 if CLIENT then
 
 	--Copied from garrysmod CalcVehicleView function, to allow acf ents to be included into the filter
-	function ACE_CalcVehicleView( Vehicle, ply, view )
+	function ACE.CalcVehicleView( Vehicle, ply, view )
 
 		--Make sure that allowed seats use this override.
 		if not Vehicle.ACE_CamOverride then return end
@@ -55,9 +55,11 @@ if CLIENT then
 	end
 
 	hook.Remove( "CalcVehicleView", "ACE_CalcVehicleView_Override")
-	hook.Add( "CalcVehicleView", "ACE_CalcVehicleView_Override", ACE_CalcVehicleView)
+	hook.Add( "CalcVehicleView", "ACE_CalcVehicleView_Override", ACE.CalcVehicleView)
 
 end
+
+ACE_CalcVehicleView = ACE.CalcVehicleView
 
 -- Workaround to issue: https://github.com/Facepunch/garrysmod-issues/issues/4142. Brought from ACF3
 local Hull = util.TraceHull

--- a/lua/effects/ace_scaled_detonation/init.lua
+++ b/lua/effects/ace_scaled_detonation/init.lua
@@ -84,7 +84,7 @@ function EFFECT:Init( data )
 	end
 
 	local Mat = Ground.MatType or 0
-	local Material = ACE_GetMaterialName( Mat )
+	local Material = ACE.GetMaterialName( Mat )
 
 	if Ground.HitNonWorld then --Overide with ACE prop material
 		Mat = Mat

--- a/lua/effects/acf_ap_impact/init.lua
+++ b/lua/effects/acf_ap_impact/init.lua
@@ -78,7 +78,7 @@ function EFFECT:Init( data )
 		if self.Id and self.Id == "FL" then self.Caliber = 0.01 end
 
 		local Mat = SurfaceTr.MatType or 0
-		MatVal = ACE_GetMaterialName( Mat )
+		MatVal = ACE.GetMaterialName( Mat )
 
 		if SurfaceTr.HitNonWorld then --Overide with ACE prop material
 			local TEnt = SurfaceTr.Entity
@@ -128,7 +128,7 @@ function EFFECT:Init( data )
 		end
 
 		util.Decal(DecalMat, SurfaceTr.StartPos, self.Origin + self.DirVec * 10 )
-		ACE_SBulletImpact( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal )
+		ACE.SBulletImpact( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal )
 
 	end
 

--- a/lua/effects/acf_ap_penetration/init.lua
+++ b/lua/effects/acf_ap_penetration/init.lua
@@ -89,7 +89,7 @@ function EFFECT:Init( data )
 	if self.Id and not RoundTypesIgnore[self.Id] and ((IsValid(TraceEntity) and not EntityFilter[TraceEntity:GetClass()]) or SurfaceTr.HitWorld) then
 
 		local Mat = SurfaceTr.MatType or 0
-		MatVal = ACE_GetMaterialName( Mat )
+		MatVal = ACE.GetMaterialName( Mat )
 		if SurfaceTr.HitNonWorld then --Overide with ACE prop material
 			local TEnt = SurfaceTr.Entity
 			if  TEnt:IsPlayer() or TEnt:IsNPC() then --Super disgusting. Get rid of this ASAP.
@@ -155,7 +155,7 @@ function EFFECT:Init( data )
 
 	end
 
-	ACE_SPenetration( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal, self.Mass )
+	ACE.SPenetration( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal, self.Mass )
 
 	local Energy = (self.Mass * (self.Velocity / 39.37) ^2) / 500000
 	local LocPly = LocalPlayer()

--- a/lua/effects/acf_ap_ricochet/init.lua
+++ b/lua/effects/acf_ap_ricochet/init.lua
@@ -51,7 +51,7 @@ function EFFECT:Init( data )
 		if self.Id and self.Id == "FL" then self.Caliber = 0.01 end
 
 		local Mat = SurfaceTr.MatType
-		MatVal = ACE_GetMaterialName( Mat )
+		MatVal = ACE.GetMaterialName( Mat )
 
 		if SurfaceTr.HitNonWorld then --Overide with ACE prop material
 			local TEnt = SurfaceTr.Entity
@@ -91,7 +91,7 @@ function EFFECT:Init( data )
 		end
 
 	util.Decal(DecalMat, self.Origin + self.DirVec * 10, self.Origin - self.DirVec * 10 )
-	ACE_SRicochet( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal )
+	ACE.SRicochet( self.Origin, self.Caliber, self.Velocity, SurfaceTr.HitWorld, MatVal )
 
 	local Energy = (self.Mass * (self.Velocity / 39.37) ^2) / 1700000
 

--- a/lua/effects/acf_bulleteffect/init.lua
+++ b/lua/effects/acf_bulleteffect/init.lua
@@ -1,6 +1,6 @@
 
 --This is a fully loaded bullet removal
-function ACE_RemoveBulletClient( Bullet, Index )
+function ACE.RemoveBulletClient( Bullet, Index )
 
 	if Bullet then
 
@@ -177,8 +177,8 @@ local function CanBulletCrack( Bullet )
 
 	if Bullet.IsMissile then return false end
 	if Bullet.CrackCreated then return false end
-	if ACE_SInDistance( Bullet.InitialPos, 750 ) then return false end
-	if not ACE_SInDistance( Bullet.SimPos, math.max(Bullet.Caliber * 100 * ACE.CrackDistanceMultipler,250) ) then return false end
+	if ACE.SInDistance( Bullet.InitialPos, 750 ) then return false end
+	if not ACE.SInDistance( Bullet.SimPos, math.max(Bullet.Caliber * 100 * ACE.CrackDistanceMultipler,250) ) then return false end
 	if Bullet.Impacted then return false end
 
 	local SqrtSpeed = (Bullet.SimPos - Bullet.SimPosLast):LengthSqr()
@@ -199,9 +199,9 @@ local function CanWhistle( Bullet )
 	local BulSpeed = Bullet.SimFlight:Length()
 
 	if BulSpeed < 50 then return false end
-	if not ACE_SInDistance( Bullet.SimPos, math.min(BulSpeed, 5000)) then return false end
+	if not ACE.SInDistance( Bullet.SimPos, math.min(BulSpeed, 5000)) then return false end
 
-	if ACE_Approaching( Bullet.SimPos, Bullet.SimFlight ) > 0 then return false end --Shell is moving away.
+	if ACE.Approaching( Bullet.SimPos, Bullet.SimFlight ) > 0 then return false end --Shell is moving away.
 
 
 	return true
@@ -222,7 +222,7 @@ function EFFECT:ApplyMovement( Bullet, Index )
 
 	local setPos = Bullet.SimPos
 	if (math.abs(setPos.x) > 16380) or (math.abs(setPos.y) > 16380) or (setPos.z < -16380) then -- the bullet will never come back to the map.
-		ACE_RemoveBulletClient( Bullet, Index )
+		ACE.RemoveBulletClient( Bullet, Index )
 
 		return
 	end
@@ -232,12 +232,12 @@ function EFFECT:ApplyMovement( Bullet, Index )
 
 		--sonic crack sound
 		if CanBulletCrack( Bullet ) then
-			ACE_SBulletCrack(Bullet, Bullet.Caliber)
+			ACE.SBulletCrack(Bullet, Bullet.Caliber)
 		end
 
 		--incoming shell whistle
 		if CanWhistle( Bullet ) then
-			ACE_SBulletWhistle(Bullet, Bullet.Caliber)
+			ACE.SBulletWhistle(Bullet, Bullet.Caliber)
 		end
 
 		local WaterTr = { }
@@ -255,7 +255,7 @@ function EFFECT:ApplyMovement( Bullet, Index )
 	else
 		--We don't need small bullets to stay outside of skybox. This is meant for large calibers only.
 		if Bullet.Caliber < 5 then
-			ACE_RemoveBulletClient( Bullet, Index )
+			ACE.RemoveBulletClient( Bullet, Index )
 			return
 		end
 	end
@@ -316,7 +316,7 @@ function EFFECT:ApplyMovement( Bullet, Index )
 			Sparks:SetScale( Bullet.Caliber * 10 )
 			util.Effect( "watersplash", Sparks )
 
-			ACE_EmitSound( "ambient/water/water_splash" .. math.random(1,3) .. ".wav" , Water.HitPos, 100, 100 / Bullet.Caliber * 4, 300 )
+			ACE.EmitSound( "ambient/water/water_splash" .. math.random(1,3) .. ".wav" , Water.HitPos, 100, 100 / Bullet.Caliber * 4, 300 )
 
 			Bullet.HasSplashed = true
 		end
@@ -383,3 +383,5 @@ function EFFECT:Render()
 	end
 
 end
+
+ACE_RemoveBulletClient = ACE.RemoveBulletClient

--- a/lua/effects/acf_missilelaunch/init.lua
+++ b/lua/effects/acf_missilelaunch/init.lua
@@ -18,7 +18,7 @@ function EFFECT:Init( data )
 			Sound = "acf_extra/airfx/rocket_fire2.wav"
 		end
 
-		ACE_SimpleSound( Sound, Missile:WorldSpaceCenter(), SoundPitch, 4000 )
+		ACE.SimpleSound( Sound, Missile:WorldSpaceCenter(), SoundPitch, 4000 )
 	end
 end
 

--- a/lua/effects/acf_muzzleflash/init.lua
+++ b/lua/effects/acf_muzzleflash/init.lua
@@ -49,7 +49,7 @@ function EFFECT:Init( data )
 
 	if Propellant > 0 then
 
-		ACE_SGunFire( Gun, Sound, SoundPitch, Propellant )
+		ACE.SGunFire( Gun, Sound, SoundPitch, Propellant )
 
 		local Muzzle = Gun:GetAttachment( Gun:LookupAttachment(Attachment)) or { Pos = Gun:GetPos(), Ang = Gun:GetAngles() }
 
@@ -127,7 +127,7 @@ function EFFECT:Shockwave( MuzzleType )
 	local Ground = util.TraceLine( GroundTr )
 
 	local MatType = Ground.MatType or 0
-	local Materialvalue = ACE_GetMaterialName( MatType )
+	local Materialvalue = ACE.GetMaterialName( MatType )
 	local DustColors = table.Copy(ACE.DustMaterialColor)
 
 	-- The explosion was detonated above a prop

--- a/lua/effects/acf_radar_noise/init.lua
+++ b/lua/effects/acf_radar_noise/init.lua
@@ -13,7 +13,7 @@ function EFFECT:Init( data )
 			Sound = ACFM.DefaultRadarSound
 		end
 
-		ACE_SimpleSound( Sound, Radar:WorldSpaceCenter(), SoundPitch, 1000 )
+		ACE.SimpleSound( Sound, Radar:WorldSpaceCenter(), SoundPitch, 1000 )
 	end
 end
 

--- a/lua/effects/acf_scaled_explosion/init.lua
+++ b/lua/effects/acf_scaled_explosion/init.lua
@@ -42,7 +42,7 @@ function EFFECT:Init( data )
 
 	local Mat = Ground.MatType or 0
 	--print(Ground.MatType)
-	local Material = ACE_GetMaterialName( Mat )
+	local Material = ACE.GetMaterialName( Mat )
 
 	--Overide with ACE prop material
 	if Ground.HitNonWorld then
@@ -92,7 +92,7 @@ function EFFECT:Init( data )
 		ACF_RenderLight( 0, self.Radius * 1800, Color(255, 90, 15), self.Origin, 1) -- idx 0: world
 	end
 
-	ACE_SBlast( self.Origin, self.Radius, self.HitWater, Ground.HitWorld )
+	ACE.SBlast( self.Origin, self.Radius, self.HitWater, Ground.HitWorld )
 
 	local PlayerDist = (LocalPlayer():GetPos() - self.Origin):Length() / 20 + 0.001 --Divide by 0 is death, 20 is roughly 39.37 / 2
 	if PlayerDist < self.Radius * 10 and not LocalPlayer():HasGodMode() then

--- a/lua/effects/acf_smoke/init.lua
+++ b/lua/effects/acf_smoke/init.lua
@@ -60,7 +60,7 @@ function EFFECT:Init( data )
         Flash:SetRadius( math.Round(math.max(Radius / 39.37, 1),2) )
     util.Effect( "ACF_Scaled_Explosion", Flash )
 
-    ACE_SBlast( self.Origin, self.Magnitude, false, Ground.HitWorld ) --hitwater is false
+    ACE.SBlast( self.Origin, self.Magnitude, false, Ground.HitWorld ) --hitwater is false
 
     self.Emitter:Finish()
     DebugEffect("acf_smoke Init:Exit")

--- a/lua/entities/ace_bomb_aerial/init.lua
+++ b/lua/entities/ace_bomb_aerial/init.lua
@@ -6,5 +6,5 @@ include("shared.lua")
 DEFINE_BASECLASS("ace_explosive_prebuilt")
 
 duplicator.RegisterEntityClass("ace_bomb_aerial", function(ply, Pos, Ang)
-	return ACE_MakePrebuiltExplosive(ply, "ace_bomb_aerial", Pos, Ang)
+	return ACE.MakePrebuiltExplosive(ply, "ace_bomb_aerial", Pos, Ang)
 end, "Pos", "Angle")

--- a/lua/entities/ace_bomb_barrel/init.lua
+++ b/lua/entities/ace_bomb_barrel/init.lua
@@ -6,5 +6,5 @@ include("shared.lua")
 DEFINE_BASECLASS("ace_explosive_prebuilt")
 
 duplicator.RegisterEntityClass("ace_bomb_barrel", function(ply, Pos, Ang)
-	return ACE_MakePrebuiltExplosive(ply, "ace_bomb_barrel", Pos, Ang)
+	return ACE.MakePrebuiltExplosive(ply, "ace_bomb_barrel", Pos, Ang)
 end, "Pos", "Angle")

--- a/lua/entities/ace_bomb_satchel/init.lua
+++ b/lua/entities/ace_bomb_satchel/init.lua
@@ -8,5 +8,5 @@ DEFINE_BASECLASS("ace_explosive_prebuilt")
 -- The Make/SpawnFunction/logic all live on the base. Looked up lazily so the
 -- base entity having loaded after this one doesn't matter.
 duplicator.RegisterEntityClass("ace_bomb_satchel", function(ply, Pos, Ang)
-	return ACE_MakePrebuiltExplosive(ply, "ace_bomb_satchel", Pos, Ang)
+	return ACE.MakePrebuiltExplosive(ply, "ace_bomb_satchel", Pos, Ang)
 end, "Pos", "Angle")

--- a/lua/entities/ace_crewseat_driver/init.lua
+++ b/lua/entities/ace_crewseat_driver/init.lua
@@ -8,7 +8,7 @@ local round, ceil = math.Round, math.ceil
 local CrewseatTable = ACF.Weapons.Crewseats
 
 function ENT:Initialize()
-	ACE_InitializeCrewseat(self, self.ModelType)
+	ACE.InitializeCrewseat(self, self.ModelType)
 
 	self.LinkedEngine = nil
 
@@ -63,12 +63,12 @@ list.Set("ACFCvars", "ace_crewseat_driver", {"id", "entitydata"})
 duplicator.RegisterEntityClass("ace_crewseat_driver", MakeACE_Crewseat_Driver, "Pos", "Angle", "Id", "ModelType")
 
 function ENT:GetPoseModifiers()
-	return ACE_GetPoseModifiers(self) or { gforce = 1, tilt = 1 }
+	return ACE.GetPoseModifiers(self) or { gforce = 1, tilt = 1 }
 end
 
 function ENT:Think()
-	ACE_UpdateCrewseatAnglePenalty(self)
-	ACE_CrewseatLegalCheck(self)
+	ACE.UpdateCrewseatAnglePenalty(self)
+	ACE.CrewseatLegalCheck(self)
 
 	local eng = self.LinkedEngine
 	if not self.Legal and IsValid(eng) then
@@ -80,7 +80,7 @@ function ENT:Think()
 end
 
 function ENT:OnRemove()
-	ACE_CrewseatOnRemove(self)
+	ACE.CrewseatOnRemove(self)
 end
 
 function ENT:UpdateWireOutputs()
@@ -95,7 +95,7 @@ end
 function ENT:UpdateOverlayText()
 	local hp = round(self.ACF.Health / self.ACF.MaxHealth * 100)
 	local pose = self:GetPoseModifiers()
-	local isStanding = ACE_IsStandingPose(self.ModelType)
+	local isStanding = ACE.IsStandingPose(self.ModelType)
 
 	local str = self.Name
 	str = str .. "\n\nHealth: " .. hp .. "%"
@@ -131,14 +131,14 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
-	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
-	ACE_CrewseatDeferredModelSync(self, info)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE.CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
+	ACE.CrewseatDeferredModelSync(self, info)
 end
 
 function ENT:ACF_OnDamage(Entity, Energy, FrArea, _, Inflictor, _, _)
-	local HitRes = ACE_CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
+	local HitRes = ACE.CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
 
 	if HitRes.Kill or HitRes.Overkill > 1 then
 		self:ConsumeCrewseats()

--- a/lua/entities/ace_crewseat_gunner/init.lua
+++ b/lua/entities/ace_crewseat_gunner/init.lua
@@ -8,7 +8,7 @@ local round, ceil = math.Round, math.ceil
 local CrewseatTable = ACF.Weapons.Crewseats
 
 function ENT:Initialize()
-	ACE_InitializeCrewseat(self, self.ModelType)
+	ACE.InitializeCrewseat(self, self.ModelType)
 
 	self.LinkedGun = nil
 
@@ -64,7 +64,7 @@ list.Set("ACFCvars", "ace_crewseat_gunner", {"id", "entitydata"})
 duplicator.RegisterEntityClass("ace_crewseat_gunner", MakeACE_Crewseat_Gunner, "Pos", "Angle", "Id", "ModelType")
 
 function ENT:GetPoseModifiers()
-	return ACE_GetPoseModifiers(self) or { gforce = 1, tilt = 1, accuracy = 1 }
+	return ACE.GetPoseModifiers(self) or { gforce = 1, tilt = 1, accuracy = 1 }
 end
 
 function ENT:GetAccuracyPenalty()
@@ -84,9 +84,9 @@ function ENT:GetAccuracyPenalty()
 end
 
 function ENT:Think()
-	ACE_UpdateCrewseatAnglePenalty(self)
-	ACE_UpdateGForcePenalty(self)
-	ACE_CrewseatLegalCheck(self)
+	ACE.UpdateCrewseatAnglePenalty(self)
+	ACE.UpdateGForcePenalty(self)
+	ACE.CrewseatLegalCheck(self)
 
 	local gun = self.LinkedGun
 	if not self.Legal and IsValid(gun) then
@@ -98,7 +98,7 @@ function ENT:Think()
 end
 
 function ENT:OnRemove()
-	ACE_CrewseatOnRemove(self)
+	ACE.CrewseatOnRemove(self)
 end
 
 function ENT:UpdateWireOutputs()
@@ -114,7 +114,7 @@ end
 function ENT:UpdateOverlayText()
 	local hp = round(self.ACF.Health / self.ACF.MaxHealth * 100)
 	local pose = self:GetPoseModifiers()
-	local isStanding = ACE_IsStandingPose(self.ModelType)
+	local isStanding = ACE.IsStandingPose(self.ModelType)
 
 	local str = self.Name
 	str = str .. "\n\nHealth: " .. hp .. "%"
@@ -154,7 +154,7 @@ function ENT:UpdateOverlayText()
 end
 
 function ENT:ACF_OnDamage(Entity, Energy, FrArea, _, Inflictor, _, _)
-	local HitRes = ACE_CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
+	local HitRes = ACE.CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
 
 	if HitRes.Kill or HitRes.Overkill > 1 then
 		self:ConsumeCrewseats()
@@ -165,7 +165,7 @@ function ENT:ACF_OnDamage(Entity, Energy, FrArea, _, Inflictor, _, _)
 end
 
 function ENT:ConsumeCrewseats()
-	ACE_CrewseatDeathSound(self)
+	ACE.CrewseatDeathSound(self)
 
 	self.Legal = false
 	self.LegalIssues = "Apparently He Died"
@@ -179,7 +179,7 @@ function ENT:ConsumeCrewseats()
 		end
 	end
 
-	local ReplaceEnt, ClosestDist = ACE_FindReplacementLoader(self)
+	local ReplaceEnt, ClosestDist = ACE.FindReplacementLoader(self)
 
 	if IsValid(ReplaceEnt) then
 		self.Name = ReplaceEnt.Name
@@ -225,8 +225,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
-	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, false)
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
-	ACE_CrewseatDeferredModelSync(self, info)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE.CrewseatApplyDupeModel(self, info, defaultModelType, false)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
+	ACE.CrewseatDeferredModelSync(self, info)
 end

--- a/lua/entities/ace_crewseat_loader/init.lua
+++ b/lua/entities/ace_crewseat_loader/init.lua
@@ -9,7 +9,7 @@ local clamp = math.Clamp
 local CrewseatTable = ACF.Weapons.Crewseats
 
 function ENT:Initialize()
-	ACE_InitializeCrewseat(self, self.ModelType)
+	ACE.InitializeCrewseat(self, self.ModelType)
 
 	self.Stamina = 100
 	self.LinkedGun = nil
@@ -70,7 +70,7 @@ list.Set("ACFCvars", "ace_crewseat_loader", {"id", "entitydata"})
 duplicator.RegisterEntityClass("ace_crewseat_loader", MakeACE_Crewseat_Loader, "Pos", "Angle", "Id", "ModelType")
 
 function ENT:GetPoseModifiers()
-	return ACE_GetPoseModifiers(self) or { gforce = 1, tilt = 1, stamina = 1 }
+	return ACE.GetPoseModifiers(self) or { gforce = 1, tilt = 1, stamina = 1 }
 end
 
 function ENT:DecreaseStamina()
@@ -126,9 +126,9 @@ function ENT:IncreaseStamina()
 end
 
 function ENT:Think()
-	ACE_UpdateCrewseatAnglePenalty(self)
-	ACE_UpdateGForcePenalty(self)
-	ACE_CrewseatLegalCheck(self)
+	ACE.UpdateCrewseatAnglePenalty(self)
+	ACE.UpdateGForcePenalty(self)
+	ACE.CrewseatLegalCheck(self)
 
 	if self.Legal then
 		self:IncreaseStamina()
@@ -144,7 +144,7 @@ function ENT:Think()
 end
 
 function ENT:OnRemove()
-	ACE_CrewseatOnRemove(self)
+	ACE.CrewseatOnRemove(self)
 end
 
 function ENT:UpdateWireOutputs()
@@ -161,7 +161,7 @@ function ENT:UpdateOverlayText()
 	local hp = round(self.ACF.Health / self.ACF.MaxHealth * 100)
 	local stamina = round(self.Stamina)
 	local pose = self:GetPoseModifiers()
-	local isStanding = ACE_IsStandingPose(self.ModelType)
+	local isStanding = ACE.IsStandingPose(self.ModelType)
 
 	local str = self.Name
 	str = str .. "\n\nHealth: " .. hp .. "%"
@@ -201,10 +201,10 @@ function ENT:UpdateOverlayText()
 end
 
 function ENT:ACF_OnDamage(Entity, Energy, FrArea, _, Inflictor, _, _)
-	local HitRes = ACE_CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
+	local HitRes = ACE.CrewseatDamage(self, Entity, Energy, FrArea, Inflictor)
 
 	if HitRes.Kill or HitRes.Overkill > 1 then
-		ACE_CrewseatDeathSound(self)
+		ACE.CrewseatDeathSound(self)
 		ACF_HEKill(self, VectorRand(), 0)
 		return { Damage = 0, Overkill = 0, Loss = 0, Kill = false }
 	end
@@ -225,8 +225,8 @@ function ENT:ApplyDupeInfo(ply, ent, info, GetEntByID)
 	local class = self:GetClass()
 	local defaultModelType = (ACE.CrewseatDefaults and ACE.CrewseatDefaults[class]) or "Sitting"
 
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
-	local modelType, _, reason = ACE_CrewseatApplyDupeModel(self, info, defaultModelType, true)
-	ACE_CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
-	ACE_CrewseatDeferredModelSync(self, info)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoStart", info, "model=" .. tostring(self:GetModel()))
+	local modelType, _, reason = ACE.CrewseatApplyDupeModel(self, info, defaultModelType, true)
+	ACE.CrewseatDebugLog(self, "ApplyDupeInfoEnd", info, "resolved=" .. tostring(modelType) .. " reason=" .. tostring(reason))
+	ACE.CrewseatDeferredModelSync(self, info)
 end

--- a/lua/entities/ace_explosive/init.lua
+++ b/lua/entities/ace_explosive/init.lua
@@ -15,7 +15,7 @@ local STEEL_DENS  = 7.9      -- g/cm^3 (casing)
 -- not tens). Returns: fillerMass (HE), fragMass (casing, for blast frag),
 -- physMass (what the prop actually weighs - much lighter than solid steel, since
 -- a charge is mostly filler + thin casing, not a billet).
-function ACE_GetExplosiveMasses(volCuIn, fillerFraction)
+function ACE.GetExplosiveMasses(volCuIn, fillerFraction)
 	local f         = fillerFraction or ACF.ExplosiveFillerFraction or 0.65
 	local mul       = ACF.ExplosiveHEMul or 0.12
 	local cm3       = volCuIn * CUIN_TO_CM3
@@ -28,6 +28,8 @@ function ACE_GetExplosiveMasses(volCuIn, fillerFraction)
 
 	return fillerMass, fragMass, math.max(physMass, 1)
 end
+
+ACE_GetExplosiveMasses = ACE.GetExplosiveMasses
 
 function ENT:Initialize()
 	self.Detonated     = false
@@ -70,7 +72,7 @@ function MakeACE_Explosive(Owner, Pos, Angle, Id, Data1, Data2)
 	local info = Scalable.ApplyShape(Charge, scaleVec, Data2, def)
 	if not info then Charge:Remove() return false end
 
-	local fillerMass, fragMass, physMass = ACE_GetExplosiveMasses(info.volume, def.FillerFraction)
+	local fillerMass, fragMass, physMass = ACE.GetExplosiveMasses(info.volume, def.FillerFraction)
 
 	Charge.Id          = Id
 	Charge.SizeId      = Data1
@@ -78,7 +80,7 @@ function MakeACE_Explosive(Owner, Pos, Angle, Id, Data1, Data2)
 	Charge.Dimensions  = info.dims
 	Charge.FillerMass  = fillerMass
 	Charge.FragMass    = fragMass
-	Charge.BlastRadius = ACE_CalculateHERadius(fillerMass) / 39.37   -- metres
+	Charge.BlastRadius = ACE.CalculateHERadius(fillerMass) / 39.37   -- metres
 	Charge.Mass        = physMass
 	Charge.DamageOwner = Owner
 
@@ -104,7 +106,7 @@ function ENT:Detonate()
 	-- Identical to how HE rounds deal their blast.
 	ACF_HE(origin, Vector(0, 0, 1), self.FillerMass or 0, self.FragMass or 0, owner, self, self)
 
-	local radiusIn = ACE_CalculateHERadius(self.FillerMass or 0)
+	local radiusIn = ACE.CalculateHERadius(self.FillerMass or 0)
 	local Flash = EffectData()
 		Flash:SetOrigin(origin)
 		Flash:SetNormal(Vector(0, 0, -1))
@@ -177,9 +179,9 @@ function ENT:UpdateOverlayText()
 	txt = txt .. "\nBlast Energy: " .. math.Round((self.FillerMass or 0) * (ACF.HEPower or 8000), 0) .. " KJ"
 	txt = txt .. "\nMass: " .. math.Round(self.Mass or 0, 1) .. " kg"
 
-	if ACE_GetRoundLethalityLine then
+	if ACE.GetRoundLethalityLine then
 		local round = { Type = "HE", maxPen = 0, FrArea = 0, blastMass = self.FillerMass or 0, guidance = "Dumb" }
-		local lethality = ACE_GetRoundLethalityLine(round)
+		local lethality = ACE.GetRoundLethalityLine(round)
 		if lethality then
 			txt = txt .. "\nLethality: " .. lethality
 		end

--- a/lua/entities/ace_explosive_prebuilt/init.lua
+++ b/lua/entities/ace_explosive_prebuilt/init.lua
@@ -27,7 +27,7 @@ end
 -- the model + filler fraction through its ENT table (read off the created
 -- entity), and we read the model's REAL physics volume at its natural size -
 -- no model scaling on these props.
-function ACE_MakePrebuiltExplosive(Owner, class, Pos, Angle)
+function ACE.MakePrebuiltExplosive(Owner, class, Pos, Angle)
 	if IsValid(Owner) and not Owner:CheckLimit("_ace_explosive") then return false end
 
 	local stored = scripted_ents.GetStored(class)
@@ -46,11 +46,11 @@ function ACE_MakePrebuiltExplosive(Owner, class, Pos, Angle)
 
 	local phys    = Charge:GetPhysicsObject()
 	local volCuIn = (IsValid(phys) and phys:GetVolume()) or 1000   -- model's true volume
-	local fillerMass, fragMass, physMass = ACE_GetExplosiveMasses(volCuIn, Charge.FillerFraction or def.FillerFraction)
+	local fillerMass, fragMass, physMass = ACE.GetExplosiveMasses(volCuIn, Charge.FillerFraction or def.FillerFraction)
 
 	Charge.FillerMass  = fillerMass
 	Charge.FragMass    = fragMass
-	Charge.BlastRadius = ACE_CalculateHERadius(fillerMass) / 39.37
+	Charge.BlastRadius = ACE.CalculateHERadius(fillerMass) / 39.37
 	Charge.Mass        = physMass
 	Charge.DamageOwner = Owner
 
@@ -74,6 +74,8 @@ function ACE_MakePrebuiltExplosive(Owner, class, Pos, Angle)
 	return Charge
 end
 
+ACE_MakePrebuiltExplosive = ACE.MakePrebuiltExplosive
+
 -- Shared by every variant's SpawnFunction (sandbox Q-menu). GMod passes the
 -- concrete class name as the third argument, which is exactly the variant we
 -- want to spawn.
@@ -82,7 +84,7 @@ function ENT:SpawnFunction(ply, tr, ClassName)
 	local class = ClassName or self.ClassName or "ace_bomb_satchel"
 	local pos = tr.HitPos + tr.HitNormal * 16
 	local ang = Angle(0, IsValid(ply) and ply:EyeAngles().yaw or 0, 0)
-	return ACE_MakePrebuiltExplosive(ply, class, pos, ang)
+	return ACE.MakePrebuiltExplosive(ply, class, pos, ang)
 end
 
 function ENT:Detonate()
@@ -95,7 +97,7 @@ function ENT:Detonate()
 
 	ACF_HE(origin, Vector(0, 0, 1), self.FillerMass or 0, self.FragMass or 0, owner, self, self)
 
-	local radiusIn = ACE_CalculateHERadius(self.FillerMass or 0)
+	local radiusIn = ACE.CalculateHERadius(self.FillerMass or 0)
 	local Flash = EffectData()
 		Flash:SetOrigin(origin)
 		Flash:SetNormal(Vector(0, 0, -1))
@@ -163,9 +165,9 @@ function ENT:UpdateOverlayText()
 	txt = txt .. "\nBlast Energy: " .. math.Round((self.FillerMass or 0) * (ACF.HEPower or 8000), 0) .. " KJ"
 	txt = txt .. "\nMass: " .. math.Round(self.Mass or 0, 1) .. " kg"
 
-	if ACE_GetRoundLethalityLine then
+	if ACE.GetRoundLethalityLine then
 		local round = { Type = "HE", maxPen = 0, FrArea = 0, blastMass = self.FillerMass or 0, guidance = "Dumb" }
-		local lethality = ACE_GetRoundLethalityLine(round)
+		local lethality = ACE.GetRoundLethalityLine(round)
 		if lethality then
 			txt = txt .. "\nLethality: " .. lethality
 		end

--- a/lua/entities/ace_flare/cl_init.lua
+++ b/lua/entities/ace_flare/cl_init.lua
@@ -12,7 +12,7 @@ function ENT:Initialize()
 
 	if InterpretColor.b == 1 then --Flare
 		ParticleEffectAttach("ACFM_Flare",4, self,1) --TODO: Create a way to identify chaff/flare.  And make effects scale with flare filler.
-		ACE_EmitSound( FlareSound, self, 70, 100, 1 )
+		ACE.EmitSound( FlareSound, self, 70, 100, 1 )
 	else
 		ParticleEffectAttach("ACFM_Chaff",4, self,1) --TODO: Create a way to identify chaff/flare.  And make effects scale with flare filler.
 		self.StopLight = true

--- a/lua/entities/ace_irst/init.lua
+++ b/lua/entities/ace_irst/init.lua
@@ -241,7 +241,7 @@ function ENT:ScanForContraptions()
 		local BaseTemp = 0
 
 		if IsValid(BasePhys) and BasePhys:IsMoveable() then
-			BaseTemp = ACE_InfraredHeatFromProp(Base, self.HeatAboveAmbient)
+			BaseTemp = ACE.InfraredHeatFromProp(Base, self.HeatAboveAmbient)
 		end
 
 		local Pos
@@ -293,7 +293,7 @@ function ENT:ScanForContraptions()
 
 			self.TargetDetected = true
 
-			local Index = ACE_GetContraptionIndex(Contraption)
+			local Index = ACE.GetContraptionIndex(Contraption)
 
 			self.IRResolution[Index] = Clamp((self.IRResolution[Index] or self.MaxInaccuracy) - self.ResolveSpeedBase * self.ThinkDelay * ResolveMul * 2.5,ClampMin,self.MaxInaccuracy)
 
@@ -308,7 +308,7 @@ function ENT:ScanForContraptions()
 
 			FinalAngle.r = 0
 
-			local InsertionIndex = ACE_GetBinaryInsertIndex(Distances, Distance)
+			local InsertionIndex = ACE.GetBinaryInsertIndex(Distances, Distance)
 
 			insert(Distances, InsertionIndex, Distance)
 			insert(AngTable, InsertionIndex, FinalAngle)
@@ -370,7 +370,7 @@ function ENT:ScanForContraptions()
 
 			FinalAngle.r = 0
 
-			local InsertionIndex = ACE_GetBinaryInsertIndex(Distances, Distance)
+			local InsertionIndex = ACE.GetBinaryInsertIndex(Distances, Distance)
 
 			insert(Distances, InsertionIndex, Distance)
 			insert(AngTable, InsertionIndex, FinalAngle)

--- a/lua/entities/ace_mine/init.lua
+++ b/lua/entities/ace_mine/init.lua
@@ -107,7 +107,7 @@ do
 
 		local HEWeight = self.HEWeight
 		local FragMass = self.FragMass
-		local Radius = ACE_CalculateHERadius( HEWeight )
+		local Radius = ACE.CalculateHERadius( HEWeight )
 		local ExplosionOrigin = self:LocalToWorld(Vector(0,0,5))
 
 		ACF_HE( ExplosionOrigin, Vector(0,0,1), HEWeight, FragMass, self.DamageOwner, self, self) --0.5 is standard antipersonal mine
@@ -183,7 +183,7 @@ do
 
 	local MineTable = ACE.MineData
 
-	function ACE_CreateMine( MineId, Pos, Angle, Owner )
+	function ACE.CreateMine( MineId, Pos, Angle, Owner )
 		if not IsValid(Owner) then return end
 
 		VerifyMineLimits(Owner)
@@ -241,3 +241,5 @@ do
 		end
 	end
 end
+
+ACE_CreateMine = ACE.CreateMine

--- a/lua/entities/ace_searchradar/init.lua
+++ b/lua/entities/ace_searchradar/init.lua
@@ -397,8 +397,8 @@ function ENT:Think()
 
 				OutputPosition = BasePos + BaseInaccuracy
 
-				local ContraptionIndex = ACE_GetContraptionIndex(Contraption)
-				local InsertionIndex = ACE_GetBinaryInsertIndex(Distances, BaseDistance)
+				local ContraptionIndex = ACE.GetContraptionIndex(Contraption)
+				local InsertionIndex = ACE.GetBinaryInsertIndex(Distances, BaseDistance)
 
 
 				tableInsert(Owners, InsertionIndex, Owner:Nick())

--- a/lua/entities/ace_sonar/init.lua
+++ b/lua/entities/ace_sonar/init.lua
@@ -472,7 +472,7 @@ function ENT:activeSonar()
 	----------------------------------------
 
 	local SelfContraption = self.SelfContraption
-	local MyID = ACE_GetContraptionIndex(SelfContraption) or -1
+	local MyID = ACE.GetContraptionIndex(SelfContraption) or -1
 
 
 	local CacheTime = ACF.CurTime + 5 --Time in seconds to remove a sonar ping
@@ -590,7 +590,7 @@ function ENT:activeSonar()
 				if not IsValid(Base) then return end
 				debugoverlay.Line(SelfPos, BasePos, TravelTime, Color(0, 255, 38), true)
 
-				local ID = ACE_GetContraptionIndex(Contraption)
+				local ID = ACE.GetContraptionIndex(Contraption)
 				local Owner = Base:CPPIGetOwner()
 
 
@@ -713,7 +713,7 @@ function ENT:passiveSonar() --Subject to rework
 				if not IsValid(Base) then return end
 				debugoverlay.Line(SelfPos, BasePos, TravelTime, Color(0, 255, 38), true)
 
-				local ID = ACE_GetContraptionIndex(Contraption)
+				local ID = ACE.GetContraptionIndex(Contraption)
 				local Owner = Base:CPPIGetOwner()
 
 				local WashOutErrorMul = 1 + self.WashOut * 4
@@ -934,7 +934,7 @@ function ENT:UpdateSonarTracks() --Step the track forward by velocity? Or let pl
 			--print("SonoDist: " .. math.Round(Dist / 39.37,2))
 			debugoverlay.Cross(OutputPosition,35,self.PulseDuration,Color( 183, 0, 255), true)
 
-			local InsertionIndex = ACE_GetBinaryInsertIndex(Distances, OutputDistance)
+			local InsertionIndex = ACE.GetBinaryInsertIndex(Distances, OutputDistance)
 			tableInsert(SonoBearings, InsertionIndex, Bearing)
 			tableInsert(SonoDepths, InsertionIndex, Depth)
 			tableInsert(SonoDistances, InsertionIndex, Dist)

--- a/lua/entities/ace_trackingradar/init.lua
+++ b/lua/entities/ace_trackingradar/init.lua
@@ -365,8 +365,8 @@ function ENT:ScanForContraptions()
 
 					OutputPosition = BasePos + BaseInaccuracy * OffboreInaccuracy
 
-					local ContraptionIndex = ACE_GetContraptionIndex(Contraption)
-					local InsertionIndex = ACE_GetBinaryInsertIndex(Distances, BaseDistance)
+					local ContraptionIndex = ACE.GetContraptionIndex(Contraption)
+					local InsertionIndex = ACE.GetBinaryInsertIndex(Distances, BaseDistance)
 
 					tableInsert(Owners, InsertionIndex, Owner:Nick())
 					tableInsert(Distances, InsertionIndex, BaseDistance)

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -331,7 +331,7 @@ do
 			Ammo:Spawn()
 
 			-- If the crate is not valid in the system, but it could be in the LegacyAmmoTable o be scalable.
-			if not ACE_CheckAmmo( Id ) then
+			if not ACE.CheckAmmo( Id ) then
 
 				local Scale
 
@@ -377,7 +377,7 @@ do
 			end
 
 			-- If the crate is legacy, but still valid in the system
-			if ACE_CheckAmmo( Id ) then
+			if ACE.CheckAmmo( Id ) then
 
 				local AmmoData = AmmoTable[Id]
 
@@ -469,12 +469,12 @@ function ENT:Update( ArgsTable )
 	self.LastMass = 1 -- force update of mass
 	self:UpdateMass()
 
-	if ACE_PointsInputChanged then
-		ACE_PointsInputChanged( self, "ammo-updated" )
+	if ACE.PointsInputChanged then
+		ACE.PointsInputChanged( self, "ammo-updated" )
 		-- Linked guns may sit in a different contraption; their firepower prices
 		-- this crate's round, so their side must go stale-proof too.
 		for _, Gun in pairs( self.Master or {} ) do
-			if IsValid( Gun ) then ACE_PointsInputChanged( Gun, "linked-ammo-updated" ) end
+			if IsValid( Gun ) then ACE.PointsInputChanged( Gun, "linked-ammo-updated" ) end
 		end
 	end
 
@@ -511,12 +511,12 @@ function ENT:UpdateOverlayText()
 			text = text .. "\n" .. RoundData.cratetxt( self.BulletData, self )
 		end
 
-		if ACE_Points_RoundFromBullet and ACE_Points_BaseRoundCost then
-			local round = ACE_Points_RoundFromBullet( self.BulletData )
+		if ACE.Points_RoundFromBullet and ACE.Points_BaseRoundCost then
+			local round = ACE.Points_RoundFromBullet( self.BulletData )
 			if round then
-				local roundLine = ACE_GetRoundLethalityLine and ACE_GetRoundLethalityLine( round )
+				local roundLine = ACE.GetRoundLethalityLine and ACE.GetRoundLethalityLine( round )
 				if roundLine then text = text .. "\nLethality: " .. roundLine end
-				text = text .. "\nBase Round Cost: " .. string.Comma(math.Round(ACE_Points_BaseRoundCost(round)))
+				text = text .. "\nBase Round Cost: " .. string.Comma(math.Round(ACE.Points_BaseRoundCost(round)))
 				text = text .. "\nCrate Inventory Points: 0"
 			end
 		end
@@ -572,10 +572,10 @@ do
 
 	function ENT:CreateAmmo(_, Data1, Data2, Data3, Data4, Data5, Data6, Data7, Data8, Data9, Data10 , Data11 , Data12 , Data13 , Data14 , Data15)
 
-		if not ACE_CheckGun( Data1 ) then
+		if not ACE.CheckGun( Data1 ) then
 			Data1 = BackComp[Data1] or "100mmC"
 		end
-		if not ACE_CheckRound( Data2 ) then
+		if not ACE.CheckRound( Data2 ) then
 			Data2 = AmmoComp[ Data2 ] or "AP"
 		end
 
@@ -944,10 +944,10 @@ function ENT:Think()
 							end )
 
 							local MiniRoundType = self.BulletData.Type
-							local MiniClass = ACE_GetAmmoCookoffClass(MiniRoundType, IsMissile)
-							local HE = ACE_GetAmmoCookoffBlastMass(MiniRoundType, self.BulletData)
+							local MiniClass = ACE.GetAmmoCookoffClass(MiniRoundType, IsMissile)
+							local HE = ACE.GetAmmoCookoffBlastMass(MiniRoundType, self.BulletData)
 							local Propel = self.BulletData.PropMass or 0
-							local PropScale = ACE_GetAmmoCookoffPropScale(MiniClass)
+							local PropScale = ACE.GetAmmoCookoffPropScale(MiniClass)
 							local HEWeight = ((HE + Propel * PropScale * ACF.APAmmoDetonateFactor * (ACF.PBase / ACF.HEPower)) * ACF.BoomMult)
 							local RunHE = self.CookoffHEToggle
 							self.CookoffHEToggle = not self.CookoffHEToggle
@@ -1065,7 +1065,7 @@ end
 function ENT:OnRemove()
 
 	-- Preserve linked weapons before CFW's removal hook can receive an invalid crate.
-	if ACE_NotifyCrateWeapons then ACE_NotifyCrateWeapons(self, "ammo-removed") end
+	if ACE.NotifyCrateWeapons then ACE.NotifyCrateWeapons(self, "ammo-removed") end
 
 	for Key in pairs(self.Master) do
 		if self.Master[Key] and self.Master[Key]:IsValid() then

--- a/lua/entities/acf_engine/cl_init.lua
+++ b/lua/entities/acf_engine/cl_init.lua
@@ -20,7 +20,7 @@ function ENT:Draw()
 
 end
 
-function ACE_EngineGUI_Update( Table )
+function ACE.EngineGUI_Update( Table )
 
 	acfmenupanel:CPanelText("Name", Table.name, "DermaDefaultBold")
 
@@ -72,3 +72,5 @@ function ACE_EngineGUI_Update( Table )
 	acfmenupanel.CustomDisplay:PerformLayout()
 
 end
+
+ACE_EngineGUI_Update = ACE.EngineGUI_Update

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -88,7 +88,7 @@ do
 		local Engine = ents.Create( "acf_engine" )
 		if not IsValid( Engine ) then return false end
 
-		if not ACE_CheckEngine( Id ) then
+		if not ACE.CheckEngine( Id ) then
 			Id = BackComp[Id] or "5.7-V8"
 		end
 
@@ -245,7 +245,7 @@ function ENT:Update( ArgsTable )
 	self:UpdateOverlayText()
 
 	ACF_Activate( self, 1 )
-	if ACE_PointsInputChanged then ACE_PointsInputChanged( self, "engine-updated" ) end
+	if ACE.PointsInputChanged then ACE.PointsInputChanged( self, "engine-updated" ) end
 
 	return true, "Engine updated successfully!" .. Feedback
 end
@@ -420,7 +420,7 @@ function ENT:TriggerInput( iname, value )
 				end
 
 			end
-			ACE_DoContraptionLegalCheck(self)
+			ACE.DoContraptionLegalCheck(self)
 		elseif (value <= 0 and self.Active) then
 			self.Active = false
 			self.FlyRPM = 0
@@ -532,7 +532,7 @@ function ENT:Think()
 		self.NextUpdate = ACF.CurTime + 1
 	end
 
-	self.Heat = ACE_HeatFromEngine( self )
+	self.Heat = ACE.HeatFromEngine( self )
 	Wire_TriggerOutput(self, "EngineHeat", self.Heat)
 
 	if ACF.CurTime > self.NextUpdate then
@@ -688,7 +688,7 @@ function ENT:CalcRPM()
 		self.HasFuel = false
 	end
 
-	ACE_DoContraptionLegalCheck(self)
+	ACE.DoContraptionLegalCheck(self)
 
 	if self.RequiresDriver and not (self.HasDriver or self.HasSeatDriver)  then
 		self:TriggerInput( "Active", 0 ) --shut off if no driver and requires it
@@ -745,7 +745,7 @@ function ENT:CalcRPM()
 
 
 	-- Heat Temperature calculation. Below is the damage caused by rpm if damaged.
-	self.Heat = ACE_HeatFromEngine( self )
+	self.Heat = ACE.HeatFromEngine( self )
 
 	local HealthRatio = self.ACF.Health / self.ACF.MaxHealth
 	if HealthRatio < 0.995 then
@@ -940,7 +940,7 @@ do
 
 		local Rope = nil
 		if self:CPPIGetOwner():GetInfoNum( "ACF_MobilityRopeLinks", 1) == 1 then
-			Rope = ACE_CreateLinkRope( OutPos, self, self.Out, Target, Target.In )
+			Rope = ACE.CreateLinkRope( OutPos, self, self.Out, Target, Target.In )
 		end
 
 		local Link = {

--- a/lua/entities/acf_fueltank/init.lua
+++ b/lua/entities/acf_fueltank/init.lua
@@ -175,7 +175,7 @@ do
 			Tank:Spawn()
 
 			-- If the crate is not valid in the system, but it could be scalable.
-			if not ACE_CheckFuelTank( Data1 ) then
+			if not ACE.CheckFuelTank( Data1 ) then
 
 				-- Reminder: When the legacy fueltanks get deleted. Do the same as ammo crates.
 				local Scale = ConvertStringScale(Data1)
@@ -215,7 +215,7 @@ do
 				end
 			end
 
-			if ACE_CheckFuelTank( Data1 ) then
+			if ACE.CheckFuelTank( Data1 ) then
 
 				local TankData = TankTable[Data1]
 

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -62,7 +62,7 @@ do
 
 		if not IsValid( Gearbox ) then return false end
 
-		if not ACE_CheckGearbox( Id ) then
+		if not ACE.CheckGearbox( Id ) then
 			Id = "1Gear-T-S" --deal with it
 			Data1	= 0.1 --gear1
 			Data10  = 0.5 --gear2
@@ -581,7 +581,7 @@ function ENT:Calc( InputRPM, InputInertia )
 	end
 
 	--I would need to learn more about this, disabled atm
-	--self.Heat = ACE_HeatFromGearbox( self , InputRPM)
+	--self.Heat = ACE.HeatFromGearbox( self , InputRPM)
 	--Wire_TriggerOutput(self, "Heat", self.Heat)
 
 	return math.min( self.TotalReqTq, self.MaxTorque )
@@ -790,7 +790,7 @@ function ENT:Link( Target )
 
 	local Rope = nil
 	if self:CPPIGetOwner():GetInfoNum( "ACF_MobilityRopeLinks", 1) == 1 then
-		Rope = ACE_CreateLinkRope( OutPosWorld, self, OutPos, Target, InPos )
+		Rope = ACE.CreateLinkRope( OutPosWorld, self, OutPos, Target, InPos )
 	end
 
 	local Phys	= Target:GetPhysicsObject()

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -67,7 +67,7 @@ function ENT:Initialize()
 	self.CanLegalCheck		= true
 
 	self:CallOnRemove("ACE_Points", function(ent)
-		if ACE_PointsInputChanged then ACE_PointsInputChanged(ent, "gun-removed") end
+		if ACE.PointsInputChanged then ACE.PointsInputChanged(ent, "gun-removed") end
 	end)
 end
 
@@ -152,7 +152,7 @@ do
 		local Gun = ents.Create("acf_gun")
 		if not IsValid(Gun) then return false end
 
-		if not ACE_CheckGun( Id ) then
+		if not ACE.CheckGun( Id ) then
 			Id = BackComp[Id] or "100mmC"
 		end
 
@@ -318,17 +318,17 @@ function ENT:UpdateOverlayText()
 
 	text = text .. "\nRounds Per Minute: " .. math.Round( self.RateOfFire or 0, 2 )
 
-	if ACE_GetGunFirepowerReadout then
-		local readout = ACE_GetGunFirepowerReadout(self)
+	if ACE.GetGunFirepowerReadout then
+		local readout = ACE.GetGunFirepowerReadout(self)
 		if readout then
 			text = text .. "\nFirepower: " .. string.Comma(math.Round(readout.Points)) .. " pts"
-			local roundLine = readout.Round and ACE_GetRoundLethalityLine
-				and ACE_GetRoundLethalityLine(readout.Round, true)
+			local roundLine = readout.Round and ACE.GetRoundLethalityLine
+				and ACE.GetRoundLethalityLine(readout.Round, true)
 			if roundLine then text = text .. "\nBest Round: " .. roundLine end
 			if readout.MinimumApplied then
 				text = text .. "\nWeapon Minimum Applied: " .. string.Comma(math.Round(readout.Points)) .. " pts"
 			end
-			local floorLine = ACE_GetRateFloorLine and ACE_GetRateFloorLine(readout, true)
+			local floorLine = ACE.GetRateFloorLine and ACE.GetRateFloorLine(readout, true)
 			if floorLine then text = text .. "\n" .. floorLine end
 		end
 	end
@@ -355,7 +355,7 @@ end
 
 local function IsInRetDist( enta, entb, Distance )
 	if not IsValid(enta) or not IsValid(entb) then return end
-	return ACE_InDist( enta:GetPos(), entb:GetPos(), Distance )
+	return ACE.InDist( enta:GetPos(), entb:GetPos(), Distance )
 end
 
 local BreakSoundTbl = {
@@ -406,9 +406,9 @@ function ENT:Link( Target )
 		self.HasGunner = true
 		Target.LinkedGun = self
 
-		if ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "gunner-linked" )
-			ACE_PointsInputChanged( Target, "gunner-linked" )
+		if ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "gunner-linked" )
+			ACE.PointsInputChanged( Target, "gunner-linked" )
 		end
 		return true, "Link successful!"
 
@@ -441,9 +441,9 @@ function ENT:Link( Target )
 		self.LoaderCount = self.LoaderCount + 1
 		Target.LinkedGun = self
 
-		if ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "loader-linked" )
-			ACE_PointsInputChanged( Target, "loader-linked" )
+		if ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "loader-linked" )
+			ACE.PointsInputChanged( Target, "loader-linked" )
 		end
 		return true, "Link successful!"
 
@@ -501,9 +501,9 @@ function ENT:Link( Target )
 		Wire_TriggerOutput( self, "Muzzle Weight", math.floor( Target.BulletData.ProjMass * 1000 ) )
 		Wire_TriggerOutput( self, "Muzzle Velocity", math.floor( Target.BulletData.MuzzleVel * ACF.VelScale ) )
 
-		if ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "gun-ammo-linked" )
-			ACE_PointsInputChanged( Target, "gun-ammo-linked" )
+		if ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "gun-ammo-linked" )
+			ACE.PointsInputChanged( Target, "gun-ammo-linked" )
 		end
 		return true, "Link successful!"
 
@@ -538,9 +538,9 @@ function ENT:Unlink( Target )
 	end
 
 	if Success then
-		if ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "gun-unlinked" )
-			ACE_PointsInputChanged( Target, "gun-unlinked" )
+		if ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "gun-unlinked" )
+			ACE.PointsInputChanged( Target, "gun-unlinked" )
 		end
 		return true, "Unlink successful!"
 	else
@@ -578,7 +578,7 @@ function ENT:TriggerInput(iname, value)
 		-- Triggered to fire if conditions are met
 		if self.NextFire < CurTime() then
 			-- Check if it's time to fire
-			self.User = ACE_GetWeaponUser(self, self.Inputs.Fire.Src)
+			self.User = ACE.GetWeaponUser(self, self.Inputs.Fire.Src)
 			if not IsValid(self.User) then
 				self.User = self:CPPIGetOwner()
 			end
@@ -612,8 +612,8 @@ function ENT:TriggerInput(iname, value)
 			self.ROFLimit = 0
 		end
 
-		if oldLimit ~= self.ROFLimit and ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "gun-rof-limit" )
+		if oldLimit ~= self.ROFLimit and ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "gun-rof-limit" )
 		end
 	end
 end
@@ -624,7 +624,7 @@ function ENT:Heat_Function()
 
 	--print(DeltaTime)
 
-	self.Heat = ACE_HeatFromGun( self , self.Heat, self.DeltaTime )
+	self.Heat = ACE.HeatFromGun( self , self.Heat, self.DeltaTime )
 	Wire_TriggerOutput(self, "Heat", math.Round(self.Heat))
 
 	-- TODO: instead of breaking the gun by heat, decrease accurancy and jam it
@@ -920,7 +920,7 @@ do
 			return
 		end
 
-		ACE_DoContraptionLegalCheck(self)
+		ACE.DoContraptionLegalCheck(self)
 
 		local bool = true
 
@@ -1065,7 +1065,7 @@ function ENT:LoadAmmo( AddTime, Reload )
 		--print(maxRof)
 
 		-- Check if self.Class is in the invalidClasses table
-		if not ACE_table_contains(invalidClasses, self.Class) and self.maxrof then
+		if not ACE.table_contains(invalidClasses, self.Class) and self.maxrof then
 
 			if self.LoaderCount > 0 and IsValid(curLoader) then -- if loaders are linked then
 

--- a/lua/entities/acf_missileradar/init.lua
+++ b/lua/entities/acf_missileradar/init.lua
@@ -242,7 +242,7 @@ function ENT:Think()
 		self.LastStatusUpdate = curTime
 	end
 
-	self.Heat = ACE_HeatFromRadar(self, self.ThinkDelay)
+	self.Heat = ACE.HeatFromRadar(self, self.ThinkDelay)
 	WireLib.TriggerOutput(self, "Heat", self.Heat)
 	self:GetOverlayText()
 
@@ -307,7 +307,7 @@ function ENT:ScanForMissiles()
 		count = count + 1
 
 		-- Sort the missiles by distance from the radar
-		local insertionIndex = ACE_GetBinaryInsertIndex(distArray, distanceSqr)
+		local insertionIndex = ACE.GetBinaryInsertIndex(distArray, distanceSqr)
 		tableInsert(distArray, insertionIndex, distanceSqr)
 		tableInsert(entArray, insertionIndex, missile)
 		tableInsert(posArray, insertionIndex, missile.CurPos) --Replaced with non-cached value as to not lag behind.

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -117,7 +117,7 @@ function ENT:Initialize()
 	self.CanLegalCheck = true
 
 	self:CallOnRemove("ACE_Points", function(ent)
-		if ACE_PointsInputChanged then ACE_PointsInputChanged(ent, "rack-removed") end
+		if ACE.PointsInputChanged then ACE.PointsInputChanged(ent, "rack-removed") end
 	end)
 end
 
@@ -138,7 +138,7 @@ function MakeACF_Rack(Owner, Pos, Angle, Id)
 	Owner:AddCount("_acf_rack", Rack)
 	Owner:AddCleanup( "acfmenu", Rack )
 
-	if not ACE_CheckRack( Id ) then
+	if not ACE.CheckRack( Id ) then
 		Id = "1xRK"
 	end
 
@@ -426,7 +426,7 @@ function ENT:ShootMissile()
 
 	if not ShotMissile:IsValid() then self.CurMissile = self:UpdateValidMissiles() return end
 
-	ACE_DoContraptionLegalCheck(self)
+	ACE.DoContraptionLegalCheck(self)
 
 	self.NextReload = CT + self.ReloadTime
 
@@ -879,17 +879,17 @@ function ENT:GetOverlayText()
 		txt = txt .. "\nNot legal, disabled for " .. math.ceil(self.NextLegalCheck - ACF.CurTime) .. "s\nIssues: " .. self.LegalIssues
 	end
 
-	if ACE_GetGunFirepowerReadout then
-		local readout = ACE_GetGunFirepowerReadout(self)
+	if ACE.GetGunFirepowerReadout then
+		local readout = ACE.GetGunFirepowerReadout(self)
 		if readout then
 			txt = txt .. "\nFirepower: " .. string.Comma(math.Round(readout.Points)) .. " pts"
-			local roundLine = readout.Round and ACE_GetRoundLethalityLine
-				and ACE_GetRoundLethalityLine(readout.Round, true)
+			local roundLine = readout.Round and ACE.GetRoundLethalityLine
+				and ACE.GetRoundLethalityLine(readout.Round, true)
 			if roundLine then txt = txt .. "\nBest Round: " .. roundLine end
 			if readout.MinimumApplied then
 				txt = txt .. "\nWeapon Minimum Applied: " .. string.Comma(math.Round(readout.Points)) .. " pts"
 			end
-			local floorLine = ACE_GetRateFloorLine and ACE_GetRateFloorLine(readout, true)
+			local floorLine = ACE.GetRateFloorLine and ACE.GetRateFloorLine(readout, true)
 			if floorLine then txt = txt .. "\n" .. floorLine end
 		end
 	end
@@ -975,9 +975,9 @@ function ENT:Link( Target )
 
 	self:SetOverlayText(txt)
 
-	if ACE_PointsInputChanged then
-		ACE_PointsInputChanged( self, "rack-ammo-linked" )
-		ACE_PointsInputChanged( Target, "rack-ammo-linked" )
+	if ACE.PointsInputChanged then
+		ACE.PointsInputChanged( self, "rack-ammo-linked" )
+		ACE.PointsInputChanged( Target, "rack-ammo-linked" )
 	end
 	return true, "Link successful!"
 
@@ -997,9 +997,9 @@ function ENT:Unlink( Target )
 
 		self:GetOverlayText()
 
-		if ACE_PointsInputChanged then
-			ACE_PointsInputChanged( self, "rack-unlinked" )
-			ACE_PointsInputChanged( Target, "rack-unlinked" )
+		if ACE.PointsInputChanged then
+			ACE.PointsInputChanged( self, "rack-unlinked" )
+			ACE.PointsInputChanged( Target, "rack-unlinked" )
 		end
 		return true, "Unlink successful!"
 	else

--- a/lua/entities/gmod_wire_expression2/core/custom/acf.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acf.lua
@@ -52,7 +52,7 @@ local function CalcArmor( Area, Ductility, Thickness, Mat )
 
 	Mat = Mat or "RHA"
 
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 	local MassMod	= MatData.massMod
 
 	local mass		= Area * ( 1 + Ductility ) ^ 0.5 * Thickness * 0.00078 * MassMod
@@ -85,7 +85,7 @@ local function E2SetACEArmor(ent, armor, ductility, material)
 	ent.ACF.Material = mat
 	duplicator.StoreEntityModifier( ent, "acfsettings", { Material = mat } )
 
-	ACE_MarkArmorDirty(con, ent, "armor-expression2")
+	ACE.MarkArmorDirty(con, ent, "armor-expression2")
 
 end
 
@@ -1221,7 +1221,7 @@ do
 	e2function number entity:acfPenetration()
 		if not (isAmmo(this) or isGun(this)) then return self:throw("Entity is not a valid ACF ammo crate or gun", 0) end
 		if restrictInfo(self.player, this) then return 0 end
-		if not ACE_CheckRound(this.BulletData.Type) then return 0 end
+		if not ACE.CheckRound(this.BulletData.Type) then return 0 end
 
 		return ACF.RoundTypes[this.BulletData.Type].getDisplayData(this.BulletData).MaxPen or 0
 	end
@@ -1231,7 +1231,7 @@ do
 	e2function number entity:acfPenetration(number index)
 		if not (isAmmo(this) or isGun(this)) then return self:throw("Entity is not a valid ACF ammo crate or gun", 0) end
 		if restrictInfo(self.player, this) then return 0 end
-		if not ACE_CheckRound(this.BulletData.Type) then return 0 end
+		if not ACE.CheckRound(this.BulletData.Type) then return 0 end
 
 		local displayData = ACF.RoundTypes[this.BulletData.Type].getDisplayData(this.BulletData)
 
@@ -1249,7 +1249,7 @@ do
 	e2function number entity:acfBlastRadius()
 		if not (isAmmo(this) or isGun(this)) then return self:throw("Entity is not a valid ACF ammo crate or gun", 0) end
 		if restrictInfo(self.player, this) then return 0 end
-		if not ACE_CheckRound(this.BulletData.Type) then return 0 end
+		if not ACE.CheckRound(this.BulletData.Type) then return 0 end
 
 		local type = this.BulletData.Type
 

--- a/lua/starfall/libs_sv/acf.lua
+++ b/lua/starfall/libs_sv/acf.lua
@@ -47,7 +47,7 @@ local function CalcArmor( Area, Ductility, Thickness, Mat )
 
 	Mat = Mat or "RHA"
 
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 	local MassMod	= MatData.massMod
 
 	local mass		= Area * ( 1 + Ductility ) ^ 0.5 * Thickness * 0.00078 * MassMod
@@ -80,7 +80,7 @@ local function E2SetACEArmor(ent, armor, ductility, material)
 	ent.ACF.Material = mat
 	duplicator.StoreEntityModifier( ent, "acfsettings", { Material = mat } )
 
-	ACE_MarkArmorDirty(con, ent, "armor-starfall")
+	ACE.MarkArmorDirty(con, ent, "armor-starfall")
 
 end
 
@@ -465,9 +465,9 @@ do
 
 		local Heat
 		if isGun(this) then
-			Heat = ACE_HeatFromGun(this, this.Heat, this.DeltaTime)
+			Heat = ACE.HeatFromGun(this, this.Heat, this.DeltaTime)
 		elseif isEngine(this) then
-			Heat = ACE_HeatFromEngine(this)
+			Heat = ACE.HeatFromEngine(this)
 		else
 			Heat = ACE.AmbientTemp
 		end
@@ -1069,7 +1069,7 @@ do
 		local this = getent(self)
 		if not (isAmmo(this) or isGun(this)) then return 0 end
 		if restrictInfo(this) then return 0 end
-		if not ACE_CheckRound(this.BulletData.Type) then return 0 end
+		if not ACE.CheckRound(this.BulletData.Type) then return 0 end
 
 		return ACF.RoundTypes[this.BulletData.Type].getDisplayData(this.BulletData).MaxPen or 0
 	end

--- a/lua/tests/ace/spall_rubber.lua
+++ b/lua/tests/ace/spall_rubber.lua
@@ -1,0 +1,134 @@
+local function makeEntity(name)
+	return {
+		name = name,
+		ACF = { Ductility = 0 },
+		GetClass = function() return "prop_physics" end,
+		GetPhysicsObject = function() return nil end,
+	}
+end
+
+local function withSpallTraceStubs(callback)
+	local original = {
+		TraceLine = util.TraceLine,
+		Decal = util.Decal,
+		ACFCheck = _G.ACF_Check,
+		ACFCheckClips = _G.ACF_CheckClips,
+		ACFDamage = _G.ACF_Damage,
+		ACFHitAngle = _G.ACF_GetHitAngle,
+		GetMaterialData = ACE.GetMaterialData,
+		VectorRand = _G.VectorRand,
+		Line = debugoverlay.Line,
+		CritEnts = ACE.CritEnts,
+		Spall = ACE.Spall[1],
+	}
+
+	local ok, err = pcall(callback)
+
+	util.TraceLine = original.TraceLine
+	util.Decal = original.Decal
+	_G.ACF_Check = original.ACFCheck
+	_G.ACF_CheckClips = original.ACFCheckClips
+	_G.ACF_Damage = original.ACFDamage
+	_G.ACF_GetHitAngle = original.ACFHitAngle
+	ACE.GetMaterialData = original.GetMaterialData
+	_G.VectorRand = original.VectorRand
+	debugoverlay.Line = original.Line
+	ACE.CritEnts = original.CritEnts
+	ACE.Spall[1] = original.Spall
+
+	if not ok then error(err, 0) end
+end
+
+local function withSuccessfulArmorRoll(callback)
+	local originalRandom = math.random
+	math.random = function() return 0 end
+
+	local ok, err = pcall(callback)
+
+	math.random = originalRandom
+
+	if not ok then error(err, 0) end
+end
+
+return {
+	groupName = "ACE rubber spall behavior",
+	cases = {
+		{
+			name = "routes spall through thickness-scaled ordinary rubber resolution",
+			func = function()
+				withSuccessfulArmorRoll(function()
+					local rubber = ACE.ArmorTypes.Rub
+					local entity = { ACF = { Ductility = 0 } }
+					local result = rubber.ArmorResolution(entity, 15, 15, 15 ^ 1.1 * 3.5, 100, 1, 1, 1, "Spall")
+					local expectedLoss = 15 ^ 0.93 * 0.15 / 100
+
+					expect(rubber.spallresist).to.equal(0.15)
+					expect(result.Overkill).to.beGreaterThan(0)
+					expect(result.Loss).to.aboutEqual(expectedLoss)
+				end)
+			end,
+		},
+		{
+			name = "carries one fragment's remaining energy through a recursive layer",
+			func = function()
+				local front = makeEntity("front")
+				local rear = makeEntity("rear")
+				local seen = {}
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.CritEnts = {}
+					ACE.Spall[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return true end
+					_G.ACF_CheckClips = function() return false end
+					_G.ACF_GetHitAngle = function() return 0 end
+					_G.VectorRand = function() return Vector(0, 0, 0) end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					local traceEnds = {}
+					util.TraceLine = function(trace)
+						traces = traces + 1
+						traceEnds[traces] = trace.endpos
+						local entity = traces == 1 and front or rear
+
+						return {
+							Hit = true,
+							Entity = entity,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector((traces - 1) * 100, 0, 0),
+							HitPos = Vector(0, traces * 100, 0),
+						}
+					end
+					_G.ACF_Damage = function(entity, energy)
+						seen[#seen + 1] = { entity = entity, penetration = energy.Penetration, kinetic = energy.Kinetic }
+
+						if entity == front then
+							return { Overkill = 10, Loss = 0.25, Kill = false }
+						end
+
+						return { Overkill = 0, Loss = 1, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(traceEnds[2].x).to.equal(0)
+					expect(traceEnds[2].y).to.beGreaterThan(traceEnds[2].x + 100)
+				end)
+
+				expect(traces).to.equal(2)
+				expect(#seen).to.equal(2)
+				expect(seen[1].penetration).to.equal(100)
+				expect(seen[1].kinetic).to.equal(80)
+				expect(seen[2].penetration).to.equal(75)
+				expect(seen[2].kinetic).to.equal(60)
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/spall_rubber.lua
+++ b/lua/tests/ace/spall_rubber.lua
@@ -1,0 +1,127 @@
+local function makeEntity(name)
+	return {
+		name = name,
+		ACF = { Ductility = 0 },
+		GetClass = function() return "prop_physics" end,
+		GetPhysicsObject = function() return nil end,
+	}
+end
+
+local function withSpallTraceStubs(callback)
+	local original = {
+		TraceLine = util.TraceLine,
+		Decal = util.Decal,
+		ACFCheck = ACF_Check,
+		ACFCheckClips = ACF_CheckClips,
+		ACFDamage = ACF_Damage,
+		ACFHitAngle = ACF_GetHitAngle,
+		GetMaterialData = ACE.GetMaterialData,
+		Line = debugoverlay.Line,
+		CritEnts = ACE.CritEnts,
+		Spall = ACE.Spall[1],
+	}
+
+	local ok, err = pcall(callback)
+
+	util.TraceLine = original.TraceLine
+	util.Decal = original.Decal
+	ACF_Check = original.ACFCheck
+	ACF_CheckClips = original.ACFCheckClips
+	ACF_Damage = original.ACFDamage
+	ACF_GetHitAngle = original.ACFHitAngle
+		ACE.GetMaterialData = original.GetMaterialData
+	debugoverlay.Line = original.Line
+	ACE.CritEnts = original.CritEnts
+	ACE.Spall[1] = original.Spall
+
+	if not ok then error(err, 0) end
+end
+
+local function withSuccessfulArmorRoll(callback)
+	local originalRandom = math.random
+	math.random = function() return 0 end
+
+	local ok, err = pcall(callback)
+
+	math.random = originalRandom
+
+	if not ok then error(err, 0) end
+end
+
+return {
+	groupName = "ACE rubber spall behavior",
+	cases = {
+		{
+			name = "routes spall through thickness-scaled ordinary rubber resolution",
+			func = function()
+				withSuccessfulArmorRoll(function()
+					local rubber = ACE.ArmorTypes.Rub
+					local entity = { ACF = { Ductility = 0 } }
+					local result = rubber.ArmorResolution(entity, 15, 15, 15 ^ 1.1 * 3.5, 100, 1, 1, 1, "Spall")
+					local expectedLoss = 15 ^ 0.93 * 0.15 / 100
+
+					expect(rubber.spallresist).to.equal(0.15)
+					expect(result.Overkill).to.beGreaterThan(0)
+					expect(result.Loss).to.aboutEqual(expectedLoss)
+				end)
+			end,
+		},
+		{
+			name = "carries one fragment's remaining energy through a recursive layer",
+			func = function()
+				local front = makeEntity("front")
+				local rear = makeEntity("rear")
+				local seen = {}
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.CritEnts = {}
+					ACE.Spall[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(100, 0, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					ACF_Check = function() return true end
+					ACF_CheckClips = function() return false end
+					ACF_GetHitAngle = function() return 0 end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					util.TraceLine = function()
+						traces = traces + 1
+						local entity = traces == 1 and front or rear
+
+						return {
+							Hit = true,
+							Entity = entity,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector((traces - 1) * 100, 0, 0),
+							HitPos = Vector(traces * 100, 0, 0),
+						}
+					end
+					ACF_Damage = function(entity, energy)
+						seen[#seen + 1] = { entity = entity, penetration = energy.Penetration, kinetic = energy.Kinetic }
+
+						if entity == front then
+							return { Overkill = 10, Loss = 0.25, Kill = false }
+						end
+
+						return { Overkill = 0, Loss = 1, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+				end)
+
+				expect(traces).to.equal(2)
+				expect(#seen).to.equal(2)
+				expect(seen[1].penetration).to.equal(100)
+				expect(seen[1].kinetic).to.equal(80)
+				expect(seen[2].penetration).to.equal(75)
+				expect(seen[2].kinetic).to.equal(60)
+			end,
+		},
+	},
+}

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -32,7 +32,7 @@ local function CalcArmor( Area, Ductility, Thickness, Mat )
 
 	Mat = Mat or "RHA"
 
-	local MatData	= ACE_GetMaterialData( Mat )
+	local MatData	= ACE.GetMaterialData( Mat )
 	local MassMod	= MatData.massMod
 
 	local mass		= Area * ( 1 + Ductility ) ^ 0.5 * Thickness * 0.00078 * MassMod
@@ -70,7 +70,7 @@ local function ApplySettings( _, ent, data )
 		duplicator.StoreEntityModifier( ent, "acfsettings", { Material = data.Material } )
 	end
 
-	ACE_MarkArmorDirty(con, ent, "armor-tool")
+	ACE.MarkArmorDirty(con, ent, "armor-tool")
 
 end
 
@@ -168,8 +168,8 @@ function TOOL:Reload( trace )
 	local power		= tonumber(data.Power) or 0
 
 	local Contraption = ent:CFW_GetContraption() or nil
-	if Contraption and ACE_EnsureContraptionPoints then
-		ACE_EnsureContraptionPoints(Contraption, ent, false)
+	if Contraption and ACE.EnsureContraptionPoints then
+		ACE.EnsureContraptionPoints(Contraption, ent, false)
 	end
 
 	local PointVal		= 0
@@ -184,7 +184,7 @@ function TOOL:Reload( trace )
 
 	if Contraption ~= nil then
 		local pointsPerType = Contraption.ACEPointsPerType or {}
-		PointVal		= safeNumber(Contraption.ACEPoints or ACE_GetEntPoints(ent))
+		PointVal		= safeNumber(Contraption.ACEPoints or ACE.GetEntPoints(ent))
 		PtsArmor = safeNumber(pointsPerType.Armor)
 		PtsEngine = safeNumber(pointsPerType.Engines)
 		PtsFirepower = safeNumber(pointsPerType.Firepower)
@@ -192,15 +192,15 @@ function TOOL:Reload( trace )
 		PtsElectronics = safeNumber(pointsPerType.Electronics)
 		ArmorInitMissing = not Contraption.ACEArmorCalculated
 
-		if ACE_GetContraptionEntities and ACE_GetPtsType then
-			for _, candidate in ipairs(ACE_GetContraptionEntities(Contraption, ent)) do
-				if IsValid(candidate) and ACE_GetPtsType(candidate:GetClass()) == "Firepower" then
+		if ACE.GetContraptionEntities and ACE.GetPtsType then
+			for _, candidate in ipairs(ACE.GetContraptionEntities(Contraption, ent)) do
+				if IsValid(candidate) and ACE.GetPtsType(candidate:GetClass()) == "Firepower" then
 					FirepowerCount = FirepowerCount + 1
 				end
 			end
 		end
 	else
-		PointVal = safeNumber(ACE_GetEntPoints(ent))
+		PointVal = safeNumber(ACE.GetEntPoints(ent))
 	end
 
 	local GeneralTb	= { data.MaterialMass or {}, data.MaterialPercent or {} }
@@ -305,51 +305,51 @@ local function ACE_GetPopupPoints(ent)
 
 	local cls = ent:GetClass()
 	local con = ent:CFW_GetContraption()
-	local armorPoints = ACE_GetArmorPoints and ACE_GetArmorPoints(ent) or 0
+	local armorPoints = ACE.GetArmorPoints and ACE.GetArmorPoints(ent) or 0
 	local componentPoints = 0
 	local componentLabel
 	local lines = {}
 
 	if cls == "acf_engine" then
-		componentPoints = ACE_GetEntPoints and ACE_GetEntPoints(ent) or 0
+		componentPoints = ACE.GetEntPoints and ACE.GetEntPoints(ent) or 0
 		componentLabel = CostLabelByCategory.Engines
 	elseif cls == "acf_gun" or cls == "acf_rack" then
-		local conEnts = (con and ACE_GetContraptionEntities) and ACE_GetContraptionEntities(con, ent) or nil
-		local readout = ACE_GetGunFirepowerReadout and ACE_GetGunFirepowerReadout(ent, conEnts)
+		local conEnts = (con and ACE.GetContraptionEntities) and ACE.GetContraptionEntities(con, ent) or nil
+		local readout = ACE.GetGunFirepowerReadout and ACE.GetGunFirepowerReadout(ent, conEnts)
 		componentPoints = readout and readout.Points
-			or (ACE_GetGunFirepowerPointsFor and ACE_GetGunFirepowerPointsFor(ent, conEnts))
-			or (ACE_GetGunFirepowerPoints and ACE_GetGunFirepowerPoints(ent)) or 0
+			or (ACE.GetGunFirepowerPointsFor and ACE.GetGunFirepowerPointsFor(ent, conEnts))
+			or (ACE.GetGunFirepowerPoints and ACE.GetGunFirepowerPoints(ent)) or 0
 		componentLabel = CostLabelByCategory.Firepower
 
 		if readout then
-			local pricing = ACE_GetGunFirepowerPricingLine and ACE_GetGunFirepowerPricingLine(readout, true)
+			local pricing = ACE.GetGunFirepowerPricingLine and ACE.GetGunFirepowerPricingLine(readout, true)
 			if pricing then lines[#lines + 1] = pricing end
 			if readout.MinimumApplied then
 				lines[#lines + 1] = "Weapon Minimum Applied: " .. ACE_FormatPoints(readout.Points)
 			end
-			local floorLine = ACE_GetRateFloorLine and ACE_GetRateFloorLine(readout, true)
+			local floorLine = ACE.GetRateFloorLine and ACE.GetRateFloorLine(readout, true)
 			if floorLine then lines[#lines + 1] = floorLine end
-			local roundLine = readout.Round and ACE_GetRoundLethalityLine and ACE_GetRoundLethalityLine(readout.Round, true)
+			local roundLine = readout.Round and ACE.GetRoundLethalityLine and ACE.GetRoundLethalityLine(readout.Round, true)
 			if roundLine then lines[#lines + 1] = "Best Round: " .. roundLine end
 		end
 	elseif cls == "acf_ammo" then
 		componentPoints = 0
-		if ACE_Points_RoundFromBullet and ACE_Points_BaseRoundCost and istable(ent.BulletData) then
-			local round = ACE_Points_RoundFromBullet(ent.BulletData)
+		if ACE.Points_RoundFromBullet and ACE.Points_BaseRoundCost and istable(ent.BulletData) then
+			local round = ACE.Points_RoundFromBullet(ent.BulletData)
 			if round then
-				local roundLine = ACE_GetRoundLethalityLine and ACE_GetRoundLethalityLine(round, true)
+				local roundLine = ACE.GetRoundLethalityLine and ACE.GetRoundLethalityLine(round, true)
 				lines[#lines + 1] = "Crate Inventory Points: 0"
 				if roundLine then lines[#lines + 1] = "Best Round: " .. roundLine end
 				lines[#lines + 1] = "Base Round Cost: "
-					.. string.format("%.1f", ACE_Points_BaseRoundCost(round))
+					.. string.format("%.1f", ACE.Points_BaseRoundCost(round))
 			end
 		end
 	else
 		local category = ACE_GetPointsCategory(ent)
-		if category == "Crew" and ACE_GetCrewSeatPointCost then
-			componentPoints = ACE_GetCrewSeatPointCost(ent)
+		if category == "Crew" and ACE.GetCrewSeatPointCost then
+			componentPoints = ACE.GetCrewSeatPointCost(ent)
 		else
-			componentPoints = ACE_GetEntPoints and ACE_GetEntPoints(ent) or 0
+			componentPoints = ACE.GetEntPoints and ACE.GetEntPoints(ent) or 0
 		end
 		if componentPoints > 0 and category and category ~= "Armor" and category ~= "Ignore" then
 			componentLabel = CostLabelByCategory[category] or (category .. " Cost")
@@ -362,8 +362,8 @@ local function ACE_GetPopupPoints(ent)
 	end
 
 	-- Manufacturing values are computed on read and are not part of combat points.
-	if ACE_Manu_EntCost then
-		local mfgCost = ACE_Manu_EntCost(ent)
+	if ACE.Manu_EntCost then
+		local mfgCost = ACE.Manu_EntCost(ent)
 		if mfgCost and mfgCost > 0 then
 			lines[#lines + 1] = "Mfg. Cost: " .. ACE_FormatMoney(mfgCost)
 		end
@@ -401,7 +401,7 @@ function TOOL:Think()
 	if ACF_Check( ent ) then
 
 		local Mat = ent.ACF.Material or "RHA"
-		local MatData = ACE_GetMaterialData( Mat )
+		local MatData = ACE.GetMaterialData( Mat )
 		local AcePts, pointsLabel, pointBreakdown, componentCost = ACE_GetPopupPoints(ent)
 
 		if not MatData then return end
@@ -444,23 +444,23 @@ if CLIENT then
 
 	-- Use the server pricing weights; unknown materials fall back to live material data.
 	local function ACE_GetArmorPointPreview(armor, health, mat, matData)
-		if not ACE_Points_EffectiveMm or not ACE_Points_ArmorProp then return 0 end
+		if not ACE.Points_EffectiveMm or not ACE.Points_ArmorProp then return 0 end
 
 		local effKE, effCHEM
-		if ACE_Points_MaterialEff then
-			effKE, effCHEM = ACE_Points_MaterialEff(mat)
+		if ACE.Points_MaterialEff then
+			effKE, effCHEM = ACE.Points_MaterialEff(mat)
 		end
 		if not effKE then
 			if not matData then return 0 end
 			effKE = tonumber(matData.effectiveness) or 1
 			effCHEM = tonumber(matData.HEATeffectiveness or matData.effectiveness) or effKE
 		end
-		local effMm = ACE_Points_EffectiveMm(armor, effKE, effCHEM)
+		local effMm = ACE.Points_EffectiveMm(armor, effKE, effCHEM)
 		local hp = tonumber(health) or 0
 
 		if effMm <= 0 or hp <= 0 then return 0 end
 
-		return ACE_Points_ArmorProp(effMm, hp)
+		return ACE.Points_ArmorProp(effMm, hp)
 	end
 
 	-- Helper to add centered help text; mirrors PANEL:CPanelText for this file.
@@ -619,7 +619,7 @@ if CLIENT then
 
 			if IsValid(ToolPanel.panel) then
 
-				local MatData = ACE_GetMaterialData( value )
+				local MatData = ACE.GetMaterialData( value )
 
 				-- Fallback to RHA if the selected material is invalid.
 				if not MatData then RunConsoleCommand( "acfarmorprop_material", "RHA" ) return end
@@ -783,7 +783,7 @@ if CLIENT then
 		local thickness	= GetConVar( "acfarmorprop_thickness" ):GetFloat()
 		local mat		= GetConVar( "acfarmorprop_material" ):GetString() or "RHA"
 
-		local MatData	= ACE_GetMaterialData( mat )
+		local MatData	= ACE.GetMaterialData( mat )
 
 		local mass, armor, health = CalcArmor( area, ductility / 100, thickness , mat)
 		mass = math.min( mass, 50000 )

--- a/lua/weapons/weapon_ace_antipersonmine/init.lua
+++ b/lua/weapons/weapon_ace_antipersonmine/init.lua
@@ -14,7 +14,7 @@ function SWEP:DoAmmoStatDisplay()
 
 
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_antipersonmine/shared.lua
+++ b/lua/weapons/weapon_ace_antipersonmine/shared.lua
@@ -83,7 +83,7 @@ function SWEP:PrimaryAttack()
 		local Pos       = Owner:GetShootPos() + Forward * 32
 		local Angle     = Owner:EyeAngles()
 
-		ACE_CreateMine( "APL", Pos, Angle, Owner )
+		ACE.CreateMine( "APL", Pos, Angle, Owner )
 
 	end
 

--- a/lua/weapons/weapon_ace_antitankmine/init.lua
+++ b/lua/weapons/weapon_ace_antitankmine/init.lua
@@ -11,7 +11,7 @@ function SWEP:DoAmmoStatDisplay()
 	local sendInfo = string.format( "AT Mine")
 		sendInfo = sendInfo .. string.format(", %.1fm blast", 60 ^ 0.33 * 8) --4 taken from mine entity
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_antitankmine/shared.lua
+++ b/lua/weapons/weapon_ace_antitankmine/shared.lua
@@ -83,7 +83,7 @@ function SWEP:PrimaryAttack()
 		local Pos       = Owner:GetShootPos() + Forward * 32
 		local Angle     = Owner:EyeAngles()
 
-		ACE_CreateMine( "ATL", Pos, Angle, Owner )
+		ACE.CreateMine( "ATL", Pos, Angle, Owner )
 
 	end
 

--- a/lua/weapons/weapon_ace_base/init.lua
+++ b/lua/weapons/weapon_ace_base/init.lua
@@ -109,7 +109,7 @@ function SWEP:DoAmmoStatDisplay()
 		sendInfo = sendInfo .. string.format(", (2)%.1fmm pen", MaxPen)
 	end
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_base/shared.lua
+++ b/lua/weapons/weapon_ace_base/shared.lua
@@ -320,16 +320,16 @@ function SWEP:PrimaryAttack()
 
 		if game.SinglePlayer() then
 			if owner:IsPlayer() then
-				ACE_NetworkSPEffects( self, self.BulletData.PropMass) -- singleplayer, this whole function is not called clientside, so we need to network the client here
+				ACE.NetworkSPEffects( self, self.BulletData.PropMass) -- singleplayer, this whole function is not called clientside, so we need to network the client here
 			else
-				ACE_NetworkMPEffects(owner, self, self.BulletData.PropMass)
+				ACE.NetworkMPEffects(owner, self, self.BulletData.PropMass)
 			end
 		else
 			--Client is called here. So lets go as usual.
 			local sounds = ACE.GSounds.GunFire[self.Primary.Sound]
 			if next(sounds) then
 				if SERVER then
-					ACE_NetworkMPEffects(owner, self, self.BulletData.PropMass)
+					ACE.NetworkMPEffects(owner, self, self.BulletData.PropMass)
 				else
 					self:EmitSound(sounds.main.Package[math.random(#sounds.main.Package)])
 				end

--- a/lua/weapons/weapon_ace_boundingmine/init.lua
+++ b/lua/weapons/weapon_ace_boundingmine/init.lua
@@ -14,7 +14,7 @@ function SWEP:DoAmmoStatDisplay()
 
 
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_boundingmine/shared.lua
+++ b/lua/weapons/weapon_ace_boundingmine/shared.lua
@@ -83,7 +83,7 @@ function SWEP:PrimaryAttack()
 		local Pos       = Owner:GetShootPos() + Forward * 32
 		local Angle     = Owner:EyeAngles()
 
-		ACE_CreateMine( "Bounding-APL", Pos, Angle, Owner )
+		ACE.CreateMine( "Bounding-APL", Pos, Angle, Owner )
 
 	end
 

--- a/lua/weapons/weapon_ace_glock/shared.lua
+++ b/lua/weapons/weapon_ace_glock/shared.lua
@@ -131,9 +131,9 @@ function SWEP:SecondaryAttack()
 	if CLIENT then return end
 
 	if self.Primary.Automatic then
-		ACE_SendNotification(owner, "<<Automatic>>", 2)
+		ACE.SendNotification(owner, "<<Automatic>>", 2)
 	else
-		ACE_SendNotification(owner, "<<Semi>>", 2)
+		ACE.SendNotification(owner, "<<Semi>>", 2)
 	end
 	end
 

--- a/lua/weapons/weapon_ace_grenade/init.lua
+++ b/lua/weapons/weapon_ace_grenade/init.lua
@@ -14,7 +14,7 @@ function SWEP:DoAmmoStatDisplay()
 
 
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_javelin/init.lua
+++ b/lua/weapons/weapon_ace_javelin/init.lua
@@ -34,5 +34,5 @@ function SWEP:DoAmmoStatDisplay()
 	sendInfo = sendInfo .. ", Burn time: 15s"
 
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end

--- a/lua/weapons/weapon_ace_javelin/shared.lua
+++ b/lua/weapons/weapon_ace_javelin/shared.lua
@@ -337,7 +337,7 @@ function SWEP:AcquireLock()
 				end
 
 				dist = difpos:Length()
-				Heat = ACE_InfraredHeatFromProp(scanEnt, dist)
+				Heat = ACE.InfraredHeatFromProp(scanEnt, dist)
 			end
 
 			--Skip if not Hotter than AmbientTemp in deg C.

--- a/lua/weapons/weapon_ace_minedetector/init.lua
+++ b/lua/weapons/weapon_ace_minedetector/init.lua
@@ -548,7 +548,7 @@ function SWEP:SecondaryAttack()
         end
     else
         -- Regular mine
-        mine = ACE_CreateMine(mineData.type, tr.HitPos + Vector(0, 0, 5), Angle(0, owner:EyeAngles().y, 0), owner)
+        mine = ACE.CreateMine(mineData.type, tr.HitPos + Vector(0, 0, 5), Angle(0, owner:EyeAngles().y, 0), owner)
     end
 
     if IsValid(mine) then

--- a/lua/weapons/weapon_ace_portablemortar/shared.lua
+++ b/lua/weapons/weapon_ace_portablemortar/shared.lua
@@ -546,13 +546,13 @@ function SWEP:PrimaryAttack()
 		end
 
 		if game.SinglePlayer() then
-			ACE_NetworkSPEffects( self, self.BulletData.PropMass) -- singleplayer, this whole function is not called clientside, so we need to network the client here
+			ACE.NetworkSPEffects( self, self.BulletData.PropMass) -- singleplayer, this whole function is not called clientside, so we need to network the client here
 		else
 			--Client is called here. So lets go as usual.
 			local sounds = ACE.GSounds.GunFire[self.Primary.Sound]
 			if next(sounds) then
 				if SERVER then
-					ACE_NetworkMPEffects(owner, self, self.BulletData.PropMass)
+					ACE.NetworkMPEffects(owner, self, self.BulletData.PropMass)
 				else
 					self:EmitSound(sounds.main.Package[math.random(#sounds.main.Package)])
 				end

--- a/lua/weapons/weapon_ace_slam/init.lua
+++ b/lua/weapons/weapon_ace_slam/init.lua
@@ -15,7 +15,7 @@ function SWEP:DoAmmoStatDisplay()
 	local MaxPen = (Energy.Penetration / bdata.SlugPenArea) * ACF.KEtoRHA
 	sendInfo = sendInfo .. string.format(", %.1fmm pen", MaxPen)
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_smokegrenade/init.lua
+++ b/lua/weapons/weapon_ace_smokegrenade/init.lua
@@ -9,7 +9,7 @@ function SWEP:DoAmmoStatDisplay()
 	local sendInfo = string.format( "Smoke Grenade")
 		sendInfo = sendInfo .. string.format(", 10m radius")
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end
 
 function SWEP:Equip()

--- a/lua/weapons/weapon_ace_stinger/init.lua
+++ b/lua/weapons/weapon_ace_stinger/init.lua
@@ -22,5 +22,5 @@ function SWEP:DoAmmoStatDisplay()
 	sendInfo = sendInfo .. ", Burn time: 2.0s"
 
 
-	ACE_SendNotification(self:GetOwner(), sendInfo, 10)
+	ACE.SendNotification(self:GetOwner(), sendInfo, 10)
 end

--- a/lua/weapons/weapon_ace_stinger/shared.lua
+++ b/lua/weapons/weapon_ace_stinger/shared.lua
@@ -290,7 +290,7 @@ function SWEP:AcquireLock()
 				end
 
 				dist = difpos:Length()
-				Heat = ACE_InfraredHeatFromProp(scanEnt, dist)
+				Heat = ACE.InfraredHeatFromProp(scanEnt, dist)
 			end
 
 			--Skip if not Hotter than AmbientTemp in deg C.

--- a/lua/weapons/weapon_ace_xm25/shared.lua
+++ b/lua/weapons/weapon_ace_xm25/shared.lua
@@ -120,7 +120,7 @@ function SWEP:SecondaryAttack()
 				self:SetPg(GetConVar("sv_gravity"):GetInt() * -1)
 			end
 
-			ACE_SendNotification(owner, "Fuse Delay: " .. (self.FuseDelay > 0 and (math.Round(self.FuseDelay * 184.871) .. " m") or "None"), 2)
+			ACE.SendNotification(owner, "Fuse Delay: " .. (self.FuseDelay > 0 and (math.Round(self.FuseDelay * 184.871) .. " m") or "None"), 2)
 			return
 
 	end

--- a/lua/weapons/weapon_szcreator/shared.lua
+++ b/lua/weapons/weapon_szcreator/shared.lua
@@ -72,7 +72,7 @@ function SWEP:PrimaryAttack()
 		end
 	end
 
-	ACE_SendMsg(owner, Color(0,255,0), "[ACE SZ Tool] moved point(1)")
+	ACE.SendMsg(owner, Color(0,255,0), "[ACE SZ Tool] moved point(1)")
 	print("[ACE SZ Tool] moved point(1)")
 	self.Corner1Ent:SetPos(PointPos)
 	self.SZCorner1  = PointPos
@@ -84,7 +84,7 @@ function SWEP:PrimaryAttack()
 		if IsValid(self.PreviewEntity) then
 			self.PreviewEntity:Remove()
 		end
-		self.PreviewEntity = ACE_VisualizeSZ(self.SZCorner1, self.SZCorner2)
+		self.PreviewEntity = ACE.VisualizeSZ(self.SZCorner1, self.SZCorner2)
 	end
 
 end
@@ -126,7 +126,7 @@ function SWEP:SecondaryAttack()
 		end
 	end
 
-	ACE_SendMsg(owner, Color(255,0,0), "[ACE SZ Tool] moved point(2)")
+	ACE.SendMsg(owner, Color(255,0,0), "[ACE SZ Tool] moved point(2)")
 	print("[ACE SZ Tool] moved point(2)")
 	self.Corner2Ent:SetPos(PointPos)
 	self.SZCorner2  = PointPos
@@ -139,7 +139,7 @@ function SWEP:SecondaryAttack()
 		if IsValid(self.PreviewEntity) then
 			self.PreviewEntity:Remove()
 		end
-		self.PreviewEntity = ACE_VisualizeSZ(self.SZCorner1, self.SZCorner2)
+		self.PreviewEntity = ACE.VisualizeSZ(self.SZCorner1, self.SZCorner2)
 	end
 
 end

--- a/tests/python/lua_source.py
+++ b/tests/python/lua_source.py
@@ -101,7 +101,10 @@ def iter_named_calls(source: str, function_name: str):
         index = match.end()
         if token != function_parts[0]:
             continue
-        if match.start() > 0 and source[match.start() - 1] == ".":
+        previous = match.start() - 1
+        while previous >= 0 and source[previous] in " \t":
+            previous -= 1
+        if previous >= 0 and source[previous] == ".":
             continue
 
         matched = True

--- a/tests/python/lua_source.py
+++ b/tests/python/lua_source.py
@@ -82,6 +82,7 @@ def read_quoted_string(source: str, start: int):
 def iter_named_calls(source: str, function_name: str):
     """Yield ``(first_string_argument, name_offset, after_argument)`` calls."""
 
+    function_parts = function_name.split(".")
     index = 0
     while index < len(source):
         if source[index].isspace():
@@ -98,9 +99,25 @@ def iter_named_calls(source: str, function_name: str):
 
         token = match.group(0)
         index = match.end()
-        if token != function_name:
+        if token != function_parts[0]:
             continue
         if match.start() > 0 and source[match.start() - 1] == ".":
+            continue
+
+        matched = True
+        for part in function_parts[1:]:
+            index = skip_space_and_comments(source, index)
+            if index >= len(source) or source[index] != ".":
+                matched = False
+                break
+            index = skip_space_and_comments(source, index + 1)
+            part_match = IDENTIFIER.match(source, index)
+            if not part_match or part_match.group(0) != part:
+                matched = False
+                break
+            index = part_match.end()
+
+        if not matched:
             continue
 
         call_index = skip_space_and_comments(source, index)

--- a/tests/python/test_lua_source.py
+++ b/tests/python/test_lua_source.py
@@ -39,6 +39,7 @@ class LuaSourceHelperTests(unittest.TestCase):
         -- ACE.DefineMine(\"fake-comment\")
         local text = 'ACE.DefineMine(\\\"fake-string\\\")'
         object.ACE.DefineMine(\"not-a-global-call\")
+        object . ACE.DefineMine(\"also-not-a-global-call\")
         ACE . DefineMine(\"real\")
         """
 

--- a/tests/python/test_lua_source.py
+++ b/tests/python/test_lua_source.py
@@ -34,6 +34,22 @@ class LuaSourceHelperTests(unittest.TestCase):
             [("real", source.index('ACF_defineGun("real")'))],
         )
 
+    def test_named_calls_support_dotted_names(self):
+        source = """
+        -- ACE.DefineMine(\"fake-comment\")
+        local text = 'ACE.DefineMine(\\\"fake-string\\\")'
+        object.ACE.DefineMine(\"not-a-global-call\")
+        ACE . DefineMine(\"real\")
+        """
+
+        self.assertEqual(
+            ["real"],
+            [
+                identifier
+                for identifier, _, _ in iter_named_calls(source, "ACE.DefineMine")
+            ],
+        )
+
     def test_qualified_assignments_require_code_and_exact_name(self):
         source = """
         -- ACE.Value = \"comment\"

--- a/tests/python/test_native_suite_manifest.py
+++ b/tests/python/test_native_suite_manifest.py
@@ -19,7 +19,7 @@ class NativeSuiteManifestTests(unittest.TestCase):
     def test_native_suite_contains_multiple_groups(self):
         suites = {path.name for path in NATIVE_ROOT.glob("*.lua")}
         self.assertEqual(
-            {"000_discovery_canary.lua", "entity_registration.lua", "registries.lua"},
+            {"000_discovery_canary.lua", "entity_registration.lua", "registries.lua", "spall_rubber.lua"},
             suites,
         )
 

--- a/tests/python/test_registry_definitions.py
+++ b/tests/python/test_registry_definitions.py
@@ -17,14 +17,14 @@ ROUND_ROOT = SHARED_ROOT / "rounds"
 
 DEFINITION_FUNCTIONS = {
     "ACF_DefineEntity",
-    "ACE_DefineCrewseat",
-    "ACE_DefineExtras",
-    "ACE_DefineMuzzleFlash",
-    "ACE_DefineGunFireSound",
+    "ACE.DefineCrewseat",
+    "ACE.DefineExtras",
+    "ACE.DefineMuzzleFlash",
+    "ACE.DefineGunFireSound",
     "ACF_defineGunClass",
     "ACF_defineGun",
-    "ACE_DefineAmmoCrate",
-    "ACE_DefineLegacyAmmoCrate",
+    "ACE.DefineAmmoCrate",
+    "ACE.DefineLegacyAmmoCrate",
     "ACF_DefineRack",
     "ACF_DefineRackClass",
     "ACF_DefineEngine",
@@ -40,8 +40,8 @@ DEFINITION_FUNCTIONS = {
     "ACF_DefineIRST",
     "ACF_DefineIRSTClass",
     "ACF_DefineVHeatSource",
-    "ACE_DefineExplosive",
-    "ACE_DefineMine",
+    "ACE.DefineExplosive",
+    "ACE.DefineMine",
 }
 
 

--- a/tests/python/test_registry_definitions.py
+++ b/tests/python/test_registry_definitions.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from pathlib import Path
+import re
 import unittest
 
 from lua_source import (
@@ -14,6 +15,17 @@ from lua_source import (
 REPO = Path(__file__).resolve().parents[2]
 SHARED_ROOT = REPO / "lua" / "acf" / "shared"
 ROUND_ROOT = SHARED_ROOT / "rounds"
+COMPATIBILITY_SOURCE = REPO / "lua" / "autorun" / "acf_globals.lua"
+PREEXISTING_NAMESPACE_FUNCTIONS = {"GetHeadPos"}
+LATE_LOADED_ALIASES = {
+    "CalcVehicleView": "lua/autorun/sh_ace_workarounds.lua",
+    "PrimitivePropertiesApplied": "lua/autorun/server/sv_ace_primitive_compat.lua",
+    "CreateMine": "lua/entities/ace_mine/init.lua",
+    "RemoveBulletClient": "lua/effects/acf_bulleteffect/init.lua",
+    "EngineGUI_Update": "lua/entities/acf_engine/cl_init.lua",
+    "GetExplosiveMasses": "lua/entities/ace_explosive/init.lua",
+    "MakePrebuiltExplosive": "lua/entities/ace_explosive_prebuilt/init.lua",
+}
 
 DEFINITION_FUNCTIONS = {
     "ACF_DefineEntity",
@@ -89,6 +101,48 @@ class RegistryDefinitionTests(unittest.TestCase):
             for identifier, path in entries:
                 with self.subTest(function=function, source=path):
                     self.assertTrue(identifier.strip())
+
+    def test_migrated_namespace_functions_have_legacy_aliases(self):
+        namespace_functions = set()
+        legacy_globals = set()
+
+        for path in (REPO / "lua").rglob("*.lua"):
+            source = code_without_comments_and_strings(
+                path.read_text(encoding="utf-8", errors="replace")
+            )
+            namespace_functions.update(
+                re.findall(r"(?m)^\s*function\s+ACE\.([A-Za-z_][A-Za-z0-9_]*)\s*\(", source)
+            )
+            self.assertNotRegex(
+                source,
+                r"(?m)^\s*function\s+ACE_[A-Za-z_][A-Za-z0-9_]*\s*\(",
+                f"legacy global function definition remains in {path.relative_to(REPO)}",
+            )
+
+        compatibility_source = COMPATIBILITY_SOURCE.read_text(encoding="utf-8")
+        table = re.search(
+            r"local legacyACEFunctions = \{(.*?)\n\}",
+            compatibility_source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(table, "legacy compatibility table is missing")
+        legacy_globals.update(re.findall(r'"([A-Za-z_][A-Za-z0-9_]*)"', table.group(1)))
+        self.assertIn(
+            '_G["ACE_" .. name] = func',
+            compatibility_source,
+            "legacy compatibility loop is missing",
+        )
+
+        migrated = namespace_functions - PREEXISTING_NAMESPACE_FUNCTIONS
+        self.assertTrue(migrated <= legacy_globals)
+
+        for name, relative_path in LATE_LOADED_ALIASES.items():
+            source = (REPO / relative_path).read_text(encoding="utf-8")
+            self.assertIn(
+                f"ACE_{name} = ACE.{name}",
+                source,
+                f"late-loaded function {name} is missing its direct alias",
+            )
 
     def test_definition_scanner_ignores_comments_and_strings(self):
         source = '''

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -21,6 +21,7 @@ SOURCE = (
     / "server"
     / "sv_acfdamage.lua"
 )
+RUBBER_SOURCE = SOURCE.parents[1] / "shared" / "armor" / "rubber.lua"
 
 
 @dataclass(frozen=True)
@@ -69,6 +70,28 @@ def trace_fragments(
             shared_penetration = result[0]
 
     return results
+
+
+def apply_resolver_loss(penetration: float, kinetic: float, loss: float) -> tuple[float, float]:
+    """Apply ACE's HitRes.Loss contract once to one fragment's private energy."""
+
+    remaining = min(max(1.0 - loss, 0.0), 1.0)
+    return penetration * remaining, kinetic * remaining
+
+
+def rubber_spall_cost(thickness: float) -> float:
+    """Model the material's spall RHAe input before the standard resolver."""
+
+    return thickness**0.93 * 0.15
+
+
+def trace_rubber_layers(initial_penetration: float, thicknesses: list[float]) -> float:
+    """Deterministic strong-penetration path through ordinary rubber spall armor."""
+
+    penetration = initial_penetration
+    for thickness in thicknesses:
+        penetration = max(penetration - rubber_spall_cost(thickness), 0.0)
+    return penetration
 
 
 class SpallOracleTests(unittest.TestCase):
@@ -171,6 +194,39 @@ class SpallOracleTests(unittest.TestCase):
 
         self.assertEqual({remaining for remaining, _ in results}, {0})
 
+    def test_resolver_loss_reduces_both_energy_fields_once(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+
+    def test_resolver_loss_is_not_applied_twice_for_one_impact(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+        self.assertNotEqual(penetration, 56.25)
+        self.assertNotEqual(kinetic, 45)
+
+    def test_rubber_spall_is_thickness_scaled_and_not_a_flat_kill_switch(self):
+        fifteen = trace_rubber_layers(20, [15])
+        forty_five = trace_rubber_layers(20, [45])
+
+        self.assertGreater(fifteen, 0)
+        self.assertGreater(forty_five, 0)
+        self.assertLess(forty_five, fifteen)
+
+    def test_layered_rubber_consumes_the_same_fragment_budget_sequentially(self):
+        one_layer = trace_rubber_layers(20, [45])
+        two_layers = trace_rubber_layers(20, [45, 45])
+
+        self.assertGreater(one_layer, 0)
+        self.assertGreater(two_layers, 0)
+        self.assertLess(two_layers, one_layer)
+
+    def test_rubber_does_not_revert_to_the_old_spall_special_resilience(self):
+        self.assertAlmostEqual(rubber_spall_cost(15), 1.861, places=2)
+        self.assertAlmostEqual(rubber_spall_cost(45), 5.173, places=2)
+        self.assertGreater(trace_rubber_layers(20, [15]), 18)
+
 
 class SpallSourceContractTests(unittest.TestCase):
     @classmethod
@@ -184,6 +240,7 @@ class SpallSourceContractTests(unittest.TestCase):
         if not match:
             raise AssertionError("ACF_SpallTrace body could not be located")
         cls.body = match.group("body")
+        cls.rubber_source = RUBBER_SOURCE.read_text(encoding="utf-8")
 
     def test_trace_owns_a_copy_before_mutating_penetration(self):
         copy_pos = self.body.index("SpallEnergy = table.Copy(SpallEnergy)")
@@ -204,13 +261,38 @@ class SpallSourceContractTests(unittest.TestCase):
     def test_all_recursive_retries_preserve_incoming_direction(self):
         recursive_calls = re.findall(r"ACF_SpallTrace\((.*?)\)", self.body)
 
-        self.assertEqual(len(recursive_calls), 3)
+        self.assertEqual(len(recursive_calls), 2)
         self.assertTrue(all(re.match(r"\s*HitVec\s*,", call) for call in recursive_calls))
         self.assertNotIn("ACF_SpallTrace( SpallRes.HitPos", self.body)
 
     def test_trace_has_no_shared_penetration_assignment_before_copy(self):
         self.assertEqual(self.body.count("SpallEnergy = table.Copy(SpallEnergy)"), 1)
         self.assertGreaterEqual(self.body.count("SpallEnergy.Penetration ="), 2)
+
+    def test_resolver_loss_is_applied_once_before_the_single_retry(self):
+        self.assertEqual(self.body.count("local Remaining = math.Clamp"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Kinetic = SpallEnergy.Kinetic * Remaining"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Penetration = SpallEnergy.Penetration * Remaining"), 1)
+        self.assertEqual(self.body.count("-- Retry"), 1)
+
+    def test_kill_path_does_not_spawn_a_second_retry(self):
+        kill_block = re.search(r"if HitRes\.Kill then(?P<body>.*?)end\n\n\t\t-- Applies a decal", self.body, re.DOTALL)
+
+        self.assertIsNotNone(kill_block)
+        self.assertNotIn("ACF_SpallTrace", kill_block.group("body"))
+        self.assertIn("Debris = ACF_APKill", kill_block.group("body"))
+
+    def test_rubber_uses_default_spall_resolution_with_material_effectiveness(self):
+        self.assertIn("Material.spallresist = 0.15", self.rubber_source)
+        self.assertIn('if Type == "Spall" then\n\t\t\teffectiveness = Material.spallresist', self.rubber_source)
+        valid_types = re.search(r"local validTypes = \{(?P<body>.*?)\n\t\t\}", self.rubber_source, re.DOTALL)
+
+        self.assertIsNotNone(valid_types)
+        self.assertNotIn('["Spall"]', valid_types.group("body"))
+        self.assertNotIn("specialresiliance = Material.spallresist", self.rubber_source)
+
+    def test_rubber_preserves_non_spall_overmatch_behavior(self):
+        self.assertIn("local breachCaliber = Type == \"Spall\" and caliber or caliber * 10", self.rubber_source)
 
     def test_original_fragment_callers_remain_compatible(self):
         callers = re.findall(r"ACF_SpallTrace\(HitVec, Index", self.source)

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -32,14 +32,19 @@ class Layer:
     normal_x: float
 
 
-def trace_fragment(initial_penetration: float, layers: list[Layer], direction_x: float) -> tuple[float, list[float]]:
+def trace_fragment(
+    initial_penetration: float,
+    layers: list[Layer],
+    direction_x: float,
+    use_surface_normal: bool = False,
+) -> tuple[float, list[float]]:
     """Trace one fragment while preserving its direction and private energy budget."""
 
     penetration = initial_penetration
     directions: list[float] = []
 
     for layer in layers:
-        directions.append(direction_x)
+        directions.append(layer.normal_x if use_surface_normal else direction_x)
         penetration = max(penetration - layer.penetration_cost, 0.0)
 
     return penetration, directions
@@ -91,6 +96,52 @@ class SpallOracleTests(unittest.TestCase):
         self.assertEqual(results[0][0], 80)
         self.assertEqual(results[1][0], 60)
         self.assertEqual(results[-1][0], 0)
+
+    def test_user_story_apfsds_front_armor_then_45mm_rubber(self):
+        layers = [Layer("120 mm APFSDS target plate", 18, -1), Layer("45 mm rubber", 9, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual(len(results), 128)
+        self.assertEqual({remaining for remaining, _ in results}, {73})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_user_story_rubber_sandwich_keeps_each_fragment_independent(self):
+        layers = [
+            Layer("front RHA", 12, -1),
+            Layer("20 mm rubber", 8, -1),
+            Layer("inner RHA", 12, -1),
+            Layer("25 mm rubber", 8, -1),
+        ]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {60})
+
+    def test_user_story_repeated_128_fragment_bursts_are_stable(self):
+        layers = [Layer("front RHA", 15, -1), Layer("rubber", 10, -1)]
+
+        for burst in range(10):
+            with self.subTest(burst=burst):
+                results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+                self.assertEqual({remaining for remaining, _ in results}, {75})
+
+    def test_user_story_empty_gap_does_not_consume_energy_or_change_direction(self):
+        layers = [Layer("front RHA", 10, -1), Layer("empty gap", 0, -1), Layer("rubber", 5, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 85)
+        self.assertEqual(directions, [1, 1, 1])
+
+    def test_surface_normal_control_case_reproduces_historical_bounce(self):
+        layers = [Layer("armor exit", 0, -1)]
+
+        _, fixed_directions = trace_fragment(100, layers, direction_x=1)
+        _, historical_directions = trace_fragment(100, layers, direction_x=1, use_surface_normal=True)
+
+        self.assertEqual(fixed_directions, [1])
+        self.assertEqual(historical_directions, [-1])
 
     def test_layer_matrix_does_not_change_fragment_independence(self):
         materials = [

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -1,0 +1,171 @@
+"""Offline regression tests for ACE's directional, layered spall traces.
+
+The source checks protect the exact GLua contract.  The small oracle below models only the
+load-bearing state transitions in ACF_SpallTrace: each fragment starts with the same energy,
+its own trace consumes energy across layers, and retries keep the incoming direction.
+It intentionally does not pretend to replace a native GMod damage test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "lua"
+    / "acf"
+    / "server"
+    / "sv_acfdamage.lua"
+)
+
+
+@dataclass(frozen=True)
+class Layer:
+    """A deterministic layer in the reduced spall-energy oracle."""
+
+    name: str
+    penetration_cost: float
+    normal_x: float
+
+
+def trace_fragment(initial_penetration: float, layers: list[Layer], direction_x: float) -> tuple[float, list[float]]:
+    """Trace one fragment while preserving its direction and private energy budget."""
+
+    penetration = initial_penetration
+    directions: list[float] = []
+
+    for layer in layers:
+        directions.append(direction_x)
+        penetration = max(penetration - layer.penetration_cost, 0.0)
+
+    return penetration, directions
+
+
+def trace_fragments(
+    initial_penetration: float,
+    layers: list[Layer],
+    fragment_count: int,
+    isolated_energy: bool,
+) -> list[tuple[float, list[float]]]:
+    """Compare per-fragment state with the historical shared-table behavior."""
+
+    shared_penetration = initial_penetration
+    results = []
+
+    for _ in range(fragment_count):
+        start = initial_penetration if isolated_energy else shared_penetration
+        result = trace_fragment(start, layers, direction_x=1.0)
+        results.append(result)
+        if not isolated_energy:
+            shared_penetration = result[0]
+
+    return results
+
+
+class SpallOracleTests(unittest.TestCase):
+    def test_single_fragment_preserves_energy_accounting_across_layers(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 80)
+        self.assertEqual(directions, [1, 1])
+
+    def test_each_fragment_starts_from_original_energy(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {80})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_shared_energy_regression_is_detectable(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=False)
+
+        self.assertEqual(results[0][0], 80)
+        self.assertEqual(results[1][0], 60)
+        self.assertEqual(results[-1][0], 0)
+
+    def test_layer_matrix_does_not_change_fragment_independence(self):
+        materials = [
+            Layer("RHA", 12, -1),
+            Layer("cast", 10, -1),
+            Layer("rubber", 8, -1),
+            Layer("ceramic", 6, -1),
+            Layer("textolite", 4, -1),
+        ]
+
+        for split in range(len(materials) + 1):
+            with self.subTest(split=split):
+                layers = materials[:split]
+                results = trace_fragments(100, layers, fragment_count=16, isolated_energy=True)
+                expected = max(100 - sum(layer.penetration_cost for layer in layers), 0)
+                self.assertEqual({remaining for remaining, _ in results}, {expected})
+
+    def test_zero_layer_trace_is_a_noop(self):
+        results = trace_fragments(100, [], fragment_count=8, isolated_energy=True)
+
+        self.assertEqual(results, [(100, [])] * 8)
+
+    def test_zero_energy_cannot_become_positive(self):
+        layers = [Layer("rubber", 0, -1), Layer("rubber", 10, -1)]
+
+        results = trace_fragments(0, layers, fragment_count=8, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {0})
+
+
+class SpallSourceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        match = re.search(
+            r"function ACF_SpallTrace\(.*?\n(?P<body>.*?)\nend\n\n--Calculates the vector",
+            cls.source,
+            re.DOTALL,
+        )
+        if not match:
+            raise AssertionError("ACF_SpallTrace body could not be located")
+        cls.body = match.group("body")
+
+    def test_trace_owns_a_copy_before_mutating_penetration(self):
+        copy_pos = self.body.index("SpallEnergy = table.Copy(SpallEnergy)")
+        mutation_pos = self.body.index("SpallEnergy.Penetration =")
+
+        self.assertLess(copy_pos, mutation_pos)
+
+    def test_both_continuation_paths_use_incoming_direction(self):
+        end_positions = re.findall(
+            r"ACE\.Spall\[Index\]\.endpos\s*=\s*(.+)",
+            self.body,
+        )
+
+        self.assertEqual(len(end_positions), 2)
+        self.assertTrue(all("HitVec:GetNormalized()" in expression for expression in end_positions))
+        self.assertTrue(all("SpallRes.HitNormal" not in expression for expression in end_positions))
+
+    def test_all_recursive_retries_preserve_incoming_direction(self):
+        recursive_calls = re.findall(r"ACF_SpallTrace\((.*?)\)", self.body)
+
+        self.assertEqual(len(recursive_calls), 3)
+        self.assertTrue(all(re.match(r"\s*HitVec\s*,", call) for call in recursive_calls))
+        self.assertNotIn("ACF_SpallTrace( SpallRes.HitPos", self.body)
+
+    def test_trace_has_no_shared_penetration_assignment_before_copy(self):
+        self.assertEqual(self.body.count("SpallEnergy = table.Copy(SpallEnergy)"), 1)
+        self.assertGreaterEqual(self.body.count("SpallEnergy.Penetration ="), 2)
+
+    def test_original_fragment_callers_remain_compatible(self):
+        callers = re.findall(r"ACF_SpallTrace\(HitVec, Index", self.source)
+
+        self.assertGreaterEqual(len(callers), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -255,15 +255,19 @@ class SpallSourceContractTests(unittest.TestCase):
         )
 
         self.assertEqual(len(end_positions), 2)
-        self.assertTrue(all("HitVec:GetNormalized()" in expression for expression in end_positions))
+        self.assertTrue(all("SpallDirection" in expression for expression in end_positions))
         self.assertTrue(all("SpallRes.HitNormal" not in expression for expression in end_positions))
 
     def test_all_recursive_retries_preserve_incoming_direction(self):
         recursive_calls = re.findall(r"ACF_SpallTrace\((.*?)\)", self.body)
 
         self.assertEqual(len(recursive_calls), 2)
-        self.assertTrue(all(re.match(r"\s*HitVec\s*,", call) for call in recursive_calls))
+        self.assertTrue(all(re.match(r"\s*SpallDirection\s*,", call) for call in recursive_calls))
         self.assertNotIn("ACF_SpallTrace( SpallRes.HitPos", self.body)
+
+    def test_fragment_direction_comes_from_current_trace_with_legacy_fallback(self):
+        self.assertIn("local SpallDirection = HitVec:GetNormalized()", self.body)
+        self.assertIn("SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()", self.body)
 
     def test_trace_has_no_shared_penetration_assignment_before_copy(self):
         self.assertEqual(self.body.count("SpallEnergy = table.Copy(SpallEnergy)"), 1)


### PR DESCRIPTION
## Description

A user in discord (@bubbly_monkey_51950) wrote up a fix for the problem that spall was extremely over-effective at eating spall. You only needed 45mm of rubber to defeat a 120mm APFSDS round. He proposed a short solution slightly modifying the end position of spall to make it more directional. I double checked the math and used Codex to implement it on top of the first namespace refactoring pr. 

## Summary

- Consolidated rubber into the normal spalling path, previously it had special behavior under the HEAT paths
- Instead, gave it a small spall resist number
- Did a minimal fix to spall behavior in general to do this, it's a pure optimization and consolidates the path further
- Corrected breach probability as it related to spalling
- Added new unit tests to ensure no regression in the future

## Requirements
- The namespace refactoring pr (#290) must be merged before this can be implemented
