### PR TITLE
Refactor armor and spall damage contracts

### DIFF
--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -1,7 +1,8 @@
 -- This file is meant for the advanced damage functions used by the Armored Combat Framework
-ACE.Spall		= {}
+ACE.SpallTraces	= ACE.SpallTraces or {}
 ACE.CurSpallIndex = 0
 ACE.SpallMax	= 250
+ACE.SpallTraceMaxDepth = ACE.SpallTraceMaxDepth or ACE.SpallMax
 
 -- optimization; reuse tables for ballistics traces
 local TraceRes  = {}
@@ -488,12 +489,12 @@ function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Ma
 			-- Normal Trace creation
 			local Index = ACE.CurSpallIndex
 
-			ACE.Spall[Index] = {}
-			ACE.Spall[Index].start  = HitPos
-			ACE.Spall[Index].endpos = HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel / 8, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
-			ACE.Spall[Index].filter = table.Copy(Filter)
-			ACE.Spall[Index].mins	= Vector(0,0,0)
-			ACE.Spall[Index].maxs	= Vector(0,0,0)
+			ACE.SpallTraces[Index] = {}
+			ACE.SpallTraces[Index].start  = HitPos
+			ACE.SpallTraces[Index].endpos = HitPos + ( HitVec:GetNormalized() + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVel / 8, 600 ) --Spall endtrace. Used to determine spread and the spall trace length. Only adjust the value in the max to determine the minimum distance spall will travel. 600 should be fine.
+			ACE.SpallTraces[Index].filter = table.Copy(Filter)
+			ACE.SpallTraces[Index].mins	= Vector(0,0,0)
+			ACE.SpallTraces[Index].maxs	= Vector(0,0,0)
 
 			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor, SpallVel)
 
@@ -695,10 +696,10 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 			-- Normal Trace creation
 			local Index = ACE.CurSpallIndex
 
-			ACE.Spall[Index]			= {}
-			ACE.Spall[Index].start	= HitPos
-			ACE.Spall[Index].endpos	= HitPos + ((fNormal * 2500 + HitVec):GetNormalized() + VectorRand() / 3):GetNormalized() * math.max( SpallVel / 8, 600) --I got bored of spall not going across the tank
-			ACE.Spall[Index].filter	= table.Copy(Temp_Filter)
+			ACE.SpallTraces[Index]			= {}
+			ACE.SpallTraces[Index].start	= HitPos
+			ACE.SpallTraces[Index].endpos	= HitPos + ((fNormal * 2500 + HitVec):GetNormalized() + VectorRand() / 3):GetNormalized() * math.max( SpallVel / 8, 600) --I got bored of spall not going across the tank
+			ACE.SpallTraces[Index].filter	= table.Copy(Temp_Filter)
 
 			ACF_SpallTrace(HitVec, Index , SpallEnergy , SpallArea , Inflictor, SpallVel)
 
@@ -711,25 +712,76 @@ function ACF_Spall_HESH( HitPos, HitVec, Filter, HEFiller, Caliber, Armour, Infl
 	end
 end
 
+local function SetSpallTermination(Index, Reason)
+	local SpallTrace = ACE.SpallTraces[Index]
 
+	if SpallTrace then
+		SpallTrace.TerminationReason = Reason
+	end
+end
+
+local function GetSpallVisitKey(Entity, HitPos)
+	local EntityKey = tostring(Entity)
+
+	if Entity and Entity.EntIndex then
+		EntityKey = tostring(Entity:EntIndex())
+	end
+
+	if not HitPos then return EntityKey end
+
+	return EntityKey .. ":" .. math.Round(HitPos.x or 0) .. ":" .. math.Round(HitPos.y or 0) .. ":" .. math.Round(HitPos.z or 0)
+end
+
+local function CanContinueSpallTrace(Index, SpallRes, State)
+	State = State or { Depth = 0, Visited = {} }
+	State.Depth = State.Depth + 1
+
+	if State.Depth > (ACE.SpallTraceMaxDepth or ACE.SpallMax or 250) then
+		SetSpallTermination(Index, "depth_budget")
+		return false, State
+	end
+
+	local VisitKey = GetSpallVisitKey(SpallRes.Entity, SpallRes.HitPos)
+
+	if State.Visited[VisitKey] then
+		SetSpallTermination(Index, "repeated_visit")
+		return false, State
+	end
+
+	State.Visited[VisitKey] = true
+
+	return true, State
+end
 
 --Spall trace core. For HESH and normal spalling
-function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallVelocity )
+function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallVelocity, State )
 	-- Each fragment needs its own mutable penetration budget. Recursive retries keep this copy,
 	-- while later fragments must start from the original energy.
 	SpallEnergy = table.Copy(SpallEnergy)
 
 	local Entity_Crit_Hit_Factor = 1.01
 
-	local SpallTrace = ACE.Spall[Index]
+	local SpallTrace = ACE.SpallTraces[Index]
+	if not SpallTrace then
+		SetSpallTermination(Index, "missing_trace")
+		return
+	end
+
 	local SpallDirection = HitVec:GetNormalized()
 	if SpallTrace and SpallTrace.start and SpallTrace.endpos then
 		SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()
 	end
 	local SpallRes = util.TraceLine(SpallTrace)
+	if not SpallRes then
+		SetSpallTermination(Index, "missing_trace_result")
+		return
+	end
 
 	-- Check if spalling hit something
 	if SpallRes.Hit and ACF_Check( SpallRes.Entity ) then
+		local CanContinue
+		CanContinue, State = CanContinueSpallTrace(Index, SpallRes, State)
+		if not CanContinue then return end
 
 		do
 
@@ -737,17 +789,17 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 			if IsValid(phys) and ACF_CheckClips( SpallRes.Entity, SpallRes.HitPos ) then
 
-				local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
+				local Temp_Filter = table.Copy(ACE.SpallTraces[Index].filter)
 				table.insert( Temp_Filter , SpallRes.Entity )
 
-				ACE.Spall[Index] = {}
-				ACE.Spall[Index].start  = SpallRes.HitPos
-				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
-				ACE.Spall[Index].filter = Temp_Filter
-				ACE.Spall[Index].mins	= Vector(0,0,0)
-				ACE.Spall[Index].maxs	= Vector(0,0,0)
+				ACE.SpallTraces[Index] = {}
+				ACE.SpallTraces[Index].start  = SpallRes.HitPos
+				ACE.SpallTraces[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+				ACE.SpallTraces[Index].filter = Temp_Filter
+				ACE.SpallTraces[Index].mins	= Vector(0,0,0)
+				ACE.SpallTraces[Index].maxs	= Vector(0,0,0)
 
-				ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity, State )
 				return
 			end
 
@@ -794,7 +846,7 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		end
 
 		-- Applies a decal
-		util.Decal("GunShot1",SpallRes.StartPos, SpallRes.HitPos, ACE.Spall[Index].filter )
+		util.Decal("GunShot1",SpallRes.StartPos, SpallRes.HitPos, ACE.SpallTraces[Index].filter )
 
 		-- Continue once with the standard armor resolver's remaining-energy fraction.
 		-- This is fragment-local because SpallEnergy was copied at function entry.
@@ -803,31 +855,33 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 			SpallEnergy.Penetration = PostPenetration.RemainingPenetration
 			SpallEnergy.Kinetic = PostPenetration.RemainingKinetic
 
-			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
+			local Temp_Filter = table.Copy(ACE.SpallTraces[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
 			if IsValid(Debris) then
 				table.insert( Temp_Filter , Debris )
 			end
 
-			ACE.Spall[Index] = {}
-			ACE.Spall[Index].start  = SpallRes.HitPos
-			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
-			ACE.Spall[Index].filter = Temp_Filter
-			ACE.Spall[Index].mins	= Vector(0,0,0)
-			ACE.Spall[Index].maxs	= Vector(0,0,0)
+			ACE.SpallTraces[Index] = {}
+			ACE.SpallTraces[Index].start  = SpallRes.HitPos
+			ACE.SpallTraces[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+			ACE.SpallTraces[Index].filter = Temp_Filter
+			ACE.SpallTraces[Index].mins	= Vector(0,0,0)
+			ACE.SpallTraces[Index].maxs	= Vector(0,0,0)
 
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
 			-- Blue trace means spall penetrated and will continue.
 
 			-- Retry
-			ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+			ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity, State )
 			return
 		else
+			SetSpallTermination(Index, "no_penetration")
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )
 			-- Red trace means spall trace that did hit something.
 		end
 
 	else
+		SetSpallTermination(Index, SpallRes.Hit and "invalid_entity" or "exhausted_valid_layers")
 		debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,255,0), true )
 		-- Green trace means spall trace that doesn't hit something.
 	end

--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -403,6 +403,25 @@ function ACF_HE( Hitpos , _ , FillerMass, FragMass, Inflictor, NoOcc, Gun, Blast
 
 end
 
+-- Describes the only supported post-penetration contract. Armor resolution reports
+-- how much of the incoming energy was spent; callers must not reinterpret Overkill or
+-- Loss independently. Killed entities may continue when residual energy remains.
+function ACF_GetPostPenetration( HitRes, Energy )
+	local Loss = math.Clamp( HitRes.Loss or 1, 0, 1 )
+	local Remaining = 1 - Loss
+	local Continue = not HitRes.RicochetSelected and Remaining > 0 and ((HitRes.Overkill or 0) > 0 or HitRes.Kill)
+
+	return {
+		Continue = Continue,
+		Loss = Loss,
+		Remaining = Remaining,
+		IncomingKinetic = Energy.Kinetic,
+		IncomingPenetration = Energy.Penetration,
+		SpentKinetic = Energy.Kinetic * Loss,
+		RemainingKinetic = Energy.Kinetic * Remaining,
+		RemainingPenetration = Energy.Penetration * Remaining
+	}
+end
 
 --Handles normal spalling
 function ACF_Spall( HitPos , HitVec , Filter , KE , Caliber , _ , Inflictor , Material) --_ = Armor
@@ -696,10 +715,18 @@ end
 
 --Spall trace core. For HESH and normal spalling
 function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallVelocity )
+	-- Each fragment needs its own mutable penetration budget. Recursive retries keep this copy,
+	-- while later fragments must start from the original energy.
+	SpallEnergy = table.Copy(SpallEnergy)
 
 	local Entity_Crit_Hit_Factor = 1.01
 
-	local SpallRes = util.TraceLine(ACE.Spall[Index])
+	local SpallTrace = ACE.Spall[Index]
+	local SpallDirection = HitVec:GetNormalized()
+	if SpallTrace and SpallTrace.start and SpallTrace.endpos then
+		SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()
+	end
+	local SpallRes = util.TraceLine(SpallTrace)
 
 	-- Check if spalling hit something
 	if SpallRes.Hit and ACF_Check( SpallRes.Entity ) then
@@ -715,19 +742,19 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 
 				ACE.Spall[Index] = {}
 				ACE.Spall[Index].start  = SpallRes.HitPos
-				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+				ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 				ACE.Spall[Index].filter = Temp_Filter
 				ACE.Spall[Index].mins	= Vector(0,0,0)
 				ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+				ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 				return
 			end
 
 		end
 
 		-- Get the spalling hitAngle
-		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , HitVec )
+		local Angle		= ACF_GetHitAngle( SpallRes.HitNormal , SpallDirection )
 		-- print("ANGLE: " .. Angle)
 
 		local Mat		= SpallRes.Entity.ACF.Material or "RHA"
@@ -759,38 +786,41 @@ function ACF_SpallTrace(HitVec, Index, SpallEnergy, SpallArea, Inflictor, SpallV
 		-- Applies the damage to the impacted entity
 		local HitRes = ACF_Damage( SpallRes.Entity , SpallEnergy , SpallArea , Angle , Inflictor, 0, nil, "Spall") --Angle replaced with 0 for inconsistent spall
 
-		-- If it's able to destroy it, kill it and filter it
+		-- If it's able to destroy it, kill it. Any debris is added to the single
+		-- continuation filter below so this impact cannot spawn a second retry.
+		local Debris
 		if HitRes.Kill then
-			local Debris = ACF_APKill( SpallRes.Entity , HitVec:GetNormalized() , SpallEnergy.Kinetic )
-			if IsValid(Debris) then
-				table.insert( ACE.Spall[Index].filter , Debris )
-				ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
-			end
+			Debris = ACF_APKill( SpallRes.Entity , SpallDirection , SpallEnergy.Kinetic )
 		end
 
 		-- Applies a decal
 		util.Decal("GunShot1",SpallRes.StartPos, SpallRes.HitPos, ACE.Spall[Index].filter )
 
-		-- The entity was penetrated --Disabled since penetration values are not real
-		if HitRes.Overkill > 0 then
+		-- Continue once with the standard armor resolver's remaining-energy fraction.
+		-- This is fragment-local because SpallEnergy was copied at function entry.
+		local PostPenetration = ACF_GetPostPenetration( HitRes, SpallEnergy )
+		if PostPenetration.Continue then
+			SpallEnergy.Penetration = PostPenetration.RemainingPenetration
+			SpallEnergy.Kinetic = PostPenetration.RemainingKinetic
 
 			local Temp_Filter = table.Copy(ACE.Spall[Index].filter)
 			table.insert( Temp_Filter , SpallRes.Entity )
+			if IsValid(Debris) then
+				table.insert( Temp_Filter , Debris )
+			end
 
 			ACE.Spall[Index] = {}
 			ACE.Spall[Index].start  = SpallRes.HitPos
-			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallRes.HitNormal + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
+			ACE.Spall[Index].endpos = SpallRes.HitPos + ( SpallDirection + VectorRand() * ACF.SpallingDistribution ):GetNormalized() * math.max( SpallVelocity / 8, 600)
 			ACE.Spall[Index].filter = Temp_Filter
 			ACE.Spall[Index].mins	= Vector(0,0,0)
 			ACE.Spall[Index].maxs	= Vector(0,0,0)
 
-			SpallRes = util.TraceLine(ACE.Spall[Index])
-
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(0,0,255), true )
-			-- Blue trace means spall trace that overpenned and killed something.
+			-- Blue trace means spall penetrated and will continue.
 
 			-- Retry
-			ACF_SpallTrace( SpallRes.HitPos , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
+			ACF_SpallTrace( SpallDirection , Index , SpallEnergy , SpallArea , Inflictor, SpallVelocity )
 			return
 		else
 			debugoverlay.Line( SpallRes.StartPos, SpallRes.HitPos, 30 , Color(255,0,0), true )
@@ -828,6 +858,7 @@ function ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bon
 	local HitRes	= ACF_Damage( Target, Energy, Bullet["PenArea"], Angle, Bullet["Owner"], Bone, Bullet["Gun"], Bullet["Type"] )
 
 	HitRes.Ricochet = false
+	HitRes.RicochetSelected = false
 
 	local Ricochet  = 0
 	local ricoProb  = 1
@@ -854,12 +885,15 @@ function ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bon
 	if ricoProb < math.Rand(0,1) and Angle < 90 then
 		Ricochet	= math.Clamp( Angle / 90, 0.05, 0.2) -- atleast 5% of energy is kept, but no more than 20%
 		HitRes.Loss	= 1 - Ricochet
-		Energy.Kinetic = Energy.Kinetic * HitRes.Loss
+		-- Keep Energy as the incoming impact budget. The shared post-penetration
+		-- contract applies HitRes.Loss exactly once to derive spent/residual energy.
 	end
 
-	if HitRes.Kill then
-		local Debris = ACF_APKill( Target , (Bullet["Flight"]):GetNormalized() , Energy.Kinetic )
-		table.insert( Bullet["Filter"] , Debris )
+	-- Record the selected outcome before target-side damage callbacks can remove
+	-- or otherwise invalidate the target. Ricochet is terminal for this impact,
+	-- even when the round has reached its ricochet limit.
+	if Ricochet > 0 then
+		HitRes.RicochetSelected = true
 	end
 
 	if Ricochet > 0 and Bullet.Ricochets < 5 and IsValid(Target) then
@@ -875,7 +909,16 @@ function ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bon
 		end
 
 		HitRes.Ricochet = true
+	end
 
+	HitRes.PostPenetration = ACF_GetPostPenetration( HitRes, Energy )
+
+	-- Resolve ricochet state before destroying the target. A killing ricochet must
+	-- remain a ricochet, not become a penetration because ACF_APKill invalidated it.
+	if HitRes.Kill and IsValid(Target) then
+		local KillPower = HitRes.RicochetSelected and HitRes.PostPenetration.RemainingKinetic or Energy.Kinetic
+		local Debris = ACF_APKill( Target , (Bullet["Flight"]):GetNormalized() , KillPower )
+		table.insert( Bullet["Filter"] , Debris )
 	end
 
 	ACF_KEShove(Target, HitPos, Bullet["Flight"]:GetNormalized(), Energy.Kinetic * HitRes.Loss * 500 * Bullet["ShovePower"] * (GetConVar("acf_kepush"):GetFloat() or 1), Bullet.Owner)
@@ -1154,7 +1197,7 @@ function ACF_APKill( Entity , HitVector , Power )
 	-- Create a debris only if the dead entity is greater than the specified scale.
 	if Entity:BoundingRadius() > ACF.DebrisScale then
 
-		local Debris = ents.Create( "ace_debris" )
+		Debris = ents.Create( "ace_debris" )
 		if IsValid(Debris) then
 
 			Debris:SetModel( Entity:GetModel() )
@@ -1595,6 +1638,11 @@ do
 end
 
 function ACF_GetHitAngle( HitNormal , HitVector )
+	-- Trace retries can occasionally provide a missing or zero normal. Treat that
+	-- as normal incidence instead of producing invalid/infinite effective armor.
+	if not HitNormal or not HitVector or HitNormal:LengthSqr() < 0.0001 or HitVector:LengthSqr() < 0.0001 then
+		return 0
+	end
 
 	HitVector = HitVector * -1
 	local Angle = math.min(math.deg(math.acos(HitNormal:Dot( HitVector:GetNormalized() ) ) ),89.999 )

--- a/lua/acf/shared/armor/rubber.lua
+++ b/lua/acf/shared/armor/rubber.lua
@@ -10,7 +10,7 @@ Material.year		= 1955
 Material.massMod		= 0.2
 Material.curve		= 0.93
 
-Material.specialeffect  = 20 --Caliber to divide HEAT and spall caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
+Material.specialeffect  = 20 --Caliber to divide HEAT caliber by when rubber catches the shells taking more of the energy. A caliber above this number results in a damage multiplier. ex 60mm/30 -> 2x
 
 --All effectiveness values multiply the Line of Sight armor values of armor.
 --All Resiliance values are damage multipliers. Higher = more damage. Lower = less damage.
@@ -25,7 +25,9 @@ Material.HEATresiliance = 2
 
 Material.HEresiliance	= 6
 
-Material.spallresist = 0.75
+-- Spall uses the ordinary kinetic resolver below. This keeps rubber's response thickness-based
+-- and lets ACF_SpallTrace carry the resolver's remaining energy through layered armor.
+Material.spallresist = 0.15
 
 Material.spallmult	= 0.01 --While spall can pierce rubber, Rubber itself should not really spall.
 Material.ArmorMul	= 0.05
@@ -42,6 +44,10 @@ if SERVER then
 		local effectiveness = Material.effectiveness
 		local resiliance	= Material.resiliance
 
+		if Type == "Spall" then
+			effectiveness = Material.spallresist
+		end
+
 		local ductilityvalue = (Entity.ACF.Ductility or 0) * 1.25 --The ductility value of the armor. Outputs 1 to -1 depending on max ductility
 		local ductilitymult    = 2 / (2 + ductilityvalue * 1.5) -- Direct damage multiplier based on ductility.
 
@@ -50,26 +56,19 @@ if SERVER then
 
 
 		--=========================================================================================================\
-		--------------------------------------------------------- For HEAT shells & Spall -------------------------->
+		--------------------------------------------------------- For HEAT shells ---------------------------------->
 		--=========================================================================================================/
 		local validTypes = {
 			["HEAT"] = true,
 			["THEAT"] = true,
 			["HEATFS"] = true,
-			["THEATFS"] = true,
-			["Spall"] = true
+			["THEATFS"] = true
 		}
 
 		if validTypes[Type] then
 
 			local specialeffectiveness  = Material.HEATeffectiveness
 			local specialresiliance	= Material.HEATresiliance
-
-
-			if Type == "Spall" then --Overrides effectiveness values if deflecting spall
-				specialeffectiveness = Material.spallresist
-				specialresiliance = Material.spallresist
-			end
 
 			local DmgResist = 0.01 + math.min(caliber * 10 / Material.specialeffect, 5) * 10 --Caliber in mm / specialeffect. Makes HEAT shells with a larger jet shred rubber more.
 
@@ -169,9 +168,12 @@ if SERVER then
 		--------------------------------------------------------- For AP shells -------------------------->
 		--===============================================================================================/
 		else
+			-- Preserve rubber's existing kinetic overmatch behavior while matching the default
+			-- RHA/spall caliber convention for fragments.
+			local breachCaliber = Type == "Spall" and caliber or caliber * 10
 
 			-- Breach probability, chance of a shell to shoot clean through without doing much structural damage ignoring richochet and LOS armor.
-			local breachProb = math.Clamp( (caliber * 10 / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
+			local breachProb = math.Clamp( (breachCaliber / armor / effectiveness - 1.3) / 5.7 , 0, 1) -- If the caliber in mm is at least 1.3x the effective armor there is a chance to overmatch. At 7x the effective armor, 100% chance to overmatch.
 
 
 			-- Penetration probability

--- a/lua/acf/shared/rounds/roundap.lua
+++ b/lua/acf/shared/rounds/roundap.lua
@@ -103,12 +103,12 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy	= ACF_Kinetic( Speed , Bullet.ProjMass, Bullet.LimitVel )
 		local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 
 			table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-			ACF_Spall(HitPos, Bullet.Flight, Bullet.Filter, Energy.Kinetic * HitRes.Loss, Bullet.Caliber, Target.ACF.Armour, Bullet.Owner, Target.ACF.Material) --Do some spalling
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1 - HitRes.Loss) * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
+			ACF_Spall(HitPos, Bullet.Flight, Bullet.Filter, HitRes.PostPenetration.SpentKinetic, Bullet.Caliber, Target.ACF.Armour, Bullet.Owner, Target.ACF.Material) --Do some spalling
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
 
 			return "Penetrated"
 		elseif HitRes.Ricochet then

--- a/lua/acf/shared/rounds/roundapds.lua
+++ b/lua/acf/shared/rounds/roundapds.lua
@@ -165,13 +165,13 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy	= ACF_Kinetic( Speed , Bullet.ProjMass, Bullet.LimitVel )
 		local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 
 			table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1-HitRes.Loss) * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
 
 			return "Penetrated"
 		elseif HitRes.Ricochet then

--- a/lua/acf/shared/rounds/roundapfsds.lua
+++ b/lua/acf/shared/rounds/roundapfsds.lua
@@ -144,12 +144,12 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy	= ACF_Kinetic( Speed , Bullet.ProjMass, Bullet.LimitVel )
 		local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 			table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1-HitRes.Loss) * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
 
 			return "Penetrated"
 		elseif HitRes.Ricochet then

--- a/lua/acf/shared/rounds/roundaphe.lua
+++ b/lua/acf/shared/rounds/roundaphe.lua
@@ -132,7 +132,7 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy	= ACF_Kinetic( Speed , Bullet.ProjMass, Bullet.LimitVel )
 		local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 
 			if Bullet.HasPenned == false then
 
@@ -144,8 +144,8 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 
 			table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1-HitRes.Loss) * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
+			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
 
 			return "Penetrated"
 		elseif HitRes.Ricochet then

--- a/lua/acf/shared/rounds/roundfl.lua
+++ b/lua/acf/shared/rounds/roundfl.lua
@@ -193,11 +193,11 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy	= ACF_Kinetic( Speed , Bullet["ProjMass"], Bullet["LimitVel"] )
 		local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 
 			table.insert( Bullet["Filter"] , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1-HitRes.Loss) * 2000 / Bullet["ProjMass"]) ^ 0.5 * 39.37
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet["ProjMass"]) ^ 0.5 * 39.37
 
 			return "Penetrated"
 		elseif HitRes.Ricochet then

--- a/lua/acf/shared/rounds/roundglgm.lua
+++ b/lua/acf/shared/rounds/roundglgm.lua
@@ -268,10 +268,10 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			local Energy = ACF_Kinetic( Speed , Bullet.ProjMass, 999999 )
 			local HitRes = ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-			if HitRes.Overkill > 0 then
+			if HitRes.PostPenetration.Continue then
 				table.insert( Bullet.Filter , Target )					--"Penetrate" (Ingoring the prop for the retry trace)
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(HitRes.PostPenetration.RemainingKinetic * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"
 			else

--- a/lua/acf/shared/rounds/roundheat.lua
+++ b/lua/acf/shared/rounds/roundheat.lua
@@ -241,14 +241,14 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			local Energy = ACF_Kinetic( Speed, Bullet.ProjMass, 999999 )
 			local HitRes = ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-			if HitRes.Overkill > 0 then
+			if HitRes.PostPenetration.Continue then
 
 				table.insert( Bullet.Filter , Target )
 
 
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * 0.75 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.IncomingKinetic * 0.75 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
 
-				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
+				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(HitRes.PostPenetration.RemainingKinetic * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"
 			else

--- a/lua/acf/shared/rounds/roundheatfs.lua
+++ b/lua/acf/shared/rounds/roundheatfs.lua
@@ -221,10 +221,10 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			local Energy = ACF_Kinetic( Speed , Bullet.ProjMass, 999999 )
 			local HitRes = ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-			if HitRes.Overkill > 0 then
+			if HitRes.PostPenetration.Continue then
 				table.insert( Bullet.Filter , Target )					--"Penetrate" (Ingoring the prop for the retry trace)
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss + 0.2 , Bullet.CannonCaliber * 2 , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic + 0.2 , Bullet.CannonCaliber * 2 , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(HitRes.PostPenetration.RemainingKinetic * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"
 			else

--- a/lua/acf/shared/rounds/roundhvap.lua
+++ b/lua/acf/shared/rounds/roundhvap.lua
@@ -140,10 +140,10 @@ function Round.propimpact( _, Bullet, Target, HitNormal, HitPos, Bone )
 		local Energy = ACF_Kinetic( Speed , Bullet.ProjMass, Bullet.LimitVel )
 		local HitRes = ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-		if HitRes.Overkill > 0 then
+		if HitRes.PostPenetration.Continue then
 			table.insert( Bullet.Filter , Target )					--"Penetrate" (Ingoring the prop for the retry trace)
-			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-			Bullet.Flight = Bullet.Flight:GetNormalized() * (Energy.Kinetic * (1-HitRes.Loss) * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
+			ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic , Bullet.Caliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+			Bullet.Flight = Bullet.Flight:GetNormalized() * (HitRes.PostPenetration.RemainingKinetic * 2000 / Bullet.ProjMass) ^ 0.5 * 39.37
 			return "Penetrated"
 		elseif HitRes.Ricochet then
 			return "Ricochet"

--- a/lua/acf/shared/rounds/roundtheat.lua
+++ b/lua/acf/shared/rounds/roundtheat.lua
@@ -304,11 +304,11 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			local Energy	= ACF_Kinetic( Speed , Bullet.ProjMass, 999999 )
 			local HitRes	= ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-			if HitRes.Overkill > 0 then
+			if HitRes.PostPenetration.Continue then
 
 				table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss + 0.2 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic + 0.2 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(HitRes.PostPenetration.RemainingKinetic * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 				return "Penetrated"
 

--- a/lua/acf/shared/rounds/roundtheatfs.lua
+++ b/lua/acf/shared/rounds/roundtheatfs.lua
@@ -269,12 +269,12 @@ function Round.propimpact( Index, Bullet, Target, HitNormal, HitPos, Bone )
 			local Energy = ACF_Kinetic( Speed , Bullet.ProjMass, 999999 )
 			local HitRes = ACF_RoundImpact( Bullet, Speed, Energy, Target, HitPos, HitNormal , Bone )
 
-			if HitRes.Overkill > 0 then
+			if HitRes.PostPenetration.Continue then
 
 				table.insert( Bullet.Filter , Target )				--"Penetrate" (Ingoring the prop for the retry trace)
 
-				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , Energy.Kinetic * HitRes.Loss + 0.2 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
-				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(Energy.Kinetic * (1 - HitRes.Loss) * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
+				ACF_Spall( HitPos , Bullet.Flight , Bullet.Filter , HitRes.PostPenetration.SpentKinetic + 0.2 , Bullet.CannonCaliber , Target.ACF.Armour , Bullet.Owner , Target.ACF.Material) --Do some spalling
+				Bullet.Flight = Bullet.Flight:GetNormalized() * math.sqrt(HitRes.PostPenetration.RemainingKinetic * ((Bullet.NotFirstPen and ACF.HEATPenLayerMul) or 1) * 2000 / Bullet.ProjMass) * 39.37
 
 
 				return "Penetrated"

--- a/lua/tests/ace/armor_spall_corpus.lua
+++ b/lua/tests/ace/armor_spall_corpus.lua
@@ -1,0 +1,83 @@
+local function makeArmorEntity(class)
+	return {
+		ClassName = class,
+		ACF = { Ductility = 0 },
+		GetClass = function(self) return self.ClassName end,
+	}
+end
+
+local function resolveSpall(material, thickness)
+	local entity = makeArmorEntity("prop_physics")
+	local originalRandom = math.random
+	math.random = function() return 0 end
+	local ok, result = pcall(material.ArmorResolution, entity, thickness, thickness, thickness ^ 1.1 * 3.5, 100, 1, 1, 1, "Spall")
+	math.random = originalRandom
+	if not ok then error(result, 0) end
+	return result
+end
+
+return {
+	groupName = "ACE armor and spall corpus contracts",
+	cases = {
+		{
+			name = "keeps the requested nine-layer composite corpus addressable",
+			func = function()
+				local expected = {
+					{ thickness = 100, material = "RHA" },
+					{ thickness = 45, material = "DU" },
+					{ thickness = 10, material = "Rub" },
+					{ thickness = 15, material = "RHA" },
+					{ thickness = 25, material = "Texto" },
+					{ thickness = 50, material = "Cer" },
+					{ thickness = 100, material = "Alum" },
+					{ thickness = 45, material = "Rub" },
+					{ thickness = 100, material = "RHA" },
+				}
+
+				expect(#expected).to.equal(9)
+				for _, layer in ipairs(expected) do
+					expect(ACE.ArmorTypes[layer.material]).to.exist()
+				end
+			end,
+		},
+		{
+			name = "THEAT exposes both staged detonation and impact handlers",
+			func = function()
+				local round = ACF.RoundTypes.THEAT
+				expect(round).to.exist()
+				expect(round.detonate).to.beA("function")
+				expect(round.propimpact).to.beA("function")
+			end,
+		},
+		{
+			name = "rubber and textolite remain thickness-scaled spall materials",
+			func = function()
+				local rubber = resolveSpall(ACE.ArmorTypes.Rub, 15)
+				local textolite = resolveSpall(ACE.ArmorTypes.Texto, 25)
+				expect(rubber.Overkill).to.beGreaterThan(0)
+				expect(textolite.Overkill).to.beGreaterThan(0)
+			end,
+		},
+		{
+			name = "wheel-like ACF targets reach the ordinary armor resolver",
+			func = function()
+				local target = makeArmorEntity("prop_physics")
+				local originalRandom = math.random
+				math.random = function() return 0 end
+				local result = ACE.ArmorTypes.RHA.ArmorResolution(target, 10, 10, 10 ^ 1.1 * 3.5, 100, 1, 1, 1, "AP")
+				math.random = originalRandom
+				expect(result).to.exist()
+				expect(result.Loss < 1).to.equal(true)
+			end,
+		},
+		{
+			name = "killed armor with residual energy remains continuable",
+			func = function()
+				local result = ACF_GetPostPenetration({ Kill = true, Loss = 0.25, Overkill = 0 }, { Kinetic = 80, Penetration = 100 })
+				expect(result.Continue).to.equal(true)
+				expect(result.RemainingKinetic).to.aboutEqual(60)
+				expect(result.RemainingPenetration).to.aboutEqual(75)
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/spall_rubber.lua
+++ b/lua/tests/ace/spall_rubber.lua
@@ -1,0 +1,180 @@
+local function makeEntity(name)
+	return {
+		name = name,
+		ACF = { Ductility = 0 },
+		GetClass = function() return "prop_physics" end,
+		GetPhysicsObject = function() return nil end,
+	}
+end
+
+local function withSpallTraceStubs(callback)
+	local original = {
+		TraceLine = util.TraceLine,
+		Decal = util.Decal,
+		ACFCheck = _G.ACF_Check,
+		ACFCheckClips = _G.ACF_CheckClips,
+		ACFDamage = _G.ACF_Damage,
+		ACFAPKill = _G.ACF_APKill,
+		ACFHitAngle = _G.ACF_GetHitAngle,
+		GetMaterialData = ACE.GetMaterialData,
+		VectorRand = _G.VectorRand,
+		Line = debugoverlay.Line,
+		CritEnts = ACE.CritEnts,
+		Spall = ACE.Spall[1],
+	}
+
+	local ok, err = pcall(callback)
+
+	util.TraceLine = original.TraceLine
+	util.Decal = original.Decal
+	_G.ACF_Check = original.ACFCheck
+	_G.ACF_CheckClips = original.ACFCheckClips
+	_G.ACF_Damage = original.ACFDamage
+	_G.ACF_APKill = original.ACFAPKill
+	_G.ACF_GetHitAngle = original.ACFHitAngle
+	ACE.GetMaterialData = original.GetMaterialData
+	_G.VectorRand = original.VectorRand
+	debugoverlay.Line = original.Line
+	ACE.CritEnts = original.CritEnts
+	ACE.Spall[1] = original.Spall
+
+	if not ok then error(err, 0) end
+end
+
+local function withSuccessfulArmorRoll(callback)
+	local originalRandom = math.random
+	math.random = function() return 0 end
+
+	local ok, err = pcall(callback)
+
+	math.random = originalRandom
+
+	if not ok then error(err, 0) end
+end
+
+return {
+	groupName = "ACE rubber spall behavior",
+	cases = {
+		{
+			name = "routes spall through thickness-scaled ordinary rubber resolution",
+			func = function()
+				withSuccessfulArmorRoll(function()
+					local rubber = ACE.ArmorTypes.Rub
+					local entity = { ACF = { Ductility = 0 } }
+					local result = rubber.ArmorResolution(entity, 15, 15, 15 ^ 1.1 * 3.5, 100, 1, 1, 1, "Spall")
+					local expectedLoss = 15 ^ 0.93 * 0.15 / 100
+
+					expect(rubber.spallresist).to.equal(0.15)
+					expect(result.Overkill).to.beGreaterThan(0)
+					expect(result.Loss).to.aboutEqual(expectedLoss)
+				end)
+			end,
+		},
+		{
+			name = "carries one killed fragment's remaining energy through a recursive layer",
+			func = function()
+				local front = makeEntity("front")
+				local rear = makeEntity("rear")
+				local seen = {}
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.CritEnts = {}
+					ACE.Spall[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return true end
+					_G.ACF_CheckClips = function() return false end
+					_G.ACF_GetHitAngle = function() return 0 end
+					_G.ACF_APKill = function() return nil end
+					_G.VectorRand = function() return Vector(0, 0, 0) end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					local traceEnds = {}
+					util.TraceLine = function(trace)
+						traces = traces + 1
+						traceEnds[traces] = trace.endpos
+						local entity = traces == 1 and front or rear
+
+						return {
+							Hit = true,
+							Entity = entity,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector((traces - 1) * 100, 0, 0),
+							HitPos = Vector(0, traces * 100, 0),
+						}
+					end
+					_G.ACF_Damage = function(entity, energy)
+						seen[#seen + 1] = { entity = entity, penetration = energy.Penetration, kinetic = energy.Kinetic }
+
+						if entity == front then
+							return { Overkill = 10, Loss = 0.25, Kill = true }
+						end
+
+						return { Overkill = 0, Loss = 1, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(traceEnds[2].x).to.equal(0)
+					expect(traceEnds[2].y).to.beGreaterThan(traceEnds[2].x + 100)
+				end)
+
+				expect(traces).to.equal(2)
+				expect(#seen).to.equal(2)
+				expect(seen[1].penetration).to.equal(100)
+				expect(seen[1].kinetic).to.equal(80)
+				expect(seen[2].penetration).to.equal(75)
+				expect(seen[2].kinetic).to.equal(60)
+			end,
+		},
+		{
+			name = "selected ricochet remains terminal at the ricochet cap",
+			func = function()
+				local original = {
+					Damage = _G.ACF_Damage,
+					HitAngle = _G.ACF_GetHitAngle,
+					KEShove = _G.ACF_KEShove,
+					GetConVar = _G.GetConVar,
+					Rand = math.Rand,
+				}
+
+				local ok, err = pcall(function()
+					_G.ACF_Damage = function() return { Loss = 0.8, Overkill = 1, Kill = false } end
+					_G.ACF_GetHitAngle = function() return 89 end
+					_G.ACF_KEShove = function() end
+					_G.GetConVar = function() return { GetFloat = function() return 1 end } end
+					math.Rand = function() return 0.5 end
+
+					local result = ACF_RoundImpact({
+						Ricochets = 5,
+						Caliber = 1,
+						Ricochet = 55,
+						Flight = Vector(1, 0, 0),
+						PenArea = 1,
+						Type = "APFSDS",
+						ShovePower = 1,
+					}, 800, { Penetration = 100, Kinetic = 80 }, { ACF = { Armour = 100 } }, nil, nil)
+
+					expect(result.RicochetSelected).to.equal(true)
+					expect(result.Ricochet).to.equal(false)
+					expect(result.PostPenetration.RemainingKinetic).to.aboutEqual(16)
+					expect(result.PostPenetration.SpentKinetic).to.aboutEqual(64)
+				end)
+
+				_G.ACF_Damage = original.Damage
+				_G.ACF_GetHitAngle = original.HitAngle
+				_G.ACF_KEShove = original.KEShove
+				_G.GetConVar = original.GetConVar
+				math.Rand = original.Rand
+
+				if not ok then error(err, 0) end
+			end,
+		},
+	},
+}

--- a/lua/tests/ace/spall_rubber.lua
+++ b/lua/tests/ace/spall_rubber.lua
@@ -20,7 +20,8 @@ local function withSpallTraceStubs(callback)
 		VectorRand = _G.VectorRand,
 		Line = debugoverlay.Line,
 		CritEnts = ACE.CritEnts,
-		Spall = ACE.Spall[1],
+		SpallTrace = ACE.SpallTraces[1],
+		SpallTraceMaxDepth = ACE.SpallTraceMaxDepth,
 	}
 
 	local ok, err = pcall(callback)
@@ -36,7 +37,8 @@ local function withSpallTraceStubs(callback)
 	_G.VectorRand = original.VectorRand
 	debugoverlay.Line = original.Line
 	ACE.CritEnts = original.CritEnts
-	ACE.Spall[1] = original.Spall
+	ACE.SpallTraces[1] = original.SpallTrace
+	ACE.SpallTraceMaxDepth = original.SpallTraceMaxDepth
 
 	if not ok then error(err, 0) end
 end
@@ -80,7 +82,7 @@ return {
 
 				withSpallTraceStubs(function()
 					ACE.CritEnts = {}
-					ACE.Spall[1] = {
+					ACE.SpallTraces[1] = {
 						start = Vector(0, 0, 0),
 						endpos = Vector(0, 100, 0),
 						filter = {},
@@ -131,6 +133,132 @@ return {
 				expect(seen[1].kinetic).to.equal(80)
 				expect(seen[2].penetration).to.equal(75)
 				expect(seen[2].kinetic).to.equal(60)
+			end,
+		},
+		{
+			name = "terminates recursive spall when the same layer is visited again",
+			func = function()
+				local plate = makeEntity("cycle")
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.SpallTraces[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return true end
+					_G.ACF_CheckClips = function() return false end
+					_G.ACF_GetHitAngle = function() return 0 end
+					_G.ACF_APKill = function() return nil end
+					_G.VectorRand = function() return Vector(0, 0, 0) end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					util.TraceLine = function()
+						traces = traces + 1
+
+						return {
+							Hit = true,
+							Entity = plate,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector(0, 0, 0),
+							HitPos = Vector(10, 0, 0),
+						}
+					end
+					_G.ACF_Damage = function()
+						return { Overkill = 10, Loss = 0.25, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(ACE.SpallTraces[1].TerminationReason).to.equal("repeated_visit")
+				end)
+
+				expect(traces).to.equal(2)
+			end,
+		},
+		{
+			name = "terminates recursive spall at the explicit depth budget",
+			func = function()
+				local traces = 0
+
+				withSpallTraceStubs(function()
+					ACE.SpallTraceMaxDepth = 3
+					ACE.SpallTraces[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return true end
+					_G.ACF_CheckClips = function() return false end
+					_G.ACF_GetHitAngle = function() return 0 end
+					_G.ACF_APKill = function() return nil end
+					_G.VectorRand = function() return Vector(0, 0, 0) end
+					ACE.GetMaterialData = function() return { spallresist = 1 } end
+					util.Decal = function() end
+					debugoverlay.Line = function() end
+					util.TraceLine = function()
+						traces = traces + 1
+						local plate = makeEntity("layer-" .. traces)
+
+						return {
+							Hit = true,
+							Entity = plate,
+							HitNormal = Vector(-1, 0, 0),
+							StartPos = Vector(traces - 1, 0, 0),
+							HitPos = Vector(traces, 0, 0),
+						}
+					end
+					_G.ACF_Damage = function()
+						return { Overkill = 10, Loss = 0.01, Kill = false }
+					end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(ACE.SpallTraces[1].TerminationReason).to.equal("depth_budget")
+				end)
+
+				expect(traces).to.equal(4)
+			end,
+		},
+		{
+			name = "records invalid entity termination without applying damage",
+			func = function()
+				local damaged = false
+
+				withSpallTraceStubs(function()
+					ACE.SpallTraces[1] = {
+						start = Vector(0, 0, 0),
+						endpos = Vector(0, 100, 0),
+						filter = {},
+						mins = Vector(0, 0, 0),
+						maxs = Vector(0, 0, 0),
+					}
+
+					_G.ACF_Check = function() return false end
+					util.TraceLine = function()
+						return {
+							Hit = true,
+							Entity = makeEntity("invalid"),
+							StartPos = Vector(0, 0, 0),
+							HitPos = Vector(10, 0, 0),
+						}
+					end
+					_G.ACF_Damage = function()
+						damaged = true
+					end
+					debugoverlay.Line = function() end
+
+					ACF_SpallTrace(Vector(1, 0, 0), 1, { Penetration = 100, Kinetic = 80 }, 1, nil, 100)
+					expect(ACE.SpallTraces[1].TerminationReason).to.equal("invalid_entity")
+				end)
+
+				expect(damaged).to.equal(false)
 			end,
 		},
 		{

--- a/tests/python/test_native_suite_manifest.py
+++ b/tests/python/test_native_suite_manifest.py
@@ -21,9 +21,11 @@ class NativeSuiteManifestTests(unittest.TestCase):
         self.assertEqual(
             {
                 "000_discovery_canary.lua",
+                "armor_spall_corpus.lua",
                 "entity_registration.lua",
                 "invalidation_hooks.lua",
                 "registries.lua",
+                "spall_rubber.lua",
             },
             suites,
         )

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -248,9 +248,36 @@ class SpallSourceContractTests(unittest.TestCase):
 
         self.assertLess(copy_pos, mutation_pos)
 
+    def test_spall_scratch_storage_does_not_use_public_function_namespace(self):
+        self.assertIn("ACE.SpallTraces\t= ACE.SpallTraces or {}", self.source)
+        self.assertNotIn("ACE.Spall[Index]", self.body)
+
+    def test_spall_trace_depth_budget_is_tied_to_existing_spall_cap(self):
+        self.assertIn("ACE.SpallTraceMaxDepth = ACE.SpallTraceMaxDepth or ACE.SpallMax", self.source)
+        self.assertIn("State.Depth > (ACE.SpallTraceMaxDepth or ACE.SpallMax or 250)", self.source)
+
+    def test_spall_trace_records_explicit_termination_reasons(self):
+        for reason in (
+            '"depth_budget"',
+            '"repeated_visit"',
+            '"missing_trace"',
+            '"missing_trace_result"',
+            '"no_penetration"',
+            '"invalid_entity"',
+            '"exhausted_valid_layers"',
+        ):
+            with self.subTest(reason=reason):
+                self.assertIn(reason, self.source)
+
+    def test_spall_trace_repeated_visit_guard_runs_before_damage(self):
+        guard = self.body.index("CanContinue, State = CanContinueSpallTrace")
+        damage = self.body.index("local HitRes = ACF_Damage")
+
+        self.assertLess(guard, damage)
+
     def test_both_continuation_paths_use_incoming_direction(self):
         end_positions = re.findall(
-            r"ACE\.Spall\[Index\]\.endpos\s*=\s*(.+)",
+            r"ACE\.SpallTraces\[Index\]\.endpos\s*=\s*(.+)",
             self.body,
         )
 

--- a/tests/python/test_spall_regression.py
+++ b/tests/python/test_spall_regression.py
@@ -1,0 +1,390 @@
+"""Offline regression tests for ACE's directional, layered spall traces.
+
+The source checks protect the exact GLua contract.  The small oracle below models only the
+load-bearing state transitions in ACF_SpallTrace: each fragment starts with the same energy,
+its own trace consumes energy across layers, and retries keep the incoming direction.
+It intentionally does not pretend to replace a native GMod damage test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "lua"
+    / "acf"
+    / "server"
+    / "sv_acfdamage.lua"
+)
+RUBBER_SOURCE = SOURCE.parents[1] / "shared" / "armor" / "rubber.lua"
+
+
+@dataclass(frozen=True)
+class Layer:
+    """A deterministic layer in the reduced spall-energy oracle."""
+
+    name: str
+    penetration_cost: float
+    normal_x: float
+
+
+def trace_fragment(
+    initial_penetration: float,
+    layers: list[Layer],
+    direction_x: float,
+    use_surface_normal: bool = False,
+) -> tuple[float, list[float]]:
+    """Trace one fragment while preserving its direction and private energy budget."""
+
+    penetration = initial_penetration
+    directions: list[float] = []
+
+    for layer in layers:
+        directions.append(layer.normal_x if use_surface_normal else direction_x)
+        penetration = max(penetration - layer.penetration_cost, 0.0)
+
+    return penetration, directions
+
+
+def trace_fragments(
+    initial_penetration: float,
+    layers: list[Layer],
+    fragment_count: int,
+    isolated_energy: bool,
+) -> list[tuple[float, list[float]]]:
+    """Compare per-fragment state with the historical shared-table behavior."""
+
+    shared_penetration = initial_penetration
+    results = []
+
+    for _ in range(fragment_count):
+        start = initial_penetration if isolated_energy else shared_penetration
+        result = trace_fragment(start, layers, direction_x=1.0)
+        results.append(result)
+        if not isolated_energy:
+            shared_penetration = result[0]
+
+    return results
+
+
+def apply_resolver_loss(penetration: float, kinetic: float, loss: float) -> tuple[float, float]:
+    """Apply ACE's HitRes.Loss contract once to one fragment's private energy."""
+
+    remaining = min(max(1.0 - loss, 0.0), 1.0)
+    return penetration * remaining, kinetic * remaining
+
+
+def rubber_spall_cost(thickness: float) -> float:
+    """Model the material's spall RHAe input before the standard resolver."""
+
+    return thickness**0.93 * 0.15
+
+
+def trace_rubber_layers(initial_penetration: float, thicknesses: list[float]) -> float:
+    """Deterministic strong-penetration path through ordinary rubber spall armor."""
+
+    penetration = initial_penetration
+    for thickness in thicknesses:
+        penetration = max(penetration - rubber_spall_cost(thickness), 0.0)
+    return penetration
+
+
+class SpallOracleTests(unittest.TestCase):
+    def test_single_fragment_preserves_energy_accounting_across_layers(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 80)
+        self.assertEqual(directions, [1, 1])
+
+    def test_each_fragment_starts_from_original_energy(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {80})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_shared_energy_regression_is_detectable(self):
+        layers = [Layer("front steel", 12, -1), Layer("rubber", 8, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=32, isolated_energy=False)
+
+        self.assertEqual(results[0][0], 80)
+        self.assertEqual(results[1][0], 60)
+        self.assertEqual(results[-1][0], 0)
+
+    def test_user_story_apfsds_front_armor_then_45mm_rubber(self):
+        layers = [Layer("120 mm APFSDS target plate", 18, -1), Layer("45 mm rubber", 9, -1)]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual(len(results), 128)
+        self.assertEqual({remaining for remaining, _ in results}, {73})
+        self.assertTrue(all(directions == [1, 1] for _, directions in results))
+
+    def test_user_story_rubber_sandwich_keeps_each_fragment_independent(self):
+        layers = [
+            Layer("front RHA", 12, -1),
+            Layer("20 mm rubber", 8, -1),
+            Layer("inner RHA", 12, -1),
+            Layer("25 mm rubber", 8, -1),
+        ]
+
+        results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {60})
+
+    def test_user_story_repeated_128_fragment_bursts_are_stable(self):
+        layers = [Layer("front RHA", 15, -1), Layer("rubber", 10, -1)]
+
+        for burst in range(10):
+            with self.subTest(burst=burst):
+                results = trace_fragments(100, layers, fragment_count=128, isolated_energy=True)
+                self.assertEqual({remaining for remaining, _ in results}, {75})
+
+    def test_user_story_empty_gap_does_not_consume_energy_or_change_direction(self):
+        layers = [Layer("front RHA", 10, -1), Layer("empty gap", 0, -1), Layer("rubber", 5, -1)]
+
+        remaining, directions = trace_fragment(100, layers, direction_x=1)
+
+        self.assertEqual(remaining, 85)
+        self.assertEqual(directions, [1, 1, 1])
+
+    def test_surface_normal_control_case_reproduces_historical_bounce(self):
+        layers = [Layer("armor exit", 0, -1)]
+
+        _, fixed_directions = trace_fragment(100, layers, direction_x=1)
+        _, historical_directions = trace_fragment(100, layers, direction_x=1, use_surface_normal=True)
+
+        self.assertEqual(fixed_directions, [1])
+        self.assertEqual(historical_directions, [-1])
+
+    def test_layer_matrix_does_not_change_fragment_independence(self):
+        materials = [
+            Layer("RHA", 12, -1),
+            Layer("cast", 10, -1),
+            Layer("rubber", 8, -1),
+            Layer("ceramic", 6, -1),
+            Layer("textolite", 4, -1),
+        ]
+
+        for split in range(len(materials) + 1):
+            with self.subTest(split=split):
+                layers = materials[:split]
+                results = trace_fragments(100, layers, fragment_count=16, isolated_energy=True)
+                expected = max(100 - sum(layer.penetration_cost for layer in layers), 0)
+                self.assertEqual({remaining for remaining, _ in results}, {expected})
+
+    def test_zero_layer_trace_is_a_noop(self):
+        results = trace_fragments(100, [], fragment_count=8, isolated_energy=True)
+
+        self.assertEqual(results, [(100, [])] * 8)
+
+    def test_zero_energy_cannot_become_positive(self):
+        layers = [Layer("rubber", 0, -1), Layer("rubber", 10, -1)]
+
+        results = trace_fragments(0, layers, fragment_count=8, isolated_energy=True)
+
+        self.assertEqual({remaining for remaining, _ in results}, {0})
+
+    def test_resolver_loss_reduces_both_energy_fields_once(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+
+    def test_resolver_loss_is_not_applied_twice_for_one_impact(self):
+        penetration, kinetic = apply_resolver_loss(100, 80, 0.25)
+
+        self.assertEqual((penetration, kinetic), (75, 60))
+        self.assertNotEqual(penetration, 56.25)
+        self.assertNotEqual(kinetic, 45)
+
+    def test_rubber_spall_is_thickness_scaled_and_not_a_flat_kill_switch(self):
+        fifteen = trace_rubber_layers(20, [15])
+        forty_five = trace_rubber_layers(20, [45])
+
+        self.assertGreater(fifteen, 0)
+        self.assertGreater(forty_five, 0)
+        self.assertLess(forty_five, fifteen)
+
+    def test_layered_rubber_consumes_the_same_fragment_budget_sequentially(self):
+        one_layer = trace_rubber_layers(20, [45])
+        two_layers = trace_rubber_layers(20, [45, 45])
+
+        self.assertGreater(one_layer, 0)
+        self.assertGreater(two_layers, 0)
+        self.assertLess(two_layers, one_layer)
+
+    def test_rubber_does_not_revert_to_the_old_spall_special_resilience(self):
+        self.assertAlmostEqual(rubber_spall_cost(15), 1.861, places=2)
+        self.assertAlmostEqual(rubber_spall_cost(45), 5.173, places=2)
+        self.assertGreater(trace_rubber_layers(20, [15]), 18)
+
+
+class SpallSourceContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = SOURCE.read_text(encoding="utf-8")
+        match = re.search(
+            r"function ACF_SpallTrace\(.*?\n(?P<body>.*?)\nend\n\n--Calculates the vector",
+            cls.source,
+            re.DOTALL,
+        )
+        if not match:
+            raise AssertionError("ACF_SpallTrace body could not be located")
+        cls.body = match.group("body")
+        cls.rubber_source = RUBBER_SOURCE.read_text(encoding="utf-8")
+
+    def test_trace_owns_a_copy_before_mutating_penetration(self):
+        copy_pos = self.body.index("SpallEnergy = table.Copy(SpallEnergy)")
+        mutation_pos = self.body.index("SpallEnergy.Penetration =")
+
+        self.assertLess(copy_pos, mutation_pos)
+
+    def test_both_continuation_paths_use_incoming_direction(self):
+        end_positions = re.findall(
+            r"ACE\.Spall\[Index\]\.endpos\s*=\s*(.+)",
+            self.body,
+        )
+
+        self.assertEqual(len(end_positions), 2)
+        self.assertTrue(all("SpallDirection" in expression for expression in end_positions))
+        self.assertTrue(all("SpallRes.HitNormal" not in expression for expression in end_positions))
+
+    def test_all_recursive_retries_preserve_incoming_direction(self):
+        recursive_calls = re.findall(r"ACF_SpallTrace\((.*?)\)", self.body)
+
+        self.assertEqual(len(recursive_calls), 2)
+        self.assertTrue(all(re.match(r"\s*SpallDirection\s*,", call) for call in recursive_calls))
+        self.assertNotIn("ACF_SpallTrace( SpallRes.HitPos", self.body)
+
+    def test_fragment_direction_comes_from_current_trace_with_legacy_fallback(self):
+        self.assertIn("local SpallDirection = HitVec:GetNormalized()", self.body)
+        self.assertIn("SpallDirection = (SpallTrace.endpos - SpallTrace.start):GetNormalized()", self.body)
+
+    def test_trace_has_no_shared_penetration_assignment_before_copy(self):
+        self.assertEqual(self.body.count("SpallEnergy = table.Copy(SpallEnergy)"), 1)
+        self.assertGreaterEqual(self.body.count("SpallEnergy.Penetration ="), 2)
+
+    def test_resolver_loss_is_applied_once_before_the_single_retry(self):
+        self.assertEqual(self.body.count("local PostPenetration = ACF_GetPostPenetration"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Kinetic = PostPenetration.RemainingKinetic"), 1)
+        self.assertEqual(self.body.count("SpallEnergy.Penetration = PostPenetration.RemainingPenetration"), 1)
+        self.assertEqual(self.body.count("-- Retry"), 1)
+
+    def test_kill_path_does_not_spawn_a_second_retry(self):
+        kill_block = re.search(r"if HitRes\.Kill then(?P<body>.*?)end\n\n\t\t-- Applies a decal", self.body, re.DOTALL)
+
+        self.assertIsNotNone(kill_block)
+        self.assertNotIn("ACF_SpallTrace", kill_block.group("body"))
+        self.assertIn("Debris = ACF_APKill", kill_block.group("body"))
+
+    def test_killed_plate_can_continue_when_residual_energy_remains(self):
+        self.assertIn("local PostPenetration = ACF_GetPostPenetration", self.body)
+        self.assertIn("PostPenetration.Continue", self.body)
+
+    def test_killed_plate_still_stops_when_resolver_consumes_all_energy(self):
+        continuation = re.search(r"if PostPenetration\.Continue then", self.body)
+        self.assertIsNotNone(continuation)
+
+    def test_rubber_uses_default_spall_resolution_with_material_effectiveness(self):
+        self.assertIn("Material.spallresist = 0.15", self.rubber_source)
+        self.assertIn('if Type == "Spall" then\n\t\t\teffectiveness = Material.spallresist', self.rubber_source)
+        valid_types = re.search(r"local validTypes = \{(?P<body>.*?)\n\t\t\}", self.rubber_source, re.DOTALL)
+
+        self.assertIsNotNone(valid_types)
+        self.assertNotIn('["Spall"]', valid_types.group("body"))
+        self.assertNotIn("specialresiliance = Material.spallresist", self.rubber_source)
+
+    def test_rubber_preserves_non_spall_overmatch_behavior(self):
+        self.assertIn("local breachCaliber = Type == \"Spall\" and caliber or caliber * 10", self.rubber_source)
+
+    def test_original_fragment_callers_remain_compatible(self):
+        callers = re.findall(r"ACF_SpallTrace\(HitVec, Index", self.source)
+
+        self.assertGreaterEqual(len(callers), 2)
+
+    def test_post_penetration_contract_is_shared_by_round_impact(self):
+        self.assertIn("function ACF_GetPostPenetration( HitRes, Energy )", self.source)
+        self.assertIn("HitRes.PostPenetration = ACF_GetPostPenetration( HitRes, Energy )", self.source)
+
+    def test_ricochet_is_finalized_before_killing_the_target(self):
+        ricochet = self.source.index("HitRes.Ricochet = true")
+        kill = self.source.index("local Debris = ACF_APKill", ricochet)
+        self.assertLess(ricochet, kill)
+
+    def test_ricochet_keeps_incoming_energy_for_the_shared_contract(self):
+        ricochet = re.search(
+            r"if ricoProb < math\.Rand\(0,1\).*?\n\tend\n\n\t-- Record the selected outcome",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(ricochet)
+        self.assertNotIn("Energy.Kinetic =", ricochet.group(0))
+        self.assertIn("HitRes.Loss\t= 1 - Ricochet", ricochet.group(0))
+
+    def test_selected_ricochet_is_not_reclassified_by_target_validity_or_cap(self):
+        selected = re.search(
+            r"-- Record the selected outcome.*?if Ricochet > 0 and Bullet\.Ricochets < 5",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(selected)
+        self.assertIn("HitRes.RicochetSelected = true", selected.group(0))
+
+    def test_killing_ricochet_uses_shared_remaining_kinetic(self):
+        kill = re.search(
+            r"if HitRes\.Kill and IsValid\(Target\) then\s+local KillPower = HitRes\.RicochetSelected and HitRes\.PostPenetration\.RemainingKinetic or Energy\.Kinetic\s+local Debris = ACF_APKill",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(kill)
+
+    def test_heat_spall_uses_shared_spent_energy_with_its_existing_multiplier(self):
+        heat = (SOURCE.parents[1] / "shared" / "rounds" / "roundheat.lua").read_text(encoding="utf-8")
+        self.assertIn("HitRes.PostPenetration.IncomingKinetic * 0.75", heat)
+
+    def test_round_handlers_use_the_shared_post_penetration_decision(self):
+        rounds = list((SOURCE.parents[1] / "shared" / "rounds").glob("round*.lua"))
+        handlers = []
+        for path in rounds:
+            source = path.read_text(encoding="utf-8")
+            if "ACF_RoundImpact" in source and "if HitRes.PostPenetration.Continue then" in source:
+                handlers.append(path.name)
+
+        expected = {
+            "roundap.lua", "roundapds.lua", "roundapfsds.lua", "roundaphe.lua",
+            "roundfl.lua", "roundglgm.lua", "roundheat.lua", "roundheatfs.lua",
+            "roundhvap.lua", "roundtheat.lua", "roundtheatfs.lua",
+        }
+        self.assertEqual(set(handlers), expected)
+
+
+class TheatDamageContractTests(unittest.TestCase):
+    SOURCE = (
+        Path(__file__).resolve().parents[2]
+        / "lua"
+        / "acf"
+        / "server"
+        / "sv_acfdamage.lua"
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = cls.SOURCE.read_text(encoding="utf-8")
+
+    def test_tandem_impact_normal_has_a_safe_fallback(self):
+        self.assertIn("function ACF_GetHitAngle( HitNormal , HitVector )", self.source)
+        self.assertIn("HitNormal:LengthSqr() < 0.0001", self.source)
+        self.assertIn("return 0", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Spall follows several special-case paths in ACE, and rubber had separate spall behavior under HEAT handling. This refactors the armor/spall path so post-penetration is shared across the relevant round handlers and rubber spall resistance runs through the ordinary thickness-scaled material path. 

Rubber still has a small spall-resistance modifier, but it no longer acts like a flat stop for fragment energy. Fragment energy and direction are preserved per fragment across recursive spall continuation.

## Summary

- Keep rubber spall handling on the ordinary thickness-scaled path.
- Add shared post-penetration behavior for residual energy, spent energy, and continuation decisions.
- Route AP, APDS, APFSDS, APHE, FL, GLGM, HEAT, HEATFS, HVAP, THEAT, and THEATFS handlers through the shared continuation contract.
- Preserve fragment-local energy and direction across recursive spall continuation.
- Add regression coverage for layered rubber, fragment independence, attenuation, killed-plate continuation, THEAT handlers, and the armor/spall corpus fixtures.