### PR TITLE
Fix Primitive armor tool NaN readout

### DIFF
--- a/lua/autorun/server/sv_ace_primitive_compat.lua
+++ b/lua/autorun/server/sv_ace_primitive_compat.lua
@@ -1,11 +1,18 @@
 -- Reconcile Primitive armor from its lifecycle callbacks, not delayed timers.
 local collisionGroups = setmetatable({}, { __mode = "k" })
 
+local function IsFiniteNumber(value)
+	return isnumber(value) and value == value and value > -math.huge and value < math.huge
+end
+
 local function CopyArmorValues(acf)
 	if not istable(acf) then return end
-	if not isnumber(acf.Area) or acf.Area <= 0 then return end
-	if not isnumber(acf.MaxArmour) or acf.MaxArmour <= 0 then return end
-	if not isnumber(acf.MaxHealth) or acf.MaxHealth <= 0 then return end
+	if not IsFiniteNumber(acf.Area) or acf.Area <= 0 then return end
+	if not IsFiniteNumber(acf.Armour) or acf.Armour <= 0 then return end
+	if not IsFiniteNumber(acf.MaxArmour) or acf.MaxArmour <= 0 then return end
+	if not IsFiniteNumber(acf.Health) or acf.Health < 0 then return end
+	if not IsFiniteNumber(acf.MaxHealth) or acf.MaxHealth <= 0 then return end
+	if not IsFiniteNumber(acf.Ductility or 0) then return end
 
 	return {
 		Area = acf.Area,
@@ -25,7 +32,7 @@ local function CaptureSavedArmor(ent)
 end
 
 local function RestoreSavedArmor(ent, phys)
-	local saved = ent.ACE_PrimitiveSavedArmor
+	local saved = CopyArmorValues(ent.ACE_PrimitiveSavedArmor)
 	if not saved or not istable(ent.ACF) then return false end
 
 	local acf = ent.ACF
@@ -79,6 +86,21 @@ local function MarkPrimitiveArmorDirty(ent, reason)
 	if ACE.MarkArmorDirty then ACE.MarkArmorDirty(con, ent, reason) end
 end
 
+local function ClearInvalidLiveArmorValues(acf)
+	acf.Area = nil
+	acf.PhysObj = nil
+
+	if not IsFiniteNumber(acf.Ductility or 0) then
+		acf.Ductility = nil
+	end
+
+	if not IsFiniteNumber(acf.Health) or acf.Health < 0
+		or not IsFiniteNumber(acf.MaxHealth) or acf.MaxHealth <= 0 then
+		acf.Health = nil
+		acf.MaxHealth = nil
+	end
+end
+
 local function ApplyPrimitiveArmor(ent, phys)
 	CapturePendingPrimitiveArmor(ent)
 	local collisionGroup = collisionGroups[ent]
@@ -89,8 +111,7 @@ local function ApplyPrimitiveArmor(ent, phys)
 	if RestoreSavedArmor(ent, phys) then return true end
 
 	if ent.ACF then
-		ent.ACF.Area = nil
-		ent.ACF.PhysObj = nil
+		ClearInvalidLiveArmorValues(ent.ACF)
 	end
 
 	return false

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -434,7 +434,9 @@ function TOOL:Think()
 		self.Weapon:SetNWFloat( "PointCost", 0 )
 		self.Weapon:SetNWFloat( "PointCostNonArmor", 0 )
 		self.Weapon:SetNWString( "PointCostBreakdown", "" )
-		self.AimEntityArmorReady = false
+		-- Only Primitive is known to transition from a temporary failed ACF check to a valid
+		-- armor state without the player changing target. Cache all other failed targets normally.
+		self.AimEntityArmorReady = not ent.IsPrimitive
 	end
 
 	self.AimEntity = ent
@@ -864,7 +866,6 @@ if CLIENT then
 
 	end
 end
-
 
 
 

--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -396,7 +396,9 @@ function TOOL:Think()
 	local trace = util.TraceHull(tr)
 
 	local ent = trace.Entity
-	if ent == self.AimEntity then return end
+	-- Primitive can expose a transient non-ACF state while it rebuilds. Do not cache that failed
+	-- observation forever: the client preview divides its zero area by zero and displays "nan".
+	if ent == self.AimEntity and self.AimEntityArmorReady then return end
 
 	if ACF_Check( ent ) then
 
@@ -417,6 +419,7 @@ function TOOL:Think()
 		self.Weapon:SetNWFloat( "PointCost", AcePts )
 		self.Weapon:SetNWFloat( "PointCostNonArmor", componentCost or 0 )
 		self.Weapon:SetNWString( "PointCostBreakdown", pointBreakdown or "" )
+		self.AimEntityArmorReady = true
 
 	else
 
@@ -431,6 +434,7 @@ function TOOL:Think()
 		self.Weapon:SetNWFloat( "PointCost", 0 )
 		self.Weapon:SetNWFloat( "PointCostNonArmor", 0 )
 		self.Weapon:SetNWString( "PointCostBreakdown", "" )
+		self.AimEntityArmorReady = false
 	end
 
 	self.AimEntity = ent
@@ -860,7 +864,6 @@ if CLIENT then
 
 	end
 end
-
 
 
 

--- a/tests/python/test_armor_tool_primitive_retry.py
+++ b/tests/python/test_armor_tool_primitive_retry.py
@@ -36,7 +36,7 @@ class ArmorToolPrimitiveRetryTests(unittest.TestCase):
             source,
         )
         self.assertIn("self.AimEntityArmorReady = true", source)
-        self.assertIn("self.AimEntityArmorReady = false", source)
+        self.assertIn("self.AimEntityArmorReady = not ent.IsPrimitive", source)
         self.assertIn('displays "nan"', source)
 
 

--- a/tests/python/test_armor_tool_primitive_retry.py
+++ b/tests/python/test_armor_tool_primitive_retry.py
@@ -1,0 +1,44 @@
+"""Regression contract for Primitive's transient armor-tool hover state."""
+
+from pathlib import Path
+import math
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "lua"
+    / "weapons"
+    / "gmod_tool"
+    / "stools"
+    / "acfarmorprop.lua"
+)
+
+
+def preview_armor(area: float, ductility: float, thickness: float) -> float:
+    """Mirror GLua's IEEE zero-area edge in the preview's armor calculation."""
+
+    mass = area * math.sqrt(1 + ductility) * thickness * 0.00078
+    if area == 0 and mass == 0:
+        return math.nan  # GLua/LuaJIT's 0 / 0 result
+    return mass * 1000 / area / 0.78 / math.sqrt(1 + ductility)
+
+
+class ArmorToolPrimitiveRetryTests(unittest.TestCase):
+    def test_zero_area_preview_is_not_a_valid_cached_state(self):
+        self.assertTrue(math.isnan(preview_armor(0.0, 0.0, 10.0)))
+
+    def test_transient_failed_hover_retries_until_acf_is_ready(self):
+        source = SOURCE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "if ent == self.AimEntity and self.AimEntityArmorReady then return end",
+            source,
+        )
+        self.assertIn("self.AimEntityArmorReady = true", source)
+        self.assertIn("self.AimEntityArmorReady = false", source)
+        self.assertIn('displays "nan"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_primitive_armor_regression.py
+++ b/tests/python/test_primitive_armor_regression.py
@@ -1,0 +1,79 @@
+"""Regression coverage for Primitive's persisted ACE armor snapshots."""
+
+from pathlib import Path
+import math
+import re
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "lua"
+    / "autorun"
+    / "server"
+    / "sv_ace_primitive_compat.lua"
+)
+
+
+def is_finite_armor_snapshot(snapshot: dict[str, float]) -> bool:
+    """Mirror the snapshot invariant: every persisted armor number is finite."""
+
+    positive = ("Area", "Armour", "MaxArmour", "MaxHealth")
+    non_negative = ("Health",)
+
+    return all(math.isfinite(snapshot[field]) and snapshot[field] > 0 for field in positive) and all(
+        math.isfinite(snapshot[field]) and snapshot[field] >= 0 for field in non_negative
+    ) and math.isfinite(snapshot.get("Ductility", 0))
+
+
+class PrimitiveArmorSnapshotTests(unittest.TestCase):
+    def test_nan_snapshot_is_rejected(self):
+        snapshot = {
+            "Area": 100,
+            "Armour": math.nan,
+            "MaxArmour": 10,
+            "Health": 100,
+            "MaxHealth": 100,
+            "Ductility": 0,
+        }
+
+        self.assertFalse(is_finite_armor_snapshot(snapshot))
+
+    def test_finite_damaged_snapshot_is_preserved(self):
+        snapshot = {
+            "Area": 100,
+            "Armour": 5,
+            "MaxArmour": 10,
+            "Health": 0,
+            "MaxHealth": 100,
+            "Ductility": -0.2,
+        }
+
+        self.assertTrue(is_finite_armor_snapshot(snapshot))
+
+    def test_runtime_snapshot_and_restore_check_the_same_gate(self):
+        source = SOURCE.read_text(encoding="utf-8")
+
+        self.assertIn("value == value", source)
+        self.assertIn("value > -math.huge and value < math.huge", source)
+        self.assertIn("if not IsFiniteNumber(acf.Armour) or acf.Armour <= 0 then return end", source)
+
+        restore = re.search(
+            r"local function RestoreSavedArmor\(ent, phys\)(?P<body>.*?)\nend",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(restore)
+        self.assertIn("local saved = CopyArmorValues(ent.ACE_PrimitiveSavedArmor)", restore.group("body"))
+
+    def test_fallback_drops_other_non_finite_inputs_before_recalculation(self):
+        source = SOURCE.read_text(encoding="utf-8")
+
+        self.assertIn("local function ClearInvalidLiveArmorValues(acf)", source)
+        self.assertIn("acf.Ductility = nil", source)
+        self.assertIn("acf.Health = nil", source)
+        self.assertIn("ClearInvalidLiveArmorValues(ent.ACF)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Small bugfix for primitives displaying nan on current upstream dev. It's been around forever but was finally visible due to new optimizations and consistency improvements actually.

Code written by codex, and reviewed/tested myself.

## Summary

- Reject non-finite/incomplete Primitive ACF snapshots before restoring them.
- Refresh armor-tool hover data after a transient Primitive rebuild failure, while retaining the original cache behavior for non-Primitive failures.
- Add focused regression coverage for snapshot validation and the hover retry.