### PR TITLE
Fix particle emitter exhaustion in ACE effects

### DIFF
--- a/lua/effects/acf_bulleteffect/init.lua
+++ b/lua/effects/acf_bulleteffect/init.lua
@@ -3,6 +3,7 @@
 function ACE.RemoveBulletClient( Bullet, Index )
 
 	if Bullet then
+		if IsValid(Bullet.Tracer) then Bullet.Tracer:Finish() end
 
 		local BulletEnt = Bullet.Effect
 		if IsValid(BulletEnt) then
@@ -118,8 +119,6 @@ do
 				BulletData.TracerColour   = BulletData.Crate:GetNWVector( "TracerColour", BulletData.Crate:GetColor() ) or Vector(255,255,255)
 			end
 
-
-			BulletData.ShellParticles         = ParticleEmitter( BulletData.SimPos )
 
 			--Add all that data to the bullet table, overwriting if needed
 			ACF.BulletEffect[self.Index] = BulletData

--- a/lua/effects/acf_heat_explosion/init.lua
+++ b/lua/effects/acf_heat_explosion/init.lua
@@ -7,7 +7,6 @@ function EFFECT:Init( data )
 	self.Origin = data:GetOrigin()
 	self.DirVec = data:GetNormal()
 	self.Radius = math.max(data:GetRadius() / 39.4,1)
-	self.Emitter = ParticleEmitter( self.Origin )
 	self.ParticleMul = 1
 
 	--[[

--- a/lua/effects/acf_muzzleflash/init.lua
+++ b/lua/effects/acf_muzzleflash/init.lua
@@ -78,6 +78,8 @@ function EFFECT:Init( data )
 			ACF_RenderLight(Gun:EntIndex(), Caliber * 75, Color(255, 128, 48), Muzzle.Pos + self.DirVec * (Caliber / 5))
 		end
 
+		if IsValid(self.Emitter) then self.Emitter:Finish() end
+
 		local LocPly = LocalPlayer()
 		if IsValid(LocPly) then
 			local PlayerDist = (LocPly:GetPos() - self.Origin):Length() / 80 + 0.001 --Divide by 0 is death


### PR DESCRIPTION
## Summary

Small bugfix. Closes client-side particle-emitter leaks in ACE effects that would cause ACE to start throwing errors after a while.

## Changes

- Finish muzzleflash emitters after their synchronous particle work.
- Finish tracers when bullets are removed for leaving map bounds.
- Remove unused shell-particle and HEAT emitter allocations.