### PR TITLE
Add ACE general-use test contracts

### DIFF
--- a/.github/workflows/glualint.yml
+++ b/.github/workflows/glualint.yml
@@ -41,6 +41,21 @@ jobs:
       - name: Run Python tests
         run: python -m unittest discover -s tests/python -p 'test_*.py' -v
 
+      - name: Emit static safety warnings
+        run: python tests/run_static_safety.py --report static_safety_report.json
+
+      - name: Validate headless scenario contracts
+        run: python tests/run_headless_scenarios.py --manifest tests/fixtures/general_use_manifest.json --ci --dry-run
+
+      - name: Validate performance scenario contracts
+        run: python tests/run_perf_scenarios.py --manifest tests/fixtures/general_use_manifest.json --ci-smoke
+
+      - name: Upload static safety report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: static-safety-report
+          path: static_safety_report.json
+
       - name: Install LuaJIT
         run: sudo apt-get update && sudo apt-get install --yes luajit
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+static_safety_report.json

--- a/lua/tests/ace/general_use_contracts.lua
+++ b/lua/tests/ace/general_use_contracts.lua
@@ -1,6 +1,6 @@
-local function assertRegistryEntries(registry, names)
+local function assertRegistryEntries(expectValue, registry, names)
 	for _, name in ipairs(names) do
-		expect(registry[name]).to.exist()
+		expectValue(registry[name]).to.exist()
 	end
 end
 
@@ -10,7 +10,7 @@ return {
 		{
 			name = "covers player-facing round families",
 			func = function()
-				assertRegistryEntries(ACF.RoundTypes, {
+				assertRegistryEntries(expect, ACF.RoundTypes, {
 					"AP", "APFSDS", "HE", "HEAT", "HESH", "THEAT",
 				})
 
@@ -28,7 +28,7 @@ return {
 		{
 			name = "covers armor materials used by layered vehicle builds",
 			func = function()
-				assertRegistryEntries(ACE.ArmorTypes, {
+				assertRegistryEntries(expect, ACE.ArmorTypes, {
 					"RHA", "DU", "Rub", "Texto", "Cer", "Alum",
 				})
 

--- a/lua/tests/ace/general_use_contracts.lua
+++ b/lua/tests/ace/general_use_contracts.lua
@@ -1,0 +1,74 @@
+local function assertRegistryEntries(registry, names)
+	for _, name in ipairs(names) do
+		expect(registry[name]).to.exist()
+	end
+end
+
+return {
+	groupName = "ACE general-use contract coverage",
+	cases = {
+		{
+			name = "covers player-facing round families",
+			func = function()
+				assertRegistryEntries(ACF.RoundTypes, {
+					"AP", "APFSDS", "HE", "HEAT", "HESH", "THEAT",
+				})
+
+				for _, roundType in ipairs({ "AP", "APFSDS", "HE", "HEAT", "HESH", "THEAT" }) do
+					local round = ACF.RoundTypes[roundType]
+					expect(round.name).to.exist()
+					expect(round.desc).to.exist()
+					if round.netid then
+						expect(round.create).to.beA("function")
+						expect(ACF.IdRounds[round.netid]).to.equal(roundType)
+					end
+				end
+			end,
+		},
+		{
+			name = "covers armor materials used by layered vehicle builds",
+			func = function()
+				assertRegistryEntries(ACE.ArmorTypes, {
+					"RHA", "DU", "Rub", "Texto", "Cer", "Alum",
+				})
+
+				for _, materialId in ipairs({ "RHA", "DU", "Rub", "Texto", "Cer", "Alum" }) do
+					local material = ACE.ArmorTypes[materialId]
+					expect(material.name).to.exist()
+					expect(material.massMod).to.beA("number")
+					expect(material.ArmorResolution).to.beA("function")
+				end
+			end,
+		},
+		{
+			name = "covers propulsion fuel crew weapons racks sensors and missiles",
+			func = function()
+				for _, registryName in ipairs({
+					"Engines", "FuelTanks", "Crewseats", "Guns", "Racks", "Radars",
+				}) do
+					expect(ACF.Weapons[registryName]).to.exist()
+
+					local count = 0
+					for _ in pairs(ACF.Weapons[registryName]) do
+						count = count + 1
+					end
+
+					expect(count).to.beGreaterThan(0)
+				end
+			end,
+		},
+		{
+			name = "keeps scripted entity families registered for lifecycle scenarios",
+			func = function()
+				for _, className in ipairs({
+					"acf_gun", "acf_ammo", "acf_rack", "acf_engine", "acf_fueltank",
+					"ace_crewseat_driver", "ace_searchradar", "ace_missile",
+				}) do
+					local stored = scripted_ents.GetStored(className)
+					expect(stored).to.exist()
+					expect(stored.t).to.exist()
+				end
+			end,
+		},
+	},
+}

--- a/tests/fixtures/general_use_manifest.json
+++ b/tests/fixtures/general_use_manifest.json
@@ -1,0 +1,159 @@
+{
+  "schema": 1,
+  "artifact_root": "data/ace_test_artifacts",
+  "scenarios": [
+    {
+      "id": "entity_spawn_activate_link_remove",
+      "family": "registered_entities",
+      "realm": "native",
+      "timeout_seconds": 20,
+      "ci": true,
+      "artifacts": ["entities.json"],
+      "expected_events": ["spawn", "activate", "link", "remove"]
+    },
+    {
+      "id": "round_behavior_matrix",
+      "family": "rounds",
+      "realm": "native+luajit",
+      "timeout_seconds": 20,
+      "ci": true,
+      "artifacts": ["rounds.json"],
+      "expected_events": ["create", "impact", "terminate"]
+    },
+    {
+      "id": "material_armor_matrix",
+      "family": "materials_armor",
+      "realm": "native",
+      "timeout_seconds": 15,
+      "ci": true,
+      "artifacts": ["materials.json"],
+      "expected_events": ["classify", "resolve"]
+    },
+    {
+      "id": "tank_duel_ap",
+      "family": "tank_duel",
+      "realm": "headless",
+      "timeout_seconds": 30,
+      "ci": false,
+      "artifacts": ["tank_duel_ap.json", "errors.txt"],
+      "expected_events": ["fire", "impact", "damage", "terminate"]
+    },
+    {
+      "id": "tank_duel_heat",
+      "family": "tank_duel",
+      "realm": "headless",
+      "timeout_seconds": 30,
+      "ci": false,
+      "artifacts": ["tank_duel_heat.json", "errors.txt"],
+      "expected_events": ["fire", "impact", "jet", "terminate"]
+    },
+    {
+      "id": "spall_trace_layered_clipped_adversarial",
+      "family": "spall_layered",
+      "realm": "native",
+      "timeout_seconds": 20,
+      "ci": true,
+      "artifacts": ["spall_depth.json"],
+      "expected_events": ["trace", "continuation", "termination_reason"]
+    },
+    {
+      "id": "heat_jet_continuity",
+      "family": "heat",
+      "realm": "headless",
+      "timeout_seconds": 20,
+      "ci": false,
+      "artifacts": ["heat.json", "errors.txt"],
+      "expected_events": ["impact", "jet", "termination_reason"]
+    },
+    {
+      "id": "spall_propagation_matrix",
+      "family": "spall_layered",
+      "realm": "native",
+      "timeout_seconds": 20,
+      "ci": true,
+      "artifacts": ["spall.json"],
+      "expected_events": ["trace", "damage", "termination_reason"]
+    },
+    {
+      "id": "engine_fuel_crew_matrix",
+      "family": "propulsion_fuel_crew",
+      "realm": "native",
+      "timeout_seconds": 20,
+      "ci": true,
+      "artifacts": ["propulsion.json"],
+      "expected_events": ["initialize", "update", "cleanup"]
+    },
+    {
+      "id": "gun_ammo_rack_reload_cookoff_repair",
+      "family": "weapon_lifecycle",
+      "realm": "headless",
+      "timeout_seconds": 45,
+      "ci": false,
+      "artifacts": ["weapon_lifecycle.json", "errors.txt"],
+      "expected_events": ["link", "reload", "cookoff", "repair"]
+    },
+    {
+      "id": "contraption_spawn_split_merge_remove",
+      "family": "contraption_lifecycle",
+      "realm": "headless",
+      "timeout_seconds": 45,
+      "ci": false,
+      "artifacts": ["lifecycle.json", "errors.txt"],
+      "expected_events": ["spawn", "split", "merge", "remove"]
+    },
+    {
+      "id": "sensor_missile_guidance_smoke",
+      "family": "sensors_missiles",
+      "realm": "native",
+      "timeout_seconds": 25,
+      "ci": true,
+      "artifacts": ["sensors_missiles.json"],
+      "expected_events": ["sensor_scan", "missile_launch", "guidance", "cleanup"]
+    },
+    {
+      "id": "advdupe_minimal_roundtrip",
+      "family": "dupes",
+      "realm": "headless",
+      "timeout_seconds": 45,
+      "ci": false,
+      "artifacts": ["dupe.json", "errors.txt"],
+      "expected_events": ["paste", "link_restore", "cleanup"]
+    },
+    {
+      "id": "network_serialization_contracts",
+      "family": "network_serialization",
+      "realm": "python+luajit",
+      "timeout_seconds": 10,
+      "ci": true,
+      "artifacts": ["network_serialization.json"],
+      "expected_events": ["schema", "roundtrip"]
+    },
+    {
+      "id": "readout_contract_matrix",
+      "family": "readouts",
+      "realm": "luajit+native",
+      "timeout_seconds": 15,
+      "ci": true,
+      "artifacts": ["readouts.json"],
+      "expected_events": ["state", "readout"]
+    },
+    {
+      "id": "unexpected_error_capture",
+      "family": "runtime_errors",
+      "realm": "headless",
+      "timeout_seconds": 10,
+      "ci": true,
+      "artifacts": ["errors.txt"],
+      "expected_events": ["boot", "done"]
+    },
+    {
+      "id": "representative_fire_rate_smoke",
+      "family": "performance",
+      "realm": "headless",
+      "timeout_seconds": 60,
+      "ci": false,
+      "artifacts": ["perf.json"],
+      "expected_events": ["start", "sample", "done"]
+    }
+  ]
+}

--- a/tests/fixtures/static_allowlist.json
+++ b/tests/fixtures/static_allowlist.json
@@ -1,0 +1,12 @@
+{
+  "schema": 1,
+  "rules": {
+    "ACE_POSSIBLY_UNBOUNDED_LOOP": [],
+    "ACE_RECURSION": [],
+    "ACE_TIMER_CALLBACK_SUBSTITUTE": [],
+    "ACE_TIMER_TEARDOWN": [],
+    "ACE_TIMER_ENTITY_CAPTURE": [],
+    "ACE_TIMER_SELF_RESCHEDULE": [],
+    "ACE_TIMER_NAME_COLLISION": []
+  }
+}

--- a/tests/python/ace_static/__init__.py
+++ b/tests/python/ace_static/__init__.py
@@ -1,0 +1,1 @@
+"""Static warning helpers for ACE test quality checks."""

--- a/tests/python/ace_static/annotations.py
+++ b/tests/python/ace_static/annotations.py
@@ -1,0 +1,29 @@
+"""GitHub annotation formatting for ACE static warning reports."""
+
+from __future__ import annotations
+
+from ace_static.scanner import Finding
+
+
+def github_annotation(finding: Finding, level: str = "warning") -> str:
+    message = finding.message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    path = finding.path.replace("\\", "/")
+
+    return f"::{level} file={path},line={finding.line},title={finding.rule_id}::{message}"
+
+
+def findings_to_report(findings: list[Finding]) -> dict:
+    return {
+        "schema": 1,
+        "findings": [
+            {
+                "rule_id": finding.rule_id,
+                "path": finding.path,
+                "line": finding.line,
+                "message": finding.message,
+                "symbol": finding.symbol,
+                "severity": "warning",
+            }
+            for finding in findings
+        ],
+    }

--- a/tests/python/ace_static/scanner.py
+++ b/tests/python/ace_static/scanner.py
@@ -1,0 +1,188 @@
+"""Heuristic ACE static-safety scanner.
+
+The scanner intentionally emits warnings for broad patterns. It is not a Lua parser and should not
+be used to block existing gameplay code until a rule has been source-proven and explicitly promoted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+from lua_source import code_without_comments_and_strings
+
+
+RULE_IDS = {
+    "ACE_POSSIBLY_UNBOUNDED_LOOP",
+    "ACE_RECURSION",
+    "ACE_TIMER_CALLBACK_SUBSTITUTE",
+    "ACE_TIMER_TEARDOWN",
+    "ACE_TIMER_ENTITY_CAPTURE",
+    "ACE_TIMER_SELF_RESCHEDULE",
+    "ACE_TIMER_NAME_COLLISION",
+}
+
+LUA_ROOTS = ("lua",)
+ENTITY_CAPTURE = re.compile(r"\b(self|ent|entity|Entity|Bullet|Contraption|Player|ply)\b")
+FUNCTION_DEF = re.compile(
+    r"\b(?:local\s+function|function)\s+([A-Za-z_][A-Za-z0-9_:.]*)\s*\("
+)
+TIMER_CALL = re.compile(r"\btimer\s*\.\s*(Simple|Create)\s*\(")
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    path: str
+    line: int
+    message: str
+    symbol: str | None = None
+
+
+def iter_lua_files(repo: Path):
+    for root in LUA_ROOTS:
+        lua_root = repo / root
+        if not lua_root.exists():
+            continue
+        yield from lua_root.rglob("*.lua")
+
+
+def line_for_offset(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def scan_repo(repo: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in iter_lua_files(repo):
+        findings.extend(scan_file(repo, path))
+    return findings
+
+
+def scan_file(repo: Path, path: Path) -> list[Finding]:
+    source = path.read_text(encoding="utf-8", errors="replace")
+    code = code_without_comments_and_strings(source)
+    relative = path.relative_to(repo).as_posix()
+
+    findings: list[Finding] = []
+    findings.extend(scan_unbounded_loops(relative, code))
+    findings.extend(scan_recursion(relative, code))
+    findings.extend(scan_timers(relative, code, source))
+    return findings
+
+
+def scan_unbounded_loops(path: str, code: str) -> list[Finding]:
+    findings: list[Finding] = []
+
+    for match in re.finditer(r"\bwhile\s+true\s+do\b", code):
+        findings.append(
+            Finding(
+                "ACE_POSSIBLY_UNBOUNDED_LOOP",
+                path,
+                line_for_offset(code, match.start()),
+                "while true loop needs a visible cap, break condition, or allowlist reason",
+            )
+        )
+
+    for match in re.finditer(r"\brepeat\b(?:(?!\buntil\b).)*\buntil\s+false\b", code, re.DOTALL):
+        findings.append(
+            Finding(
+                "ACE_POSSIBLY_UNBOUNDED_LOOP",
+                path,
+                line_for_offset(code, match.start()),
+                "repeat/until false loop needs a visible cap, break condition, or allowlist reason",
+            )
+        )
+
+    return findings
+
+
+def scan_recursion(path: str, code: str) -> list[Finding]:
+    findings: list[Finding] = []
+    definitions = list(FUNCTION_DEF.finditer(code))
+
+    for index, match in enumerate(definitions):
+        symbol = match.group(1)
+        name = symbol.split(":")[-1].split(".")[-1]
+        body_start = match.end()
+        body_end = definitions[index + 1].start() if index + 1 < len(definitions) else len(code)
+        body = code[body_start:body_end]
+
+        if re.search(rf"\b{re.escape(symbol)}\s*\(", body) or re.search(rf"\b{re.escape(name)}\s*\(", body):
+            findings.append(
+                Finding(
+                    "ACE_RECURSION",
+                    path,
+                    line_for_offset(code, match.start()),
+                    f"recursive function {symbol} needs a finite runtime termination contract",
+                    symbol=symbol,
+                )
+            )
+
+    return findings
+
+
+def scan_timers(path: str, code: str, source: str) -> list[Finding]:
+    findings: list[Finding] = []
+    timer_names: dict[str, int] = {}
+
+    for match in TIMER_CALL.finditer(code):
+        kind = match.group(1)
+        line = line_for_offset(code, match.start())
+        window = code[match.start() : match.start() + 500]
+        source_window = source[match.start() : match.start() + 500]
+
+        findings.append(
+            Finding(
+                "ACE_TIMER_CALLBACK_SUBSTITUTE",
+                path,
+                line,
+                f"timer.{kind} should be audited against lifecycle/event callbacks",
+            )
+        )
+
+        name_match = re.search(r"\(\s*([\"'])(.*?)\1", source_window)
+        if kind == "Create" and name_match:
+            timer_name = name_match.group(2)
+            if timer_name in timer_names:
+                findings.append(
+                    Finding(
+                        "ACE_TIMER_NAME_COLLISION",
+                        path,
+                        line,
+                        f"static timer name {timer_name!r} appears multiple times in this file",
+                    )
+                )
+            timer_names[timer_name] = line
+
+            if not re.search(rf"\btimer\s*\.\s*Remove\s*\(\s*[\"']{re.escape(timer_name)}[\"']", code):
+                findings.append(
+                    Finding(
+                        "ACE_TIMER_TEARDOWN",
+                        path,
+                        line,
+                        f"timer {timer_name!r} has no obvious timer.Remove teardown in the same file",
+                    )
+                )
+
+        if "function" in window and ENTITY_CAPTURE.search(window) and "IsValid" not in window:
+            findings.append(
+                Finding(
+                    "ACE_TIMER_ENTITY_CAPTURE",
+                    path,
+                    line,
+                    "timer callback appears to capture entity-like state without an IsValid check in the callback window",
+                )
+            )
+
+        if kind == "Simple" and "timer.Simple" in window[window.find("function") + 1 :]:
+            findings.append(
+                Finding(
+                    "ACE_TIMER_SELF_RESCHEDULE",
+                    path,
+                    line,
+                    "timer callback appears to reschedule timer.Simple work",
+                )
+            )
+
+    return findings

--- a/tests/python/test_general_suite_manifest.py
+++ b/tests/python/test_general_suite_manifest.py
@@ -1,0 +1,64 @@
+"""Contract tests for the ACE general-use scenario manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST = REPO / "tests" / "fixtures" / "general_use_manifest.json"
+
+REQUIRED_FAMILIES = {
+    "registered_entities",
+    "rounds",
+    "materials_armor",
+    "tank_duel",
+    "spall_layered",
+    "heat",
+    "propulsion_fuel_crew",
+    "weapon_lifecycle",
+    "contraption_lifecycle",
+    "sensors_missiles",
+    "dupes",
+    "network_serialization",
+    "readouts",
+    "runtime_errors",
+    "performance",
+}
+
+
+class GeneralUseManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.scenarios = cls.manifest["scenarios"]
+
+    def test_every_intended_use_category_has_owner(self):
+        families = {scenario["family"] for scenario in self.scenarios}
+
+        self.assertEqual(REQUIRED_FAMILIES, families)
+
+    def test_scenarios_have_bounded_runtime_and_artifacts(self):
+        ids = set()
+        for scenario in self.scenarios:
+            with self.subTest(scenario=scenario["id"]):
+                self.assertNotIn(scenario["id"], ids)
+                ids.add(scenario["id"])
+                self.assertIsInstance(scenario["timeout_seconds"], int)
+                self.assertGreater(scenario["timeout_seconds"], 0)
+                self.assertLessEqual(scenario["timeout_seconds"], 60)
+                self.assertTrue(scenario["artifacts"])
+                self.assertTrue(scenario["expected_events"])
+                self.assertIn(scenario["realm"], {"python+luajit", "native", "native+luajit", "luajit+native", "headless"})
+
+    def test_headless_cases_are_not_silently_enabled_in_ci(self):
+        headless = [scenario for scenario in self.scenarios if scenario["realm"] == "headless"]
+
+        self.assertGreater(len(headless), 0)
+        self.assertTrue(all(not scenario["ci"] or scenario["id"] == "unexpected_error_capture" for scenario in headless))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_native_suite_manifest.py
+++ b/tests/python/test_native_suite_manifest.py
@@ -22,6 +22,7 @@ class NativeSuiteManifestTests(unittest.TestCase):
             {
                 "000_discovery_canary.lua",
                 "entity_registration.lua",
+                "general_use_contracts.lua",
                 "invalidation_hooks.lua",
                 "registries.lua",
             },

--- a/tests/python/test_runtime_artifact_schema.py
+++ b/tests/python/test_runtime_artifact_schema.py
@@ -1,0 +1,76 @@
+"""Artifact schema checks for headless/native ACE scenario runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+REQUIRED_ARTIFACT_KEYS = {
+    "schema",
+    "run_id",
+    "scenario_id",
+    "ace_commit",
+    "branch",
+    "started_at",
+    "finished_at",
+    "events",
+    "errors",
+}
+
+
+def validate_artifact(artifact: dict):
+    missing = REQUIRED_ARTIFACT_KEYS - set(artifact)
+    if missing:
+        raise AssertionError(f"missing artifact keys: {sorted(missing)}")
+    if artifact["schema"] != 1:
+        raise AssertionError("unsupported artifact schema")
+    if not isinstance(artifact["events"], list):
+        raise AssertionError("events must be a list")
+    if not isinstance(artifact["errors"], list):
+        raise AssertionError("errors must be a list")
+
+
+class RuntimeArtifactSchemaTests(unittest.TestCase):
+    def test_valid_artifact_shape(self):
+        artifact = {
+            "schema": 1,
+            "run_id": "local-0001",
+            "scenario_id": "tank_duel_ap",
+            "ace_commit": "unknown",
+            "branch": "agent/ace-general-use-suite",
+            "started_at": "2026-07-20T00:00:00Z",
+            "finished_at": "2026-07-20T00:00:01Z",
+            "events": [{"type": "boot"}],
+            "errors": [],
+        }
+
+        validate_artifact(artifact)
+
+    def test_missing_done_artifact_is_a_failure_condition(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expected = root / "done.json"
+
+            self.assertFalse(expected.exists())
+
+    def test_artifact_json_roundtrip(self):
+        artifact = {
+            "schema": 1,
+            "run_id": "local-0001",
+            "scenario_id": "unexpected_error_capture",
+            "ace_commit": "unknown",
+            "branch": "agent/ace-general-use-suite",
+            "started_at": "2026-07-20T00:00:00Z",
+            "finished_at": "2026-07-20T00:00:01Z",
+            "events": [{"type": "boot"}, {"type": "done"}],
+            "errors": [],
+        }
+
+        self.assertEqual(artifact, json.loads(json.dumps(artifact)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_static_safety_contracts.py
+++ b/tests/python/test_static_safety_contracts.py
@@ -1,0 +1,82 @@
+"""Warning-only static safety checks for broad ACE control-flow risks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from ace_static.annotations import findings_to_report, github_annotation
+from ace_static.scanner import RULE_IDS, scan_file, scan_repo
+
+
+REPO = Path(__file__).resolve().parents[2]
+ALLOWLIST = REPO / "tests" / "fixtures" / "static_allowlist.json"
+
+
+class StaticSafetyContractTests(unittest.TestCase):
+    def test_allowlist_declares_every_rule(self):
+        allowlist = json.loads(ALLOWLIST.read_text(encoding="utf-8"))
+
+        self.assertEqual(allowlist["schema"], 1)
+        self.assertEqual(RULE_IDS, set(allowlist["rules"]))
+
+    def test_scanner_emits_expected_warning_families_on_synthetic_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            lua = repo / "lua" / "acf" / "server"
+            lua.mkdir(parents=True)
+            source = lua / "synthetic.lua"
+            source.write_text(
+                """
+                function ACF_SpallTrace()
+                    ACF_SpallTrace()
+                end
+
+                while true do
+                    break
+                end
+
+                timer.Create("ACEStaticName", 1, 0, function()
+                    self:DoWork()
+                end)
+
+                timer.Simple(1, function()
+                    timer.Simple(1, function() end)
+                end)
+                """,
+                encoding="utf-8",
+            )
+
+            findings = scan_file(repo, source)
+            rules = {finding.rule_id for finding in findings}
+
+        self.assertIn("ACE_RECURSION", rules)
+        self.assertIn("ACE_POSSIBLY_UNBOUNDED_LOOP", rules)
+        self.assertIn("ACE_TIMER_CALLBACK_SUBSTITUTE", rules)
+        self.assertIn("ACE_TIMER_TEARDOWN", rules)
+        self.assertIn("ACE_TIMER_ENTITY_CAPTURE", rules)
+        self.assertIn("ACE_TIMER_SELF_RESCHEDULE", rules)
+
+    def test_repository_scan_is_warning_only_and_reportable(self):
+        findings = scan_repo(REPO)
+        report = findings_to_report(findings)
+
+        self.assertEqual(report["schema"], 1)
+        self.assertTrue(all(item["severity"] == "warning" for item in report["findings"]))
+        self.assertTrue(all(item["rule_id"] in RULE_IDS for item in report["findings"]))
+
+    def test_annotations_are_valid_github_warning_lines(self):
+        findings = scan_repo(REPO)
+        if not findings:
+            self.skipTest("Current source has no heuristic static-safety findings")
+
+        annotation = github_annotation(findings[0])
+
+        self.assertTrue(annotation.startswith("::warning file="))
+        self.assertIn(f"title={findings[0].rule_id}", annotation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run_headless_scenarios.py
+++ b/tests/run_headless_scenarios.py
@@ -1,0 +1,110 @@
+"""Headless ACE scenario runner scaffold.
+
+This runner is deliberately fail-closed: without an explicit srcds command it validates the manifest
+and reports which scenarios are selected, but it does not pretend to execute gameplay. CI can use the
+dry-run path for contract coverage while local/headless automation supplies the server command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(REPO), *args], text=True).strip()
+
+
+def load_manifest(path: Path) -> dict:
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    if manifest.get("schema") != 1:
+        raise SystemExit("Unsupported scenario manifest schema")
+    if not manifest.get("scenarios"):
+        raise SystemExit("Scenario manifest has no scenarios")
+    return manifest
+
+
+def selected_scenarios(manifest: dict, ci: bool) -> list[dict]:
+    scenarios = [
+        scenario
+        for scenario in manifest["scenarios"]
+        if scenario["realm"] == "headless" and (scenario.get("ci", False) or not ci)
+    ]
+    if not scenarios:
+        raise SystemExit("No headless scenarios selected")
+    return scenarios
+
+
+def write_resolved_manifest(run_dir: Path, scenarios: list[dict]) -> None:
+    payload = {
+        "schema": 1,
+        "repo": str(REPO),
+        "branch": git_output("branch", "--show-current"),
+        "ace_commit": git_output("rev-parse", "HEAD"),
+        "started_at": int(time.time()),
+        "scenarios": scenarios,
+    }
+    (run_dir / "manifest_resolved.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def run_server(command: list[str], run_dir: Path, timeout: int) -> int:
+    boot = run_dir / "boot.txt"
+    done = run_dir / "done.txt"
+    log = run_dir / "console.log"
+
+    with log.open("w", encoding="utf-8", errors="replace") as handle:
+        process = subprocess.Popen(command, stdout=handle, stderr=subprocess.STDOUT, cwd=REPO)
+        try:
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                if done.exists():
+                    return process.wait(timeout=5)
+                if process.poll() is not None:
+                    break
+                time.sleep(0.25)
+            raise TimeoutError("headless scenario runner timed out before done sentinel")
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=10)
+
+    if not boot.exists():
+        raise SystemExit("Headless run did not write boot sentinel")
+    if not done.exists():
+        raise SystemExit("Headless run did not write done sentinel")
+    return process.returncode or 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="tests/fixtures/general_use_manifest.json")
+    parser.add_argument("--ci", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--srcds-command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    manifest = load_manifest(REPO / args.manifest)
+    scenarios = selected_scenarios(manifest, args.ci)
+
+    with tempfile.TemporaryDirectory(prefix="ace-headless-") as tmp:
+        run_dir = Path(tmp)
+        write_resolved_manifest(run_dir, scenarios)
+
+        if args.dry_run or not args.srcds_command:
+            print(f"Selected {len(scenarios)} headless scenario(s); dry-run only")
+            return 0
+
+        timeout = max(scenario["timeout_seconds"] for scenario in scenarios) + 30
+        return run_server(args.srcds_command, run_dir, timeout)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/run_perf_scenarios.py
+++ b/tests/run_perf_scenarios.py
@@ -1,0 +1,41 @@
+"""Performance scenario contract runner for ACE.
+
+The initial gate is intentionally conservative. It verifies that performance scenarios are declared
+with bounded runtimes and artifact names. Hard timing thresholds should be added only after stable
+baseline data exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default="tests/fixtures/general_use_manifest.json")
+    parser.add_argument("--ci-smoke", action="store_true")
+    args = parser.parse_args()
+
+    manifest = json.loads((REPO / args.manifest).read_text(encoding="utf-8"))
+    scenarios = [scenario for scenario in manifest["scenarios"] if scenario["family"] == "performance"]
+
+    if not scenarios:
+        raise SystemExit("No performance scenarios declared")
+
+    for scenario in scenarios:
+        if scenario["timeout_seconds"] > 60:
+            raise SystemExit(f"{scenario['id']} timeout exceeds the initial smoke budget")
+        if "perf.json" not in scenario["artifacts"]:
+            raise SystemExit(f"{scenario['id']} does not declare a perf artifact")
+
+    print(f"Validated {len(scenarios)} performance scenario contract(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/run_static_safety.py
+++ b/tests/run_static_safety.py
@@ -1,0 +1,40 @@
+"""Emit ACE static-safety warnings and a JSON report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+TESTS = Path(__file__).resolve().parent
+PYTHON = TESTS / "python"
+import sys
+
+sys.path.insert(0, str(PYTHON))
+
+from ace_static.annotations import findings_to_report, github_annotation  # noqa: E402
+from ace_static.scanner import scan_repo  # noqa: E402
+
+
+REPO = TESTS.parent
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", default="static_safety_report.json")
+    args = parser.parse_args()
+
+    findings = scan_repo(REPO)
+    report = findings_to_report(findings)
+    (REPO / args.report).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    for finding in findings:
+        print(github_annotation(finding))
+
+    print(f"ACE static-safety warnings: {len(findings)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Description

This PR adds more test contracts. It keeps the scope to new tests to catch general regressions or registration issues so we don't waste the time of testers.

The suite is meant to catch the easy tester-visible failures across registered entities, round families, materials, armor/spall paths, contraption lifecycle, sensors/missiles, serialization/readouts, runtime errors, and representative performance smoke cases. 

The ideal fix for this is testers getting in-game and being unable to do their job, and to make sure servers never straight up break over an update.

## Summary

- Add a manifest for general-use ACE scenarios with explicit realms, timeouts, artifacts, and CI/local eligibility.
- Add warning-only static safety checks for unbounded loops, recursion, and timer usage, with GitHub annotations and a JSON report.
- Add dry-run headless and performance scenario runners that fail closed on missing contracts.
- Add native GLuaTest contract coverage for common round, material, entity, propulsion, weapon, sensor, and missile registries.
- Wire the new contract checks into the offline CI workflow.
