### PR TITLE
Bugfix: Rubber eating spall

### DIFF
--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -696,10 +696,18 @@ end
 
 --Spall trace core. For HESH and normal spalling
 function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallVelocity )
+	-- Each fragment needs its own mutable penetration budget. Recursive retries keep this copy,
+	-- while later fragments must start from the original energy.
+	SpallEnergy = table.Copy(SpallEnergy)
 
 	local Entity_Crit_Hit_Factor = 1.01
 
-	local SpallRes = util.TraceLine(ACE.Spall[Index])
+	local SpallTrace = ACE.Spall[Index]
+	local SpallDirection = HitVec:GetNormalized()
+	if SpallTrace and SpallTrace.start and SpallTrace.endpos then
+		SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()
+	end
+	local SpallRes = util.TraceLine(SpallTrace)
 
 	-- Check if spalling hit something
 	if SpallRes.Hit and ACF_Check( SpallRes.Entity ) then
@@ -715,19 +723,19 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 				ACE.Spall[Index] = {}
 				ACE.Spall[Index].start  = SpallRes.HitPos
-				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
 
 		end
 
 		-- Get the spalling hitAngle
-		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , HitVec )
+		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , SpallDirection )
 		-- print("ANGLE: " .. Angle)
 
 		local Mat		= SpallRes.Entity.ACF.Material or "RHA"
@@ -759,38 +767,41 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		-- Applies the damage to the impacted entity
 		local HitRes = ACF_Damage( SpallRes.Entity , SpallEnergy , SpallArea , Angle , Inflictor, 0, nil, "Spall") --Angle replaced with 0 for inconsistent spall
 
-		-- If it's able to destroy it, kill it and filter it
+		-- If it's able to destroy it, kill it. Any debris is added to the single
+		-- continuation filter below so this impact cannot spawn a second retry.
+		local Debris
 		if HitRes.Kill then
-			local Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
-			if IsValid(Debris) then
-				table.insert( ACE.Spall[Index].filter , Debris )
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
-			end
+			Debris = ACF_APKill( SpallRes.Entity , SpallDirection , SpallEnergy.Kinetic )
 		end
 
 		-- Applies a decal
 		util.Decal("GunShot1",SpallRes.StartPos, SpallRes.HitPos, ACE.Spall[Index].filter )
 
-		-- The entity was penetrated --Disabled since penetration values are not real
-		if HitRes.Overkill > 0 then
+		-- Continue once with the standard armor resolver's remaining-energy fraction.
+		-- This is fragment-local because SpallEnergy was copied at function entry.
+		local Remaining = math.Clamp(1 - (HitRes.Loss or 1), 0, 1)
+		if HitRes.Overkill > 0 and Remaining > 0 then
+			SpallEnergy.Penetration = SpallEnergy.Penetration * Remaining
+			SpallEnergy.Kinetic = SpallEnergy.Kinetic * Remaining
 
 			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
+			if IsValid(Debris) then
+				table.insert( Temp_Filter , Debris )
+			end
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
-			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-			SpallRes = util.TraceLine(ACE.Spall[Index])
-
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
-			-- Blue trace means spall trace that overpenned and killed something.
+			-- Blue trace means spall penetrated and will continue.
 
 			-- Retry
-			ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+			ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
 		else
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -10,7 +10,7 @@ Material.year		= 1955
 Material.massMod		= 0.2
 Material.curve		= 0.93
 
-Material.specialeffect  = 20 --Caliber to divide HEAT and spall caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
+Material.specialeffect  = 20 --Caliber to divide HEAT caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
 
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
@@ -25,7 +25,9 @@ Material.HEATresiliance = 2
 
 Material.HEresiliance	= 6
 
-Material.spallresist = 0.75
+-- Spall uses the ordinary kinetic resolver below. This keeps rubber's response thickness-based
+-- and lets ACF_SpallTrace carry the resolver's remaining energy through layered armor.
+Material.spallresist = 0.15
 
 Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
 Material.ArmorMul	= 0.05
@@ -42,6 +44,10 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		if Type == "Spall" then
+			effectiveness = Material.spallresist
+		end
+
 		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
 		local ductilitymult    = 2 / (2 + ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
 
@@ -50,26 +56,19 @@ if SERVER then
 
 
 		--=========================================================================================================\
-		--------------------------------------------------------- For HEAT shells & Spall -------------------------->
+		--------------------------------------------------------- For HEAT shells ---------------------------------->
 		--=========================================================================================================/
 		local validTypes = {
 			["HEAT"] = true,
 			["THEAT"] = true,
 			["HEATFS"] = true,
-			["THEATFS"] = true,
-			["Spall"] = true
+			["THEATFS"] = true
 		}
 
 		if validTypes[Type] then
 
 			local specialeffectiveness  = Material.HEATeffectiveness
 			local specialresiliance	= Material.HEATresiliance
-
-
-			if Type == "Spall" then --Overrides effectiveness values if deflecting spall
-				specialeffectiveness = Material.spallresist
-				specialresiliance = Material.spallresist
-			end
 
 			local DmgResist = 0.01 + math.min(caliber * 10 / Material.specialeffect, 5) * 10 --Caliber in mm / specialeffect. Makes HEAT shells with a larger jet shred rubber more.
 
@@ -169,9 +168,12 @@ if SERVER then
 		--------------------------------------------------------- For AP shells -------------------------->
 		--===============================================================================================/
 		else
+			-- Preserve rubber's existing kinetic overmatch behavior while matching the default
+			-- RHA/spall caliber convention for fragments.
+			local breachCaliber = Type == "Spall" and caliber or caliber * 10
 
 			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
-			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
+			local breachProb = math.Clamp( (breachCaliber / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 
 			-- Penetration probability

--- a/lua/tests/ace/spall_rubber.lua
+++ b/lua/tests/ace/spall_rubber.lua
@@ -1,0 +1,134 @@
+local function makeEntity(name)
+	return {
+		name = name,
+		ACF = { Ductility = 0 },
+		GetClass = function() return "prop_physics" end,
+		GetPhysicsObject = function() return nil end,
+	}
+end
+
+local function withSpallTraceStubs(callback)
+	local original = {
+		TraceLine = util.TraceLine,
+		Decal = util.Decal,
+		ACFCheck = _G.ACF_Check,
+		ACFCheckClips = _G.ACF_CheckClips,
+		ACFDamage = _G.ACF_Damage,
+		ACFHitAngle = _G.ACF_GetHitAngle,
+		GetMaterialData = ACE.GetMaterialData,
+		VectorRand = _G.VectorRand,
+		Line = debugoverlay.Line,
+		CritEnts = ACE.CritEnts,
+		Spall = ACE.Spall[1],
+	}
+
+	local ok, err = pcall(callback)
+
+	util.TraceLine = original.TraceLine
+	util.Decal = original.Decal
+	_G.ACF_Check = original.ACFCheck
+	_G.ACF_CheckClips = original.ACFCheckClips
+	_G.ACF_Damage = original.ACFDamage
+	_G.ACF_GetHitAngle = original.ACFHitAngle
+	ACE.GetMaterialData = original.GetMaterialData
+	_G.VectorRand = original.VectorRand
+	debugoverlay.Line = original.Line
+	ACE.CritEnts = original.CritEnts
+	ACE.Spall[1] = original.Spall
+
+	if not ok then error(err, 0) end
+end
+
+local function withSuccessfulArmorRoll(callback)
+	local originalRandom = math.random
+	math.random = function() return 0 end
+
+	local ok, err = pcall(callback)
+
+	math.random = originalRandom
+
+	if not ok then error(err, 0) end
+end
+
+return {
+	groupName = "ACE rubber spall behavior",
+	cases = {
+		{
+			name = "routes spall through thickness-scaled ordinary rubber resolution",
+			func = function()
+				withSuccessfulArmorRoll(function()
+					local rubber = ACE.ArmorTypes.Rub
+					local entity = { ACF = { Ductility = 0 } }
+					local result = rubber.ArmorResolution(entity, 15, 15, 15 ^ 1.1 * 3.5, 100, 1, 1, 1, "Spall")
+					local expectedLoss = 15 ^ 0.93 * 0.15 / 100
+
+					expect(rubber.spallresist).to.equal(0.15)
+					expect(result.Overkill).to.beGreaterThan(0)
+					expect(result.Loss).to.aboutEqual(expectedLoss)
+				end)
+			end,
+		},
+		{
+			name = "carries one fragment's remaining energy through a recursive layer",
+			func = function()
+				local front = makeEntity("front")
+				local rear = makeEntity("rear")
+				local seen = {}
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.CritEnts = {}
+					ACE.Spall[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return true end
+					_G.ACF_CheckClips = function() return false end
+					_G.ACF_GetHitAngle = function() return 0 end
+					_G.VectorRand = function() return Vector(0, 0, 0) end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					local traceEnds = {}
+					util.TraceLine = function(trace)
+						traces = traces + 1
+						traceEnds[traces] = trace.endpos
+						local entity = traces == 1 and front or rear
+
+						return {
+							Hit = true,
+							Entity = entity,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector((traces - 1) * 100, 0, 0),
+							HitPos = Vector(0, traces * 100, 0),
+						}
+					end
+					_G.ACF_Damage = function(entity, energy)
+						seen[#seen + 1] = { entity = entity, penetration = energy.Penetration, kinetic = energy.Kinetic }
+
+						if entity == front then
+							return { Overkill = 10, Loss = 0.25, Kill = false }
+						end
+
+						return { Overkill = 0, Loss = 1, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(traceEnds[2].x).to.equal(0)
+					expect(traceEnds[2].y).to.beGreaterThan(traceEnds[2].x + 100)
+				end)
+
+				expect(traces).to.equal(2)
+				expect(#seen).to.equal(2)
+				expect(seen[1].penetration).to.equal(100)
+				expect(seen[1].kinetic).to.equal(80)
+				expect(seen[2].penetration).to.equal(75)
+				expect(seen[2].kinetic).to.equal(60)
+			end,
+		},
+	},
+}

--- a/tests/python/test_native_suite_manifest.py
+++ b/tests/python/test_native_suite_manifest.py
@@ -19,7 +19,7 @@ class NativeSuiteManifestTests(unittest.TestCase):
     def test_native_suite_contains_multiple_groups(self):
         suites = {path.name for path in NATIVE_ROOT.glob("*.lua")}
         self.assertEqual(
-            {"000_discovery_canary.lua", "entity_registration.lua", "registries.lua"},
+            {"000_discovery_canary.lua", "entity_registration.lua", "registries.lua", "spall_rubber.lua"},
             suites,
         )
 

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -1,0 +1,308 @@
+"""Offline regression tests for ACE's directional, layered spall traces.
+
+The source checks protect the exact GLua contract.  The small oracle below models only the
+load-bearing state transitions in ACF_SpallTrace: each fragment starts with the same energy,
+its own trace consumes energy across layers, and retries keep the incoming direction.
+It intentionally does not pretend to replace a native GMod damage test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "lua"
+    / "acf"
+    / "server"
+    / "sv_acfdamage.lua"
+)
+RUBBER_SOURCE = SOURCE.parents[1] / "shared" / "armor" / "rubber.lua"
+
+
+@dataclass(frozen=True)
+class Layer:
+    """A deterministic layer in the reduced spall-energy oracle."""
+
+    name: str
+    penetration_cost: float
+    normal_x: float
+
+
+def trace_fragment(
+    initial_penetration: float,
+    layers: list[Layer],
+    direction_x: float,
+    use_surface_normal: bool = False,
+) -> tuple[float, list[float]]:
+    """Trace one fragment while preserving its direction and private energy budget."""
+
+    penetration = initial_penetration
+    directions: list[float] = []
+
+    for layer in layers:
+        directions.append(layer.normal_x if use_surface_normal else direction_x)
+        penetration = max(penetration - layer.penetration_cost, 0.0)
+
+    return penetration, directions
+
+
+def trace_fragments(
+    initial_penetration: float,
+    layers: list[Layer],
+    fragment_count: int,
+    isolated_energy: bool,
+) -> list[tuple[float, list[float]]]:
+    """Compare per-fragment state with the historical shared-table behavior."""
+
+    shared_penetration = initial_penetration
+    results = []
+
+    for _ in range(fragment_count):
+        start = initial_penetration if isolated_energy else shared_penetration
+        result = trace_fragment(start, layers, direction_x=1.0)
+        results.append(result)
+        if not isolated_energy:
+            shared_penetration = result[0]
+
+    return results
+
+
+def apply_resolver_loss(penetration: float, kinetic: float, loss: float) -> tuple[float, float]:
+    """Apply ACE's HitRes.Loss contract once to one fragment's private energy."""
+
+    remaining = min(max(1.0 - loss, 0.0), 1.0)
+    return penetration * remaining, kinetic * remaining
+
+
+def rubber_spall_cost(thickness: float) -> float:
+    """Model the material's spall RHAe input before the standard resolver."""
+
+    return thickness**0.93 * 0.15
+
+
+def trace_rubber_layers(initial_penetration: float, thicknesses: list[float]) -> float:
+    """Deterministic strong-penetration path through ordinary rubber spall armor."""
+
+    penetration = initial_penetration
+    for thickness in thicknesses:
+        penetration = max(penetration - rubber_spall_cost(thickness), 0.0)
+    return penetration
+
+
+class SpallOracleTests(unittest.TestCase):
+    def test_single_fragment_preserves_energy_accounting_across_layers(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 80)
+        self.assertEqual(directions, [1, 1])
+
+    def test_each_fragment_starts_from_original_energy(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {80})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_shared_energy_regression_is_detectable(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=False)
+
+        self.assertEqual(results[0][0], 80)
+        self.assertEqual(results[1][0], 60)
+        self.assertEqual(results[-1][0], 0)
+
+    def test_user_story_apfsds_front_armor_then_45mm_rubber(self):
+        layers = [Layer("120 mm APFSDS target plate", 18, -1), Layer("45 mm rubber", 9, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual(len(results), 128)
+        self.assertEqual({remaining for remaining, _ in results}, {73})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_user_story_rubber_sandwich_keeps_each_fragment_independent(self):
+        layers = [
+            Layer("front RHA", 12, -1),
+            Layer("20 mm rubber", 8, -1),
+            Layer("inner RHA", 12, -1),
+            Layer("25 mm rubber", 8, -1),
+        ]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {60})
+
+    def test_user_story_repeated_128_fragment_bursts_are_stable(self):
+        layers = [Layer("front RHA", 15, -1), Layer("rubber", 10, -1)]
+
+        for burst in range(10):
+            with self.subTest(burst=burst):
+                results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+                self.assertEqual({remaining for remaining, _ in results}, {75})
+
+    def test_user_story_empty_gap_does_not_consume_energy_or_change_direction(self):
+        layers = [Layer("front RHA", 10, -1), Layer("empty gap", 0, -1), Layer("rubber", 5, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 85)
+        self.assertEqual(directions, [1, 1, 1])
+
+    def test_surface_normal_control_case_reproduces_historical_bounce(self):
+        layers = [Layer("armor exit", 0, -1)]
+
+        _, fixed_directions = trace_fragment(100, layers, direction_x=1)
+        _, historical_directions = trace_fragment(100, layers, direction_x=1, use_surface_normal=True)
+
+        self.assertEqual(fixed_directions, [1])
+        self.assertEqual(historical_directions, [-1])
+
+    def test_layer_matrix_does_not_change_fragment_independence(self):
+        materials = [
+            Layer("RHA", 12, -1),
+            Layer("cast", 10, -1),
+            Layer("rubber", 8, -1),
+            Layer("ceramic", 6, -1),
+            Layer("textolite", 4, -1),
+        ]
+
+        for split in range(len(materials) + 1):
+            with self.subTest(split=split):
+                layers = materials[:split]
+                results = trace_fragments(100, layers, fragment_count=16, isolated_energy=True)
+                expected = max(100 - sum(layer.penetration_cost for layer in layers), 0)
+                self.assertEqual({remaining for remaining, _ in results}, {expected})
+
+    def test_zero_layer_trace_is_a_noop(self):
+        results = trace_fragments(100, [], fragment_count=8, isolated_energy=True)
+
+        self.assertEqual(results, [(100, [])] * 8)
+
+    def test_zero_energy_cannot_become_positive(self):
+        layers = [Layer("rubber", 0, -1), Layer("rubber", 10, -1)]
+
+        results = trace_fragments(0, layers, fragment_count=8, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {0})
+
+    def test_resolver_loss_reduces_both_energy_fields_once(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+
+    def test_resolver_loss_is_not_applied_twice_for_one_impact(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+        self.assertNotEqual(penetration, 56.25)
+        self.assertNotEqual(kinetic, 45)
+
+    def test_rubber_spall_is_thickness_scaled_and_not_a_flat_kill_switch(self):
+        fifteen = trace_rubber_layers(20, [15])
+        forty_five = trace_rubber_layers(20, [45])
+
+        self.assertGreater(fifteen, 0)
+        self.assertGreater(forty_five, 0)
+        self.assertLess(forty_five, fifteen)
+
+    def test_layered_rubber_consumes_the_same_fragment_budget_sequentially(self):
+        one_layer = trace_rubber_layers(20, [45])
+        two_layers = trace_rubber_layers(20, [45, 45])
+
+        self.assertGreater(one_layer, 0)
+        self.assertGreater(two_layers, 0)
+        self.assertLess(two_layers, one_layer)
+
+    def test_rubber_does_not_revert_to_the_old_spall_special_resilience(self):
+        self.assertAlmostEqual(rubber_spall_cost(15), 1.861, places=2)
+        self.assertAlmostEqual(rubber_spall_cost(45), 5.173, places=2)
+        self.assertGreater(trace_rubber_layers(20, [15]), 18)
+
+
+class SpallSourceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        match = re.search(
+            r"function ACF_SpallTrace\(.*?\n(?P<body>.*?)\nend\n\n--Calculates the vector",
+            cls.source,
+            re.DOTALL,
+        )
+        if not match:
+            raise AssertionError("ACF_SpallTrace body could not be located")
+        cls.body = match.group("body")
+        cls.rubber_source = RUBBER_SOURCE.read_text(encoding="utf-8")
+
+    def test_trace_owns_a_copy_before_mutating_penetration(self):
+        copy_pos = self.body.index("SpallEnergy = table.Copy(SpallEnergy)")
+        mutation_pos = self.body.index("SpallEnergy.Penetration =")
+
+        self.assertLess(copy_pos, mutation_pos)
+
+    def test_both_continuation_paths_use_incoming_direction(self):
+        end_positions = re.findall(
+            r"ACE\.Spall\[Index\]\.endpos\s*=\s*(.+)",
+            self.body,
+        )
+
+        self.assertEqual(len(end_positions), 2)
+        self.assertTrue(all("SpallDirection" in expression for expression in end_positions))
+        self.assertTrue(all("SpallRes.HitNormal" not in expression for expression in end_positions))
+
+    def test_all_recursive_retries_preserve_incoming_direction(self):
+        recursive_calls = re.findall(r"ACF_SpallTrace\((.*?)\)", self.body)
+
+        self.assertEqual(len(recursive_calls), 2)
+        self.assertTrue(all(re.match(r"\s*SpallDirection\s*,", call) for call in recursive_calls))
+        self.assertNotIn("ACF_SpallTrace( SpallRes.HitPos", self.body)
+
+    def test_fragment_direction_comes_from_current_trace_with_legacy_fallback(self):
+        self.assertIn("local SpallDirection = HitVec:GetNormalized()", self.body)
+        self.assertIn("SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()", self.body)
+
+    def test_trace_has_no_shared_penetration_assignment_before_copy(self):
+        self.assertEqual(self.body.count("SpallEnergy = table.Copy(SpallEnergy)"), 1)
+        self.assertGreaterEqual(self.body.count("SpallEnergy.Penetration ="), 2)
+
+    def test_resolver_loss_is_applied_once_before_the_single_retry(self):
+        self.assertEqual(self.body.count("local Remaining = math.Clamp"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Kinetic = SpallEnergy.Kinetic * Remaining"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Penetration = SpallEnergy.Penetration * Remaining"), 1)
+        self.assertEqual(self.body.count("-- Retry"), 1)
+
+    def test_kill_path_does_not_spawn_a_second_retry(self):
+        kill_block = re.search(r"if HitRes\.Kill then(?P<body>.*?)end\n\n\t\t-- Applies a decal", self.body, re.DOTALL)
+
+        self.assertIsNotNone(kill_block)
+        self.assertNotIn("ACF_SpallTrace", kill_block.group("body"))
+        self.assertIn("Debris = ACF_APKill", kill_block.group("body"))
+
+    def test_rubber_uses_default_spall_resolution_with_material_effectiveness(self):
+        self.assertIn("Material.spallresist = 0.15", self.rubber_source)
+        self.assertIn('if Type == "Spall" then\n\t\t\teffectiveness = Material.spallresist', self.rubber_source)
+        valid_types = re.search(r"local validTypes = \{(?P<body>.*?)\n\t\t\}", self.rubber_source, re.DOTALL)
+
+        self.assertIsNotNone(valid_types)
+        self.assertNotIn('["Spall"]', valid_types.group("body"))
+        self.assertNotIn("specialresiliance = Material.spallresist", self.rubber_source)
+
+    def test_rubber_preserves_non_spall_overmatch_behavior(self):
+        self.assertIn("local breachCaliber = Type == \"Spall\" and caliber or caliber * 10", self.rubber_source)
+
+    def test_original_fragment_callers_remain_compatible(self):
+        callers = re.findall(r"ACF_SpallTrace\(HitVec, Index", self.source)
+
+        self.assertGreaterEqual(len(callers), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Spall is an extremely messy path in ACE, and rubber turned out to be under HEAT exceptions for spall and have several of its own behaviors. I monitored and tested as codex moved spall into the normal path. 

Spall did still need something to give it an advantage against spall, and after researching, the end decision was to give it a small modifier to increase its effectiveness at taking away spall energy, but not stopping it in place.

## Summary

- Keep rubber spall handling on the ordinary thickness-scaled path, same as everything else.
- Preserve fragment-local energy and direction across recursive spall continuation. This was not implemented correctly before, and was required to fully fix the issue.
- Add regression coverage for layered rubber, fragment independence, attenuation, and non-spall behavior.