### PR TITLE
Cylindrical ammo model

### DIFF
--- a/lua/acf/client/cl_acfmenu_gui.lua
+++ b/lua/acf/client/cl_acfmenu_gui.lua
@@ -901,7 +901,9 @@ do
 			local Y = math.Round(acfmenupanel.AmmoPanelConfig["Crate_Width"], 1 )
 			local Z = math.Round(acfmenupanel.AmmoPanelConfig["Crate_Height"], 1)
 
+			local Shape = acfmenupanel.AmmoPanelConfig["Crate_Shape"] or "Box"
 			local Id = X .. ":" .. Y .. ":" .. Z
+			if Shape ~= "Box" then Id = Id .. ":" .. Shape end
 
 			acfmenupanel.AmmoData["Id"] = Id
 			RunConsoleCommand( "acfmenu_id", Id )
@@ -937,6 +939,7 @@ do
 		acfmenupanel.AmmoPanelConfig["Crate_Length"]  = 10
 		acfmenupanel.AmmoPanelConfig["Crate_Width"]	= 10
 		acfmenupanel.AmmoPanelConfig["Crate_Height"]  = 10
+		acfmenupanel.AmmoPanelConfig["Crate_Shape"]   = "Box"
 
 	end
 
@@ -1030,6 +1033,24 @@ do
 			CreateIdForCrate( MainPanel )
 		end
 		CrateNewPanel:AddItem(HeightSlider)
+
+		acfmenupanel:CPanelText("Crate_shape_desc", "\nCrate shape. Non-box shapes hold fewer rounds, matching the volume they fill.", nil, CrateNewPanel)
+
+		-- Keep this list in sync with the CrateShapes table in acf_ammo/init.lua.
+		local ShapeChoices = { "Box", "Cylinder" }
+
+		local ShapeCombo = vgui.Create( "DComboBox" )
+		ShapeCombo:SetSortItems( false )
+		for _, ShapeName in ipairs( ShapeChoices ) do
+			ShapeCombo:AddChoice( ShapeName )
+		end
+		ShapeCombo:SetValue( acfmenupanel.AmmoPanelConfig["Crate_Shape"] or "Box" )
+
+		function ShapeCombo:OnSelect( _, value )
+			acfmenupanel.AmmoPanelConfig["Crate_Shape"] = value
+			CreateIdForCrate( MainPanel )
+		end
+		CrateNewPanel:AddItem(ShapeCombo)
 
 	end
 

--- a/lua/acf/client/cl_acfmenu_gui.lua
+++ b/lua/acf/client/cl_acfmenu_gui.lua
@@ -1240,8 +1240,15 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 	acfmenupanel["CData"][Name].OnValueChanged = function( _, val )
 
 	--Programmatic SetMin/SetMax/SetValue (below) fire DNumSlider:ValueChanged, which calls
-	--this handler; skip re-entry during those so UpdateAttribs can't recurse into a stack overflow.
-	if acfmenupanel["CData"][Name].ACEProgrammatic then return end
+	--this handler. Record the value so AmmoData tracks what the slider shows, but don't call
+	--UpdateAttribs from here or it recurses into a client stack overflow.
+	--Coupled sliders (propellant/projectile clamped against MaxTotalLength) rely on this write:
+	--without it guiupdate re-reads a stale AmmoData next drag and the clamp never commits.
+	if acfmenupanel["CData"][Name].ACEProgrammatic then
+		acfmenupanel.AmmoData[Name] = val
+
+		return
+	end
 
 	if acfmenupanel.AmmoData[Name] ~= val then
 

--- a/lua/acf/shared/ammocrates/acfcratelist.lua
+++ b/lua/acf/shared/ammocrates/acfcratelist.lua
@@ -751,9 +751,15 @@ ACE.DefineModelData("Cylinder",{
 			Vector(4.24, 4.24, 6),
 		}
 	},
+	-- Constant cross-section swept along Z. Declaring the axis lets
+	-- ACE.Scalable derive the section polygon straight from CustomMesh above,
+	-- so packing and volume both describe the hull the game really builds.
+	ExtrudeAxis = "z",
 	volumefunction = function( L, W, H )
-		local volume = PI * (L / 2) * (W / 2) * H
-		return volume
+		-- The hull is an octagon, not a circle: PI/4 of the bounding box would
+		-- overstate it by ~11%. Ask the mesh instead of hardcoding either one.
+		local ratio = ACE.Scalable.SectionAreaRatio( ACE.ModelData["Cylinder"] )
+		return L * W * H * ratio
 	end
 })
 

--- a/lua/acf/shared/sh_ace_scalable.lua
+++ b/lua/acf/shared/sh_ace_scalable.lua
@@ -34,6 +34,223 @@ function Scalable.ShapeAllowed(shape, def)
 end
 
 ------------------------------------------------------------------
+-- Cross-section geometry.
+--
+-- A shape whose ModelData carries an `ExtrudeAxis` is a prism: constant
+-- cross-section swept along that axis. Everything below derives that
+-- cross-section from the shape's own `CustomMesh`, so the packing maths and
+-- the volume maths can never drift from the collision hull the game builds.
+-- Shapes without an ExtrudeAxis are treated as their full bounding box.
+------------------------------------------------------------------
+
+local SectionCache = {}
+
+local AxisPlane = {
+	x = { "y", "z" },
+	y = { "x", "z" },
+	z = { "x", "y" },
+}
+
+-- Monotone chain hull of 2D points, returned counter-clockwise.
+local function ConvexHull(pts)
+	table.sort(pts, function(a, b)
+		if a[1] ~= b[1] then return a[1] < b[1] end
+		return a[2] < b[2]
+	end)
+
+	local function Cross(o, a, b)
+		return (a[1] - o[1]) * (b[2] - o[2]) - (a[2] - o[2]) * (b[1] - o[1])
+	end
+
+	local function Build(source)
+		local out = {}
+		for i = 1, #source do
+			local p = source[i]
+			while #out >= 2 and Cross(out[#out - 1], out[#out], p) <= 0 do
+				out[#out] = nil
+			end
+			out[#out + 1] = p
+		end
+		out[#out] = nil -- drop the shared endpoint
+		return out
+	end
+
+	local reversed = {}
+	for i = #pts, 1, -1 do reversed[#reversed + 1] = pts[i] end
+
+	local lower, upper = Build(pts), Build(reversed)
+	for i = 1, #upper do lower[#lower + 1] = upper[i] end
+	return lower
+end
+
+--- Normalized convex cross-section of a prism shape.
+-- Projects the shape's CustomMesh onto the plane perpendicular to its
+-- ExtrudeAxis and hulls it, then divides out the mesh's half-extent so the
+-- result is expressed in units of "fraction of the bounding box half-width".
+-- @param md ModelData table (see ACE.DefineModelData).
+-- @return Array of {u, v} points counter-clockwise, or nil for a plain box.
+function Scalable.SectionPolygon(md)
+	if not md or not md.ExtrudeAxis then return end
+
+	local cached = SectionCache[md]
+	if cached ~= nil then
+		return cached or nil
+	end
+
+	local plane = AxisPlane[md.ExtrudeAxis]
+	local half  = (md.DefaultSize or 12) * 0.5
+	if not plane or half <= 0 or not md.CustomMesh then
+		SectionCache[md] = false
+		return
+	end
+
+	local seen, pts = {}, {}
+	for _, hull in ipairs(md.CustomMesh) do
+		for _, vert in ipairs(hull) do
+			local u, v = vert[plane[1]] / half, vert[plane[2]] / half
+			-- Collapse the two end caps onto one another; they are identical.
+			local key = string.format("%.4f:%.4f", u, v)
+			if not seen[key] then
+				seen[key] = true
+				pts[#pts + 1] = { u, v }
+			end
+		end
+	end
+
+	if #pts < 3 then
+		SectionCache[md] = false
+		return
+	end
+
+	local poly = ConvexHull(pts)
+	SectionCache[md] = poly
+	return poly
+end
+
+--- Fraction of its bounding box a prism shape's cross-section fills.
+-- 1 for a box, 2*sqrt(2)/4 ~= 0.707 for the eight-sided cylinder hull.
+-- Use this rather than a hand-written constant so the number always describes
+-- the mesh that actually exists.
+function Scalable.SectionAreaRatio(md)
+	local poly = Scalable.SectionPolygon(md)
+	if not poly then return 1 end
+
+	local area = 0
+	for i = 1, #poly do
+		local a, b = poly[i], poly[(i % #poly) + 1]
+		area = area + (a[1] * b[2] - b[1] * a[2])
+	end
+	-- Normalized coords span [-1, 1] on both axes, so the bounding box area is 4.
+	return math.abs(area) * 0.5 / 4
+end
+
+local EPS = 1e-9
+local MAX_ROWS = 4096
+
+-- Convex polygon as inward half-planes a*u + b*v <= c, scaled to the real
+-- half-extents. Cached per (md, halfU, halfV) would churn; building it is cheap
+-- (eight edges) and capacity is only rebuilt on a crate edit.
+local function HalfPlanes(poly, halfU, halfV)
+	local planes = {}
+	for i = 1, #poly do
+		local p1, p2 = poly[i], poly[(i % #poly) + 1]
+		local u1, v1 = p1[1] * halfU, p1[2] * halfV
+		local u2, v2 = p2[1] * halfU, p2[2] * halfV
+		local du, dv = u2 - u1, v2 - v1
+		planes[#planes + 1] = { dv, -du, dv * u1 - du * v1 }
+	end
+	return planes
+end
+
+-- Horizontal extent of the section at a given v, or nil if that v is outside.
+local function SpanAt(planes, v)
+	local lo, hi = -math.huge, math.huge
+	for i = 1, #planes do
+		local a, b, c = planes[i][1], planes[i][2], planes[i][3]
+		if math.abs(a) < EPS then
+			if b * v > c + EPS then return end
+		else
+			local bound = (c - b * v) / a
+			if a > 0 then
+				if bound < hi then hi = bound end
+			else
+				if bound > lo then lo = bound end
+			end
+		end
+	end
+	if lo > hi then return end
+	return lo, hi
+end
+
+-- Cells of cellU x cellV that fit entirely inside the section, for one grid phase.
+local function CountPhase(planes, halfV, cellU, cellV, offU, offV)
+	local jMin = math.floor((-halfV - offV) / cellV)
+	local jMax = math.ceil((halfV - offV) / cellV)
+	if jMax - jMin > MAX_ROWS then return end
+
+	local total = 0
+	for j = jMin, jMax do
+		local vLo = j * cellV + offV
+		local vHi = vLo + cellV
+
+		local loA, hiA = SpanAt(planes, vLo)
+		if loA then
+			local loB, hiB = SpanAt(planes, vHi)
+			if loB then
+				local lo = math.max(loA, loB)
+				local hi = math.min(hiA, hiB)
+				if hi > lo then
+					-- Cells are [k*cellU + offU, (k+1)*cellU + offU].
+					local kMin = math.ceil((lo - offU) / cellU - EPS)
+					local kMax = math.floor((hi - offU) / cellU + EPS) - 1
+					if kMax >= kMin then total = total + (kMax - kMin + 1) end
+				end
+			end
+		end
+	end
+	return total
+end
+
+--- How many cellU x cellV cells fit entirely inside a shape's cross-section.
+-- This is a real packing count, not a volume fraction: a cell whose corner
+-- falls outside the section is lost completely, which is what actually happens
+-- to a shell that overhangs the wall of a cylindrical crate.
+-- Falls back to the plain box count for shapes with no cross-section.
+-- @param md ModelData table, or nil for a box.
+-- @param sizeU, sizeV Full bounding-box extents on the section's two axes.
+-- @param cellU, cellV Footprint of one item on those same two axes.
+-- @return Integer cell count.
+function Scalable.SectionFit(md, sizeU, sizeV, cellU, cellV)
+	if cellU <= 0 or cellV <= 0 then return 0 end
+
+	local poly = Scalable.SectionPolygon(md)
+	if not poly then
+		return math.floor(sizeU / cellU) * math.floor(sizeV / cellV)
+	end
+
+	local halfU, halfV = sizeU * 0.5, sizeV * 0.5
+	local planes = HalfPlanes(poly, halfU, halfV)
+
+	-- Phase matters: for few items across, a grid centred on the axis and one
+	-- straddling it give different counts. Take whichever packs better.
+	local best = 0
+	for _, offU in ipairs({ 0, -cellU * 0.5 }) do
+		for _, offV in ipairs({ 0, -cellV * 0.5 }) do
+			local count = CountPhase(planes, halfV, cellU, cellV, offU, offV)
+			if not count then
+				-- Section too finely divided to enumerate; fall back to the area
+				-- estimate, which is accurate in exactly that limit.
+				local ratio = Scalable.SectionAreaRatio(md)
+				return math.floor(math.floor(sizeU / cellU) * math.floor(sizeV / cellV) * ratio)
+			end
+			if count > best then best = count end
+		end
+	end
+
+	return best
+end
+
+------------------------------------------------------------------
 -- Server-side spawn glue. Kept behind SERVER because it touches
 -- Entity/ACF; ShapeAllowed above stays shared so the menu can use it.
 ------------------------------------------------------------------

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -144,7 +144,6 @@ function ENT:Initialize()
 	self.Caliber             = 1
 	self.RoFMul              = 1
 	self.CrateShape          = "Box"	-- Scalable crate shape; overwritten on spawn for shaped crates
-	self.VolumeRatio         = 1		-- Fraction of the bounding box the shape fills (Box = 1)
 	self.LastMass            = 1
 
 	self.Inputs              = Wire_CreateInputs( self, Inputs ) --, "Fuse Length"
@@ -300,8 +299,8 @@ end
 
 do
 
-	-- Shapes a scalable crate is allowed to take. Box is the default; Cylinder packs the
-	-- same bounding box but only holds the round count its volume allows (see VolumeRatio).
+	-- Shapes a scalable crate is allowed to take. Box is the default; a shaped crate keeps
+	-- the same bounding box but packs shells against its real cross-section instead.
 	-- Keep this in sync with the shape list offered in the crate menu (cl_acfmenu_gui.lua).
 	local CrateShapes = {
 		Box      = true,
@@ -379,9 +378,6 @@ do
 					local ShapeVolume = ModelData.volumefunction(Scale.x, Scale.y, Scale.z)
 
 					Ammo.CrateShape  = Shape
-					-- Fraction of the bounding box this shape actually fills, used to scale round
-					-- capacity so a cylinder holds less than the box it fits inside.
-					Ammo.VolumeRatio = BoxVolume > 0 and (ShapeVolume / BoxVolume) or 1
 
 					-- Store the normalized id so a dupe keeps the shape (Box stays "L:W:H" for back-compat).
 					Id = Shape == "Box"
@@ -710,31 +706,37 @@ do
 
 			end
 
-			-- Calculate the capacity based on the dimensions of the entity and the dimensions of the ammo
-			local cap1 = Floor(Dimensions.x / shellLength) * Floor(Dimensions.y / width) * Floor(Dimensions.z / width)
-			local cap2 = Floor(Dimensions.y / shellLength) * Floor(Dimensions.x / width) * Floor(Dimensions.z / width)
-			local cap3 = Floor(Dimensions.z / shellLength) * Floor(Dimensions.x / width) * Floor(Dimensions.y / width)
+			-- Calculate the capacity based on the dimensions of the entity and the dimensions of the ammo.
+			-- Shells are packed on a grid in all three orientations and the best one wins. For a
+			-- shaped crate the grid is clipped to the real cross-section, so a shell overhanging a
+			-- cylinder's wall is lost outright rather than discounted -- see ACE.Scalable.SectionFit.
+			local ShapeData = ACE.ModelData[self.CrateShape or "Box"]
+			local SectionFit = ACE.Scalable.SectionFit
+
+			-- The three orientations the box packer has always tried: the shell's long side
+			-- laid along X, along Y, or standing up Z. Listed as the (X, Y, Z) extents of one
+			-- shell. A shaped crate is a prism extruded along Z, so the X and Y extents are
+			-- the ones a rounded wall can clip; the Z extent just stacks.
+			local function BestFit( a, b, c )
+				local best = 0
+				for _, side in ipairs({ {a, b, c}, {b, a, c}, {b, c, a} }) do
+					local count = SectionFit(ShapeData, Dimensions.x, Dimensions.y, side[1], side[2])
+						* Floor(Dimensions.z / side[3])
+					if count > best then best = count end
+				end
+				return best
+			end
+
+			local FCap = BestFit(shellLength, width, width)
 
 			--Split the shell in 2, leave the other piece next to it.
-			local piececap1 = Floor(Dimensions.x / (shellLength / 2)) * Floor(Dimensions.y / (width * 2)) * Floor(Dimensions.z / width)
-			local piececap2 = Floor(Dimensions.y / (shellLength / 2)) * Floor(Dimensions.x / (width * 2)) * Floor(Dimensions.z / width)
-			local piececap3 = Floor(Dimensions.z / (shellLength / 2)) * Floor(Dimensions.x / (width * 2)) * Floor(Dimensions.y / width)
-
-			local FCap	= MaxValue(cap1,cap2,cap3)
-			local FpieceCap = MaxValue(piececap1,piececap2,piececap3)
+			local FpieceCap = BestFit(shellLength / 2, width * 2, width)
 
 			--Why would you need the 2 piece for rounds below 50mm? Unless you want legos there....
 			--Missiles & bombs are excluded from using this method...
 			if AmmoGunData.caliber >= 5 and WeaponType ~= "missile" and FpieceCap > FCap and self.BulletData.TwoPiece > 0 then
 				FCap = FpieceCap
 				self.IsTwoPiece = true
-			end
-
-			-- Shells are packed into the bounding box above; scale the count down to the fraction
-			-- the actual shape fills (Box = 1). Keep at least one round so a shaped crate is usable.
-			local Ratio = self.VolumeRatio or 1
-			if Ratio < 1 and FCap > 0 then
-				FCap = MaxValue(Floor(FCap * Ratio), 1)
 			end
 
 			Capacity	= FCap

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -143,6 +143,8 @@ function ENT:Initialize()
 	self.AmmoMassMax         = 1
 	self.Caliber             = 1
 	self.RoFMul              = 1
+	self.CrateShape          = "Box"	-- Scalable crate shape; overwritten on spawn for shaped crates
+	self.VolumeRatio         = 1		-- Fraction of the bounding box the shape fills (Box = 1)
 	self.LastMass            = 1
 
 	self.Inputs              = Wire_CreateInputs( self, Inputs ) --, "Fuse Length"
@@ -298,11 +300,38 @@ end
 
 do
 
+	-- Shapes a scalable crate is allowed to take. Box is the default; Cylinder packs the
+	-- same bounding box but only holds the round count its volume allows (see VolumeRatio).
+	-- Keep this in sync with the shape list offered in the crate menu (cl_acfmenu_gui.lua).
+	local CrateShapes = {
+		Box      = true,
+		Cylinder = true,
+	}
+
 	-- Parses + clamps an "L:W:H" string into a Vector. Shared with fuel tanks and
 	-- scalable explosives (see ACE.Scalable.ParseScale); crates pass the crate size
 	-- limits as their bounds.
 	local function ConvertStringScale( ScaleId )
 		return ACE.Scalable.ParseScale( ScaleId, { min = ACF.CrateMinimumSize, max = ACF.CrateMaximumSize } )
+	end
+
+	-- A scalable crate id is "L:W:H" or "L:W:H:Shape". Splits off the optional shape token
+	-- (defaulting to Box), validates it, and returns the clamped size Vector plus the shape.
+	-- A Vector id (from an older dupe) is passed straight through as a Box crate.
+	local function ParseCrateScale( Id )
+		if isvector( Id ) then return ConvertStringScale( Id ), "Box" end
+		if not isstring( Id ) then return nil, "Box" end
+
+		local Shape = "Box"
+		local parts = string.Explode( ":", Id )
+		if #parts >= 4 then
+			Shape = parts[4]
+			Id = parts[1] .. ":" .. parts[2] .. ":" .. parts[3]
+		end
+
+		if not CrateShapes[Shape] then Shape = "Box" end
+
+		return ConvertStringScale( Id ), Shape
 	end
 
 	-- If the incoming Id belongs to an invalid ammo crate, but belongs to the legacy crates list, convert it into its scalable counterpart.
@@ -334,20 +363,32 @@ do
 			if not ACE.CheckAmmo( Id ) then
 
 				local Scale
+				local Shape = "Box"
 
 				if isstring(Id) and LegacyAmmoTable[Id] then
 					Scale = CreateLegacyScale(Id, Ammo)
 				else
-					Scale = ConvertStringScale(Id)
+					Scale, Shape = ParseCrateScale(Id)
 				end
 
 				if isvector(Scale) then
 
-					local ModelData = ACE.ModelData["Box"]
+					local ModelData = ACE.ModelData[Shape] or ACE.ModelData["Box"]
 
-					Id = Scale
+					local BoxVolume   = Scale.x * Scale.y * Scale.z
+					local ShapeVolume = ModelData.volumefunction(Scale.x, Scale.y, Scale.z)
+
+					Ammo.CrateShape  = Shape
+					-- Fraction of the bounding box this shape actually fills, used to scale round
+					-- capacity so a cylinder holds less than the box it fits inside.
+					Ammo.VolumeRatio = BoxVolume > 0 and (ShapeVolume / BoxVolume) or 1
+
+					-- Store the normalized id so a dupe keeps the shape (Box stays "L:W:H" for back-compat).
+					Id = Shape == "Box"
+						and (Scale.x .. ":" .. Scale.y .. ":" .. Scale.z)
+						or (Scale.x .. ":" .. Scale.y .. ":" .. Scale.z .. ":" .. Shape)
 					Model = ModelData.Model
-					Weight = (Scale.x * Scale.y * Scale.z) / 200
+					Weight = ShapeVolume / 200
 					Dimensions = Scale
 
 					local DefaultSize    = ModelData.DefaultSize
@@ -528,6 +569,9 @@ function ENT:UpdateOverlayText()
 
 			local dims = x .. "x" .. y .. "x" .. z
 			text = text .. "\n\n Size: " .. dims
+			if self.CrateShape and self.CrateShape ~= "Box" then
+				text = text .. "\n Shape: " .. self.CrateShape
+			end
 		end
 
 		if self.IsTwoPiece then
@@ -684,6 +728,13 @@ do
 			if AmmoGunData.caliber >= 5 and WeaponType ~= "missile" and FpieceCap > FCap and self.BulletData.TwoPiece > 0 then
 				FCap = FpieceCap
 				self.IsTwoPiece = true
+			end
+
+			-- Shells are packed into the bounding box above; scale the count down to the fraction
+			-- the actual shape fills (Box = 1). Keep at least one round so a shaped crate is usable.
+			local Ratio = self.VolumeRatio or 1
+			if Ratio < 1 and FCap > 0 then
+				FCap = MaxValue(Floor(FCap * Ratio), 1)
 			end
 
 			Capacity	= FCap


### PR DESCRIPTION
Took from suggestions.

Initially just wanted to add extra model path, so it would take couple mins to do, when I did that I noticed that cylinder shape had the same amount of ammo as the box one, which was completely wrong. Then I decided to use AI to figure out why that happened:


AI text below:
<html>
<body>
<!--StartFragment--><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-weight: 500; font-variation-settings: &quot;opsz&quot; 16, &quot;wght&quot; 560; text-rendering: optimizelegibility;">Why<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 65ms 1 normal both running _fadeInText_yu34g_1;">the<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 29ms 1 normal both running _fadeInText_yu34g_1;">cylinder<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 39ms 1 normal both running _fadeInText_yu34g_1;">held<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 10ms 1 normal both running _fadeInText_yu34g_1;">box<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 23ms 1 normal both running _fadeInText_yu34g_1;">amounts</span></strong></p><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Nothing in the capacity path knew about crate shape.<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">VolumeRatio</code><span> </span>and<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">CrateShapes</code><span> </span>didn't exist before this branch, so a cylinder ran the box arithmetic unchanged — the model was round, the<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 13ms 1 normal both running _fadeInText_yu34g_1;">maths<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 13ms 1 normal both running _fadeInText_yu34g_1;">wasn't.</span></p><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The first fix was a single scalar:<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">VolumeRatio = ShapeVolume / BoxVolume</code>, π/4 ≈ 0.785, applied to the winning box packing. That's<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 13ms 1 normal both running _fadeInText_yu34g_1;">wrong<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 13ms 1 normal both running _fadeInText_yu34g_1;">three<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 23ms 1 normal both running _fadeInText_yu34g_1;">separate<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 35ms 1 normal both running _fadeInText_yu34g_1;">ways:</span></p><ol dir="ltr" start="1" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px 0px 0px 20px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); list-style: decimal; text-rendering: optimizelegibility; gap: 6px; flex-direction: column; display: flex; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;"><strong style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-weight: 500; font-variation-settings: &quot;opsz&quot; 16, &quot;wght&quot; 560; text-rendering: optimizelegibility;">It's blind to orientation.</strong><span> </span>A cylinder loses nothing along its axis and everything at its wall, so the penalty depends on which way the shells point. The old code picked the best box packing<span> </span><em style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; font-style: italic;">first</em><span> </span>and applied one flat number afterwards, so it chose a winner before it could know what the shape would cost.</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;"><strong style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-weight: 500; font-variation-settings: &quot;opsz&quot; 16, &quot;wght&quot; 560; text-rendering: optimizelegibility;">A volume fraction isn't a count.</strong><span> </span>Shells are rigid boxes on a grid — one whose corner crosses the wall is lost entirely, not shaved proportionally. A scalar can only shave. The gap is worst when few shells span the diameter and never closes: even at 40 across, the real packed fraction is 66%, not 78.5%.</li><li style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility;"><strong style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-weight: 500; font-variation-settings: &quot;opsz&quot; 16, &quot;wght&quot; 560; text-rendering: optimizelegibility;">The hull isn't round.</strong><span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">CustomMesh</code><span> </span>is 8 vertices per cap, so the collision hull shells sit in — and shots trace against — is an octagon at 70.7% of its bounding box. Capacity was computing against a circle while<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">ApplyShape</code><span> </span>prefers<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">phys:GetVolume()</code>, so mass and points could read the octagon while capacity read the<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 18ms 1 normal both running _fadeInText_yu34g_1;">circle.</span></li></ol><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-weight: 500; font-variation-settings: &quot;opsz&quot; 16, &quot;wght&quot; 560; text-rendering: optimizelegibility;"><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 37ms 1 normal both running _fadeInText_yu34g_1;">What<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 10ms 1 normal both running _fadeInText_yu34g_1;">the<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 20ms 1 normal both running _fadeInText_yu34g_1;">fix<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 23ms 1 normal both running _fadeInText_yu34g_1;">does</span></strong></p><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Derives the cross-section from<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">CustomMesh</code><span> </span>instead of hardcoding either constant.<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">SectionPolygon</code><span> </span>projects the mesh perpendicular to<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">ExtrudeAxis</code><span> </span>and hulls it;<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">SectionFit</code><span> </span>counts cells fully inside, testing both grid phases. Clipping happens per orientation and<span> </span><em style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; font-style: italic;">before</em><span> </span>the winner is chosen, which is the part that matters. Two-piece comparison now runs on clipped numbers too, instead of deciding whether to split shells from box counts and only then discovering the crate was round. Shapes with no<span> </span><code data-epitaxy-inline-code="" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); font-family: anthropic-mono, ui-monospace, monospace; font-feature-settings: &quot;calt&quot; 0, &quot;liga&quot; 0; font-variation-settings: normal; font-size: 13px; font-variant-ligatures: none; text-rendering: optimizelegibility; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(255, 255, 255, 0.08); color: rgb(225, 224, 217); border-radius: 4px; padding-block: 1px; padding-inline: 2px; line-height: 1.4;">ExtrudeAxis</code><span> </span>fall through to plain floor division, so box crates run identical arithmetic. Counting is per row, not per cell — for a convex section the valid span at any height is one<span> </span>interval, so a 250-unit crate of small-calibre rounds resolves in a few hundred iterations,<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 10ms 1 normal both running _fadeInText_yu34g_1;">and<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 23ms 1 normal both running _fadeInText_yu34g_1;">only<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 30ms 1 normal both running _fadeInText_yu34g_1;">on<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 45ms 1 normal both running _fadeInText_yu34g_1;">crate<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 58ms 1 normal both running _fadeInText_yu34g_1;">edit.</span></p><div dir="ltr" class="overflow-x-auto" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); overflow-x: auto; text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
<img width="778" height="282" alt="image" src="https://github.com/user-attachments/assets/b3ef9506-86db-4914-964b-c4144f9628a0" />


</div><p dir="ltr" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; color: rgb(255, 255, 255); font-family: anthropic-sans, system-ui, &quot;Segoe UI&quot;, Roboto, Helvetica, Arial, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(32, 32, 31); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Corrections are largest on unevenly scaled crates — 24×24×96 was overcounting by 76%, because a tall narrow cylinder has only six shells spanning its diameter and loses far more than a fifth<span> </span>to the wall. Box crates verified identical (432 before and after, 48³<span> </span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 23ms 1 normal both running _fadeInText_yu34g_1;">with<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 25ms 1 normal both running _fadeInText_yu34g_1;">a<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 13ms 1 normal both running _fadeInText_yu34g_1;">14×4<span> </span></span><span data-wf="" class="_wordAnimating_yu34g_11" style="box-sizing: border-box; border: 0px solid color(srgb 1 1 1 / 0.1); margin: 0px; padding: 0px; outline-color: rgb(85, 152, 231); scrollbar-width: thin; scrollbar-color: rgba(225, 224, 217, 0.35) rgba(0, 0, 0, 0); text-rendering: optimizelegibility; opacity: 1; animation: 0.1s linear 28ms 1 normal both running _fadeInText_yu34g_1;">shell).</span></p><!--EndFragment-->
</body>
</html>

_____

Would love some guidance, as im not super strong with geometry. i've asked it to prove what it did there, it creates the html file, it looks correct to what I've encountered in game and it looks correct now.
[cylinder-packing.html](https://github.com/user-attachments/files/30884634/cylinder-packing.html)

Also applies the fix from here: https://github.com/ACE-Project-Team/ArmoredCombatExtended/pull/334
